### PR TITLE
Fix pre-existing humble CI failures (f-string compat, uncrustify version skew)

### DIFF
--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -116,6 +116,14 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_cmake_pytest REQUIRED)
+  if(DEFINED ENV{ROS_DISTRO} AND "$ENV{ROS_DISTRO}" STREQUAL "humble")
+    # humble ships an older uncrustify binary whose formatting output diverges
+    # from the version used on newer distros (e.g. jazzy) for a handful of
+    # files. Since a single formatting cannot satisfy both uncrustify
+    # versions at once, skip the redundant style check on humble only;
+    # jazzy (and any other supported distro) still enforces it.
+    list(APPEND AMENT_LINT_AUTO_EXCLUDE ament_cmake_uncrustify)
+  endif()
   ament_lint_auto_find_test_dependencies()
   ament_add_gtest(
     test_gnss_weighting

--- a/tools/gaussian_splatting/bim_export.py
+++ b/tools/gaussian_splatting/bim_export.py
@@ -1457,6 +1457,14 @@ def _count_dangling_wall_ends(planes: list[dict], tolerance: float = 0.3) -> int
                for i, point in enumerate(endpoints))
 
 
+def _fmt_optional_pct(value: Optional[float]) -> str:
+    return '-' if value is None else f'{value:.0%}'
+
+
+def _fmt_optional_fixed(value: Optional[float], decimals: int = 4) -> str:
+    return '-' if value is None else f'{value:.{decimals}f}'
+
+
 def build_bim_metrics(planes: list[dict], rooms: Optional[list[dict]] = None,
                       *, source: str = '', settings: Optional[dict] = None) -> dict:
     """Build a deterministic, machine-readable BIM QA manifest."""
@@ -1619,18 +1627,18 @@ def write_html_report(planes: list[dict], path: str | Path, *,
         f'<td>{html.escape(p.get("provenance", "unknown"))}</td>'
         f'<td>{p.get("confidence", "-")}</td><td>{html.escape(p.get("confidence_level", "-"))}</td>'
         f'<td>{p.get("confidence_metrics", {}).get("support_points", "-")}</td>'
-        f'<td>{("-" if p.get("element_fit", {}).get("coverage_ratio") is None else f"{p["element_fit"]["coverage_ratio"]:.0%}")}</td>'
-        f'<td>{("-" if p.get("element_fit", {}).get("distribution_ratio") is None else f"{p["element_fit"]["distribution_ratio"]:.0%}")}</td>'
-        f'<td>{("-" if p.get("element_fit", {}).get("distance_rmse_m") is None else f"{p["element_fit"]["distance_rmse_m"]:.4f}")}</td>'
-        f'<td>{("-" if p.get("element_fit", {}).get("distance_p95_m") is None else f"{p["element_fit"]["distance_p95_m"]:.4f}")}</td></tr>'
+        f'<td>{_fmt_optional_pct(p.get("element_fit", {}).get("coverage_ratio"))}</td>'
+        f'<td>{_fmt_optional_pct(p.get("element_fit", {}).get("distribution_ratio"))}</td>'
+        f'<td>{_fmt_optional_fixed(p.get("element_fit", {}).get("distance_rmse_m"))}</td>'
+        f'<td>{_fmt_optional_fixed(p.get("element_fit", {}).get("distance_p95_m"))}</td></tr>'
         for i, p in enumerate(planes))
     local_segments = [(wi, si, seg) for wi, wall in enumerate(walls)
                       for si, seg in enumerate(wall.get('quality_segments', []))]
     issue_rows = ''.join(
         f'<tr><td>Wall {wi + 1}</td><td>{si + 1}</td><td>{seg["score"]}</td>'
         f'<td>{seg["level"]}</td><td>{seg["support_points"]}</td>'
-        f'<td>{("-" if seg["observation_rmse_m"] is None else f"{seg["observation_rmse_m"]:.3f}")}</td>'
-        f'<td>{("-" if seg["model_rmse_m"] is None else f"{seg["model_rmse_m"]:.3f}")}</td>'
+        f'<td>{_fmt_optional_fixed(seg["observation_rmse_m"], 3)}</td>'
+        f'<td>{_fmt_optional_fixed(seg["model_rmse_m"], 3)}</td>'
         f'<td>{html.escape(seg["recommendation"])}</td></tr>'
         for wi, si, seg in local_segments if seg['level'] != 'High')
     regularization_rows = ''.join(


### PR DESCRIPTION
## Summary

The `humble default workflow` CI job has been red on `develop` while `jazzy default workflow` stays green, due to two independent, distro-specific root causes.

### 1. f-string syntax incompatible with Python 3.10 (humble)

`tools/gaussian_splatting/bim_export.py` built HTML table cells with nested f-strings where the **inner** f-string reused the same quote character as its own delimiter inside a subscript expression, e.g.:

```python
f"{p["element_fit"]["coverage_ratio"]:.0%}"
```

This relies on the PEP 701 grammar relaxations introduced in Python 3.12 and raises `SyntaxError: f-string: f-string: unmatched '['` on humble's Python 3.10.12. It surfaced as a collection error in `graph_based_slam/test/test_bim_export.py` (which imports `bim_export`) and cascaded into 3 failures in `graph_based_slam/test/test_bim_regression_gate.py` (reported misleadingly at `scripts/evaluate_bim_regression_gate.py:115`, which is just the `import bim_export` frame in the traceback — the actual syntax error is in `bim_export.py`).

Fix: replaced the nested f-strings with two small helper functions (`_fmt_optional_pct`, `_fmt_optional_fixed`) so no quote nesting is needed. Six call sites across two HTML-report table-building blocks were affected. Verified with `ast.parse` over every `.py` file in the repo under `ros:humble-ros-core`'s Python 3.10.12 (previously failed on this file; now clean), and the two affected pytest files pass under the same interpreter.

### 2. `ament_uncrustify` version skew between ROS distros

The `uncrustify` binary shipped with humble formats 7 files in `graph_based_slam` differently than the version used on jazzy (and the version that was used to last reformat those files for jazzy):

- `include/graph_based_slam/backend_core.hpp`
- `include/graph_based_slam/graph_based_slam_component.h`
- `include/graph_based_slam/plane_revisit_constraints.hpp`
- `test/test_intensity_profile.cpp`
- `test/test_pose_graph_optimization.cpp`
- `test/test_rko_multiscan_observability.cpp`
- `test/test_selective_visual_fusion.cpp`

No single formatting can satisfy both uncrustify binaries at once, so reformatting back and forth is not a real fix — it would just flip which distro is red. Since `graph_based_slam` uses `ament_lint_auto_find_test_dependencies()` (no per-file lint exclusion mechanism exists for a single linter), the least invasive fix is to use `ament_lint_auto`'s own `AMENT_LINT_AUTO_EXCLUDE` variable to skip only the `ament_cmake_uncrustify` test, guarded by `$ENV{ROS_DISTRO} STREQUAL "humble"`. jazzy (and any other distro) keeps full uncrustify enforcement — verified locally that `colcon test --packages-select graph_based_slam --ctest-args -R uncrustify` still passes under jazzy after this change.

## Verification

- `ast.parse` of every repo `.py` file succeeds under `ros:humble-ros-core` (Python 3.10.12)
- `graph_based_slam/test/test_bim_export.py` and `test_bim_regression_gate.py` pass under Python 3.10.12 (docker `ros:humble-ros-core`)
- `colcon build --packages-select graph_based_slam` succeeds under jazzy (validates CMake syntax)
- `colcon test --packages-select graph_based_slam --ctest-args -R uncrustify` passes under jazzy (confirms jazzy's uncrustify check is unaffected)

## Test plan

- [ ] CI: `humble default workflow` passes
- [ ] CI: `jazzy default workflow` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tRU7h2vZNcBHaFYWmZB5E