### PR TITLE
Bump rko_lio to upstream-integrated master + upstream param renames

### DIFF
--- a/configs/hilti2022/rko_lio_hilti2022_pandar_intensity_disagreement.yaml
+++ b/configs/hilti2022/rko_lio_hilti2022_pandar_intensity_disagreement.yaml
@@ -1,0 +1,43 @@
+# RKO-LIO config for HILTI 2022 handheld (Phasma) platform, exp07 long
+# corridor A/B test of the intensity_disagreement_gate (radar-less
+# scan-to-scan reflectivity cross-correlation degeneracy correction).
+#
+# Base sensor config is identical to rko_lio_hilti2022_pandar.yaml (see that
+# file for extrinsic provenance). This variant additionally enables ONLY
+# intensity_disagreement_gate -- NOT intensity_constraint. Per
+# Thirdparty/rko_lio/rko_lio/core/lio.cpp (~line 964), the two features are
+# independent: intensity_disagreement_gate does its own intensity extraction
+# and does not require intensity_constraint to be enabled (that gating is
+# only for the separate persistence-confirmed profile-prior feature). Testing
+# the gate alone isolates its effect for this A/B test.
+#
+# exp07's PandarXT-32 PointCloud2 has no "reflectivity" field; only a
+# float32 "intensity" field (verified via sqlite3/CDR field dump of
+# /hesai/pandar). point_cloud2_to_intensity() falls back to "intensity"
+# (float32) in this case.
+extrinsic_imu2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
+extrinsic_lidar2base_quat_xyzw_xyz: [0.7071068, -0.7071068, 0.0, 0.0, -0.001, -0.00855, 0.055]
+initialization_phase: true
+# PandarXT-32 clouds carry per-point float64 absolute 'timestamp' fields.
+deskew: true
+voxel_size: 0.25
+min_range: 0.7
+max_range: 100.0
+double_downsample: true
+# Competition scope is SLAM-only. Keep all saved/global-map recovery paths
+# explicitly disabled rather than relying on upstream defaults.
+enable_kidnap_relocalization: false
+reset_on_registration_failure: false
+relocalize_after_scan_gap: false
+
+# --- intensity_disagreement_gate (radar-less degeneracy correction) ---
+intensity_constraint: false
+intensity_disagreement_gate: true
+intensity_bin_size_m: 0.25
+intensity_profile_half_length_m: 30.0
+intensity_max_shift_m: 1.5
+intensity_min_correlation: 0.6
+intensity_min_filled_bins: 40
+intensity_disagreement_min_mps: 0.2
+intensity_disagreement_min_scans: 3
+intensity_disagreement_weight: 1.0

--- a/configs/hilti2022/rko_lio_hilti2022_pandar_intensity_disagreement_low.yaml
+++ b/configs/hilti2022/rko_lio_hilti2022_pandar_intensity_disagreement_low.yaml
@@ -1,0 +1,43 @@
+# RKO-LIO config for HILTI 2022 handheld (Phasma) platform, exp07 long
+# corridor A/B test of the intensity_disagreement_gate (radar-less
+# scan-to-scan reflectivity cross-correlation degeneracy correction).
+#
+# Base sensor config is identical to rko_lio_hilti2022_pandar.yaml (see that
+# file for extrinsic provenance). This variant additionally enables ONLY
+# intensity_disagreement_gate -- NOT intensity_constraint. Per
+# Thirdparty/rko_lio/rko_lio/core/lio.cpp (~line 964), the two features are
+# independent: intensity_disagreement_gate does its own intensity extraction
+# and does not require intensity_constraint to be enabled (that gating is
+# only for the separate persistence-confirmed profile-prior feature). Testing
+# the gate alone isolates its effect for this A/B test.
+#
+# exp07's PandarXT-32 PointCloud2 has no "reflectivity" field; only a
+# float32 "intensity" field (verified via sqlite3/CDR field dump of
+# /hesai/pandar). point_cloud2_to_intensity() falls back to "intensity"
+# (float32) in this case.
+extrinsic_imu2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
+extrinsic_lidar2base_quat_xyzw_xyz: [0.7071068, -0.7071068, 0.0, 0.0, -0.001, -0.00855, 0.055]
+initialization_phase: true
+# PandarXT-32 clouds carry per-point float64 absolute 'timestamp' fields.
+deskew: true
+voxel_size: 0.25
+min_range: 0.7
+max_range: 100.0
+double_downsample: true
+# Competition scope is SLAM-only. Keep all saved/global-map recovery paths
+# explicitly disabled rather than relying on upstream defaults.
+enable_kidnap_relocalization: false
+reset_on_registration_failure: false
+relocalize_after_scan_gap: false
+
+# --- intensity_disagreement_gate (radar-less degeneracy correction) ---
+intensity_constraint: false
+intensity_disagreement_gate: true
+intensity_bin_size_m: 0.25
+intensity_profile_half_length_m: 30.0
+intensity_max_shift_m: 1.5
+intensity_min_correlation: 0.6
+intensity_min_filled_bins: 40
+intensity_disagreement_min_mps: 0.05
+intensity_disagreement_min_scans: 3
+intensity_disagreement_weight: 1.0

--- a/configs/hilti2022/rko_lio_hilti2022_pandar_intensity_disagreement_vlow.yaml
+++ b/configs/hilti2022/rko_lio_hilti2022_pandar_intensity_disagreement_vlow.yaml
@@ -1,0 +1,43 @@
+# RKO-LIO config for HILTI 2022 handheld (Phasma) platform, exp07 long
+# corridor A/B test of the intensity_disagreement_gate (radar-less
+# scan-to-scan reflectivity cross-correlation degeneracy correction).
+#
+# Base sensor config is identical to rko_lio_hilti2022_pandar.yaml (see that
+# file for extrinsic provenance). This variant additionally enables ONLY
+# intensity_disagreement_gate -- NOT intensity_constraint. Per
+# Thirdparty/rko_lio/rko_lio/core/lio.cpp (~line 964), the two features are
+# independent: intensity_disagreement_gate does its own intensity extraction
+# and does not require intensity_constraint to be enabled (that gating is
+# only for the separate persistence-confirmed profile-prior feature). Testing
+# the gate alone isolates its effect for this A/B test.
+#
+# exp07's PandarXT-32 PointCloud2 has no "reflectivity" field; only a
+# float32 "intensity" field (verified via sqlite3/CDR field dump of
+# /hesai/pandar). point_cloud2_to_intensity() falls back to "intensity"
+# (float32) in this case.
+extrinsic_imu2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
+extrinsic_lidar2base_quat_xyzw_xyz: [0.7071068, -0.7071068, 0.0, 0.0, -0.001, -0.00855, 0.055]
+initialization_phase: true
+# PandarXT-32 clouds carry per-point float64 absolute 'timestamp' fields.
+deskew: true
+voxel_size: 0.25
+min_range: 0.7
+max_range: 100.0
+double_downsample: true
+# Competition scope is SLAM-only. Keep all saved/global-map recovery paths
+# explicitly disabled rather than relying on upstream defaults.
+enable_kidnap_relocalization: false
+reset_on_registration_failure: false
+relocalize_after_scan_gap: false
+
+# --- intensity_disagreement_gate (radar-less degeneracy correction) ---
+intensity_constraint: false
+intensity_disagreement_gate: true
+intensity_bin_size_m: 0.25
+intensity_profile_half_length_m: 30.0
+intensity_max_shift_m: 1.5
+intensity_min_correlation: 0.6
+intensity_min_filled_bins: 40
+intensity_disagreement_min_mps: 0.02
+intensity_disagreement_min_scans: 3
+intensity_disagreement_weight: 1.0

--- a/docs/research/lidar-degeneracy-radar-intensity-ab-2026-07.md
+++ b/docs/research/lidar-degeneracy-radar-intensity-ab-2026-07.md
@@ -97,6 +97,23 @@ run: `runs/tunnel_rko_lio_intensity_disagreement_v1`,
 `runs/fog_rko_lio_intensity_disagreement_v1`。param:
 `rko_lio_lidar_degeneracy_intensity_disagreement.{yaml,ros.yaml}` (default off)。
 
+### 追試 (2026-07-17): HILTI exp07 では全閾値で悪化 — 適用条件の確定
+
+mm-GT のある HILTI 2022 exp07 (長い自己相似廊下、baseline APE 0.318 m) に
+適用した結果、min_mps 0.2/0.05/0.02 のいずれでも **APE 0.94〜2.39 m と
+2.9〜7.5 倍悪化**。原因は閾値ではなく**相関のエイリアシング**: 自己相似廊下では
+反射テクスチャ自体も走行軸に沿って周期的で、相関 ≥0.6 の「もっともらしく
+誤った」シフトが定常的に発生し (52% の試行が閾値超過)、weight 1.0 で直接
+注入されて累積する。fog (テクスチャがセンサ随伴ノイズ) と鏡像の失敗モード。
+
+**適用条件の結論**: intensity 不一致ゲートが有効なのは「幾何は自己相似だが
+反射テクスチャは特徴的 (照明・標識・ケーブル等)」な環境のみ (NTNU tunnel が
+該当)。幾何もテクスチャも自己相似な環境 (HILTI exp07) とテクスチャが偽物の
+環境 (fog) では有害。default-off の環境別オプトインが正しい運用。対策候補
+(未実装): min_correlation 引き上げ、profile 長短縮、weight < 1 の減衰、
+シフト分布の多峰性検出によるエイリアス棄却。
+benchmark: `/media/sasaki/aiueo/benchmarks/hilti_exp07_intensity_disagreement_20260717/`。
+
 ## 実装 (Thirdparty/rko_lio、全て default-off で既存挙動バイト同一)
 
 - `core/radar_ego_velocity.hpp`: /radar/cloud (x,y,z,intensity,velocity) から

--- a/graph_based_slam/test/test_rko_lio_offline_completion_source.py
+++ b/graph_based_slam/test/test_rko_lio_offline_completion_source.py
@@ -27,7 +27,8 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-"""Source-level regression checks for RKO-LIO offline completion.
+"""
+Source-level regression checks for RKO-LIO offline completion.
 
 Paths and identifiers track the upstream-integrated rko_lio layout
 (base_node/threaded_node split, snake_case VoxelHashMap API).

--- a/graph_based_slam/test/test_rko_lio_offline_completion_source.py
+++ b/graph_based_slam/test/test_rko_lio_offline_completion_source.py
@@ -27,7 +27,11 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-"""Source-level regression checks for RKO-LIO offline completion."""
+"""Source-level regression checks for RKO-LIO offline completion.
+
+Paths and identifiers track the upstream-integrated rko_lio layout
+(base_node/threaded_node split, snake_case VoxelHashMap API).
+"""
 
 from __future__ import annotations
 
@@ -40,14 +44,17 @@ RKO_ROS_DIR = REPO_ROOT / 'Thirdparty' / 'rko_lio' / 'rko_lio' / 'ros'
 
 def test_offline_completion_does_not_wait_for_trailing_imu_buffer():
     offline_node = (RKO_ROS_DIR / 'offline_node.cpp').read_text(encoding='utf-8')
-    node_header = (RKO_ROS_DIR / 'node.hpp').read_text(encoding='utf-8')
-    node_cpp = (RKO_ROS_DIR / 'node.cpp').read_text(encoding='utf-8')
+    threaded_header = (RKO_ROS_DIR / 'threaded_node.hpp').read_text(encoding='utf-8')
+    threaded_cpp = (RKO_ROS_DIR / 'threaded_node.cpp').read_text(encoding='utf-8')
 
-    assert 'atomic_registration_active' in node_header
-    assert 'atomic_registration_active = true;' in node_cpp
-    assert 'atomic_registration_active = false;' in node_cpp
+    assert 'registration_busy' in threaded_header
+    assert 'registration_busy = true;' in threaded_cpp
+    assert 'registration_busy = false;' in threaded_cpp
     assert 'Trailing IMU messages are expected' in offline_node
-    assert 'lidar_buffer.empty() && !atomic_registration_active' in offline_node
+    assert 'lidar_buffer.empty() && !registration_busy.load()' in offline_node
+    # The end-of-bag drain must also drop trailing frames that can never be
+    # matched with IMU data instead of idling forever.
+    assert '!atomic_can_process && !registration_busy.load()' in offline_node
     assert 'imu_buffer.empty() && lidar_buffer.empty()' not in offline_node
 
 
@@ -57,10 +64,8 @@ def test_rko_lio_has_kidnap_relocalization_recovery_path():
         REPO_ROOT / 'configs' / 'mid360_robot' / 'rko_lio_mid360_kidnap_tolerant.yaml'
     )
     core_header = (rko_core_dir / 'lio.hpp').read_text(encoding='utf-8')
-    core_cpp = (REPO_ROOT / 'Thirdparty' / 'rko_lio' / 'rko_lio' / 'core' / 'lio.cpp').read_text(
-        encoding='utf-8'
-    )
-    node_cpp = (RKO_ROS_DIR / 'node.cpp').read_text(encoding='utf-8')
+    core_cpp = (rko_core_dir / 'lio.cpp').read_text(encoding='utf-8')
+    base_node_cpp = (RKO_ROS_DIR / 'base_node.cpp').read_text(encoding='utf-8')
     config = config_path.read_text(encoding='utf-8')
 
     assert 'enable_kidnap_relocalization' in core_header
@@ -69,8 +74,8 @@ def test_rko_lio_has_kidnap_relocalization_recovery_path():
     assert 'try_global_relocalization' in core_cpp
     assert 'Kidnap relocalization matched' in core_cpp
     assert 'Kidnap recovery accepted scan' in core_cpp
-    assert 'relocalization_map.AddPoints' in core_cpp
-    assert 'declare_parameter<bool>("enable_kidnap_relocalization"' in node_cpp
+    assert 'relocalization_map.add_points' in core_cpp
+    assert 'declare_parameter<bool>("enable_kidnap_relocalization"' in base_node_cpp
     assert 'enable_kidnap_relocalization: true' in config
     assert 'reset_on_registration_failure: true' in config
     assert 'relocalize_after_scan_gap: false' in config

--- a/lidarslam/param/rko_lio_lidar_degeneracy.ros.yaml
+++ b/lidarslam/param/rko_lio_lidar_degeneracy.ros.yaml
@@ -2,7 +2,7 @@
   ros__parameters:
     extrinsic_imu2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
     extrinsic_lidar2base_quat_xyzw_xyz: [0.000462, 0.0008483, 0.0028835, 0.9999954, -0.00171, 0.02149, 0.0358]
-    lidar_time_offset_sec: 0.0
+    lidar_timestamps.offset_seconds: 0.0
     initialization_phase: true
     deskew: true
     voxel_size: 0.5
@@ -10,7 +10,7 @@
     max_points_per_voxel: 20
     min_range: 0.7
     max_range: 100.0
-    max_correspondance_distance: 0.5
+    max_correspondence_distance: 0.5
     double_downsample: true
     enable_kidnap_relocalization: false
     reset_on_registration_failure: false

--- a/lidarslam/param/rko_lio_lidar_degeneracy.yaml
+++ b/lidarslam/param/rko_lio_lidar_degeneracy.yaml
@@ -4,7 +4,7 @@
 extrinsic_imu2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
 extrinsic_lidar2base_quat_xyzw_xyz: [0.000462, 0.0008483, 0.0028835, 0.9999954, -0.00171, 0.02149, 0.0358]
 
-lidar_time_offset_sec: 0.0
+lidar_timestamps.offset_seconds: 0.0
 initialization_phase: true
 deskew: true
 voxel_size: 0.5
@@ -12,7 +12,7 @@ icp_keypoint_voxel_multiplier: 1.5
 max_points_per_voxel: 20
 min_range: 0.7
 max_range: 100.0
-max_correspondance_distance: 0.5
+max_correspondence_distance: 0.5
 double_downsample: true
 
 enable_kidnap_relocalization: false

--- a/lidarslam/param/rko_lio_lidar_degeneracy_intensity.ros.yaml
+++ b/lidarslam/param/rko_lio_lidar_degeneracy_intensity.ros.yaml
@@ -2,7 +2,7 @@
   ros__parameters:
     extrinsic_imu2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
     extrinsic_lidar2base_quat_xyzw_xyz: [0.000462, 0.0008483, 0.0028835, 0.9999954, -0.00171, 0.02149, 0.0358]
-    lidar_time_offset_sec: 0.0
+    lidar_timestamps.offset_seconds: 0.0
     initialization_phase: true
     deskew: true
     voxel_size: 0.5
@@ -10,7 +10,7 @@
     max_points_per_voxel: 20
     min_range: 0.7
     max_range: 100.0
-    max_correspondance_distance: 0.5
+    max_correspondence_distance: 0.5
     double_downsample: true
     degeneracy_aware_solve: true
     degeneracy_well_conditioned_ratio: 1.5e-5

--- a/lidarslam/param/rko_lio_lidar_degeneracy_intensity.yaml
+++ b/lidarslam/param/rko_lio_lidar_degeneracy_intensity.yaml
@@ -6,7 +6,7 @@
 extrinsic_imu2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
 extrinsic_lidar2base_quat_xyzw_xyz: [0.000462, 0.0008483, 0.0028835, 0.9999954, -0.00171, 0.02149, 0.0358]
 
-lidar_time_offset_sec: 0.0
+lidar_timestamps.offset_seconds: 0.0
 initialization_phase: true
 deskew: true
 voxel_size: 0.5
@@ -14,7 +14,7 @@ icp_keypoint_voxel_multiplier: 1.5
 max_points_per_voxel: 20
 min_range: 0.7
 max_range: 100.0
-max_correspondance_distance: 0.5
+max_correspondence_distance: 0.5
 double_downsample: true
 
 degeneracy_aware_solve: true

--- a/lidarslam/param/rko_lio_lidar_degeneracy_intensity_disagreement.ros.yaml
+++ b/lidarslam/param/rko_lio_lidar_degeneracy_intensity_disagreement.ros.yaml
@@ -2,7 +2,7 @@
   ros__parameters:
     extrinsic_imu2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
     extrinsic_lidar2base_quat_xyzw_xyz: [0.000462, 0.0008483, 0.0028835, 0.9999954, -0.00171, 0.02149, 0.0358]
-    lidar_time_offset_sec: 0.0
+    lidar_timestamps.offset_seconds: 0.0
     initialization_phase: true
     deskew: true
     voxel_size: 0.5
@@ -10,7 +10,7 @@
     max_points_per_voxel: 20
     min_range: 0.7
     max_range: 100.0
-    max_correspondance_distance: 0.5
+    max_correspondence_distance: 0.5
     double_downsample: true
     degeneracy_aware_solve: true
     degeneracy_well_conditioned_ratio: 1.5e-5

--- a/lidarslam/param/rko_lio_lidar_degeneracy_intensity_disagreement.yaml
+++ b/lidarslam/param/rko_lio_lidar_degeneracy_intensity_disagreement.yaml
@@ -11,7 +11,7 @@
 extrinsic_imu2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
 extrinsic_lidar2base_quat_xyzw_xyz: [0.000462, 0.0008483, 0.0028835, 0.9999954, -0.00171, 0.02149, 0.0358]
 
-lidar_time_offset_sec: 0.0
+lidar_timestamps.offset_seconds: 0.0
 initialization_phase: true
 deskew: true
 voxel_size: 0.5
@@ -19,7 +19,7 @@ icp_keypoint_voxel_multiplier: 1.5
 max_points_per_voxel: 20
 min_range: 0.7
 max_range: 100.0
-max_correspondance_distance: 0.5
+max_correspondence_distance: 0.5
 double_downsample: true
 
 degeneracy_aware_solve: true

--- a/lidarslam/param/rko_lio_lidar_degeneracy_radar_weak_direction.ros.yaml
+++ b/lidarslam/param/rko_lio_lidar_degeneracy_radar_weak_direction.ros.yaml
@@ -2,7 +2,7 @@
   ros__parameters:
     extrinsic_imu2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
     extrinsic_lidar2base_quat_xyzw_xyz: [0.000462, 0.0008483, 0.0028835, 0.9999954, -0.00171, 0.02149, 0.0358]
-    lidar_time_offset_sec: 0.0
+    lidar_timestamps.offset_seconds: 0.0
     initialization_phase: true
     deskew: true
     voxel_size: 0.5
@@ -10,7 +10,7 @@
     max_points_per_voxel: 20
     min_range: 0.7
     max_range: 100.0
-    max_correspondance_distance: 0.5
+    max_correspondence_distance: 0.5
     double_downsample: true
     degeneracy_aware_solve: true
     degeneracy_well_conditioned_ratio: 1.5e-5

--- a/lidarslam/param/rko_lio_lidar_degeneracy_radar_weak_direction.yaml
+++ b/lidarslam/param/rko_lio_lidar_degeneracy_radar_weak_direction.yaml
@@ -19,7 +19,7 @@
 extrinsic_imu2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
 extrinsic_lidar2base_quat_xyzw_xyz: [0.000462, 0.0008483, 0.0028835, 0.9999954, -0.00171, 0.02149, 0.0358]
 
-lidar_time_offset_sec: 0.0
+lidar_timestamps.offset_seconds: 0.0
 initialization_phase: true
 deskew: true
 voxel_size: 0.5
@@ -27,7 +27,7 @@ icp_keypoint_voxel_multiplier: 1.5
 max_points_per_voxel: 20
 min_range: 0.7
 max_range: 100.0
-max_correspondance_distance: 0.5
+max_correspondence_distance: 0.5
 double_downsample: true
 
 degeneracy_aware_solve: true

--- a/lidarslam/param/rko_lio_lidar_degeneracy_radar_weak_direction_tunnel.ros.yaml
+++ b/lidarslam/param/rko_lio_lidar_degeneracy_radar_weak_direction_tunnel.ros.yaml
@@ -6,7 +6,7 @@
   ros__parameters:
     extrinsic_imu2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
     extrinsic_lidar2base_quat_xyzw_xyz: [0.000462, 0.0008483, 0.0028835, 0.9999954, -0.00171, 0.02149, 0.0358]
-    lidar_time_offset_sec: 0.0
+    lidar_timestamps.offset_seconds: 0.0
     initialization_phase: true
     deskew: true
     voxel_size: 0.5
@@ -14,7 +14,7 @@
     max_points_per_voxel: 20
     min_range: 0.7
     max_range: 100.0
-    max_correspondance_distance: 0.5
+    max_correspondence_distance: 0.5
     double_downsample: true
     degeneracy_aware_solve: true
     degeneracy_well_conditioned_ratio: 1.5e-5

--- a/lidarslam/param/rko_lio_lidar_degeneracy_radar_weak_direction_tunnel.yaml
+++ b/lidarslam/param/rko_lio_lidar_degeneracy_radar_weak_direction_tunnel.yaml
@@ -19,7 +19,7 @@
 extrinsic_imu2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
 extrinsic_lidar2base_quat_xyzw_xyz: [0.000462, 0.0008483, 0.0028835, 0.9999954, -0.00171, 0.02149, 0.0358]
 
-lidar_time_offset_sec: 0.0
+lidar_timestamps.offset_seconds: 0.0
 initialization_phase: true
 deskew: true
 voxel_size: 0.5
@@ -27,7 +27,7 @@ icp_keypoint_voxel_multiplier: 1.5
 max_points_per_voxel: 20
 min_range: 0.7
 max_range: 100.0
-max_correspondance_distance: 0.5
+max_correspondence_distance: 0.5
 double_downsample: true
 
 degeneracy_aware_solve: true

--- a/lidarslam/param/rko_lio_lidar_degeneracy_weak_direction.ros.yaml
+++ b/lidarslam/param/rko_lio_lidar_degeneracy_weak_direction.ros.yaml
@@ -2,7 +2,7 @@
   ros__parameters:
     extrinsic_imu2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
     extrinsic_lidar2base_quat_xyzw_xyz: [0.000462, 0.0008483, 0.0028835, 0.9999954, -0.00171, 0.02149, 0.0358]
-    lidar_time_offset_sec: 0.0
+    lidar_timestamps.offset_seconds: 0.0
     initialization_phase: true
     deskew: true
     voxel_size: 0.5
@@ -10,7 +10,7 @@
     max_points_per_voxel: 20
     min_range: 0.7
     max_range: 100.0
-    max_correspondance_distance: 0.5
+    max_correspondence_distance: 0.5
     double_downsample: true
     degeneracy_aware_solve: true
     degeneracy_well_conditioned_ratio: 1.5e-5

--- a/lidarslam/param/rko_lio_lidar_degeneracy_weak_direction.yaml
+++ b/lidarslam/param/rko_lio_lidar_degeneracy_weak_direction.yaml
@@ -5,7 +5,7 @@
 extrinsic_imu2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
 extrinsic_lidar2base_quat_xyzw_xyz: [0.000462, 0.0008483, 0.0028835, 0.9999954, -0.00171, 0.02149, 0.0358]
 
-lidar_time_offset_sec: 0.0
+lidar_timestamps.offset_seconds: 0.0
 initialization_phase: true
 deskew: true
 voxel_size: 0.5
@@ -13,7 +13,7 @@ icp_keypoint_voxel_multiplier: 1.5
 max_points_per_voxel: 20
 min_range: 0.7
 max_range: 100.0
-max_correspondance_distance: 0.5
+max_correspondence_distance: 0.5
 double_downsample: true
 
 degeneracy_aware_solve: true

--- a/lidarslam/param/rko_lio_ntu_viral.yaml
+++ b/lidarslam/param/rko_lio_ntu_viral.yaml
@@ -3,7 +3,7 @@ extrinsic_lidar2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, -0.05, 0.0, 0.055]
 # RKO-LIO consumes the Ouster point-level `t` field, which is already aligned
 # to the canonical bag's IMU clock. FAST-LIVO2's header-only correction does
 # not apply to this timestamp path.
-lidar_time_offset_sec: 0.0
+lidar_timestamps.offset_seconds: 0.0
 initialization_phase: true
 deskew: true
 voxel_size: 0.35
@@ -11,5 +11,5 @@ icp_keypoint_voxel_multiplier: 1.5
 max_points_per_voxel: 20
 min_range: 1.0
 max_range: 100.0
-max_correspondance_distance: 0.5
+max_correspondence_distance: 0.5
 double_downsample: true

--- a/lidarslam/param/rko_lio_ntu_viral_direct_visual.yaml
+++ b/lidarslam/param/rko_lio_ntu_viral_direct_visual.yaml
@@ -6,7 +6,7 @@ extrinsic_lidar2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, -0.05, 0.0, 0.055]
 # FAST-LIVO2 camera_T_lidar (Rcl/Pcl) and body_T_lidar calibration.
 extrinsic_cam2base_quat_xyzw_xyz: [0.50158807, 0.49175768, 0.49725142, 0.50923945, 0.00552938, -0.12431338, 0.01614686]
 
-lidar_time_offset_sec: 0.0
+lidar_timestamps.offset_seconds: 0.0
 initialization_phase: true
 deskew: true
 voxel_size: 0.35
@@ -14,7 +14,7 @@ icp_keypoint_voxel_multiplier: 1.5
 max_points_per_voxel: 20
 min_range: 1.0
 max_range: 100.0
-max_correspondance_distance: 0.5
+max_correspondence_distance: 0.5
 double_downsample: true
 enable_kidnap_relocalization: false
 reset_on_registration_failure: false


### PR DESCRIPTION
## Summary

Companion to rsasaki0109/rko_lio#3: bumps the submodule to the upstream-integrated master (full feature line ported onto the refactored architecture) and renames the degeneracy param files to upstream's parameter names (`max_correspondence_distance`, `lidar_timestamps.offset_seconds`). The renames and the bump must land together — old binaries do not bind the new names and vice versa.

Also carries the HILTI exp07 follow-up: research-note section + configs for the intensity-disagreement-gate A/B (honest negative: APE 0.318 → 0.94–2.39 m at every threshold; correlation aliasing on self-similar corridor texture — the gate is now documented as distinctive-texture environments only).

## Validation (done in rsasaki0109/rko_lio#3)
- All test suites green (upstream Catch2 45/45 + all fork feature tests).
- NTNU A/B on the new architecture: fog 35.57 → 26.17 m (radar gate), tunnel reach 493.5 m of ~500 m; determinism byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tRU7h2vZNcBHaFYWmZB5E