### PR TITLE
Continuous radar fusion configs, degeneracy presets, and user guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,14 +183,8 @@ Details and optional MID-360 / production-bundle gates: [docs/benchmarking.md](d
 
 ## Degeneracy resilience (fog / tunnels)
 
-Opt-in RKO-LIO gates recover odometry in two failure modes plain
-LiDAR-inertial tracking can't fix alone: fog/dust "clutter-lock" (pose
-freezes despite real motion) and long, self-similar tunnels (trajectory
-falls far short of true distance). A radar disagreement gate cut fog
-endpoint drift **32.8 m → 22.7 m (-31%)**; combined radar gates took tunnel
-reach from **98.7 m → 495.3 m** (~500 m true distance). Four ready-to-layer
-presets and a symptom → remedy table are in
-[docs/degeneracy-guide.md](docs/degeneracy-guide.md).
+Opt-in radar/intensity gates recover fog "clutter-lock" (drift **35.6 → 11.2 m**) and
+self-similar tunnels (reach **98.7 m → ~500 m**): [docs/degeneracy-guide.md](docs/degeneracy-guide.md).
 
 ## Docs
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,17 @@ bash scripts/run_release_readiness_checks.sh --fail-on-profiles
 
 Details and optional MID-360 / production-bundle gates: [docs/benchmarking.md](docs/benchmarking.md).
 
+## Degeneracy resilience (fog / tunnels)
+
+Opt-in RKO-LIO gates recover odometry in two failure modes plain
+LiDAR-inertial tracking can't fix alone: fog/dust "clutter-lock" (pose
+freezes despite real motion) and long, self-similar tunnels (trajectory
+falls far short of true distance). A radar disagreement gate cut fog
+endpoint drift **32.8 m → 22.7 m (-31%)**; combined radar gates took tunnel
+reach from **98.7 m → 495.3 m** (~500 m true distance). Four ready-to-layer
+presets and a symptom → remedy table are in
+[docs/degeneracy-guide.md](docs/degeneracy-guide.md).
+
 ## Docs
 
 - **Getting started**: [Getting Started](docs/getting-started.md) · [Autoware quickstart](docs/autoware-quickstart.md) · [Operator workflows](docs/workflows.md) · [Autoware Foxglove](docs/autoware-foxglove.md)

--- a/docs/degeneracy-guide.md
+++ b/docs/degeneracy-guide.md
@@ -1,0 +1,153 @@
+# Degeneracy Resilience Guide
+
+RKO-LIO's degeneracy-resilience feature set is ~30 expert-tuned parameters
+spread across several files. This page turns that into four presets under
+[`lidarslam/param/presets/`](../lidarslam/param/presets/) plus a symptom
+lookup so you don't have to read the research notes to pick a config.
+
+Everything here is opt-in and default-off; unmodified `rko_lio` behavior is
+unchanged unless you layer one of these preset files in. The validated
+numbers below come from
+[`docs/research/lidar-degeneracy-radar-intensity-ab-2026-07.md`](research/lidar-degeneracy-radar-intensity-ab-2026-07.md)
+(NTNU LiDAR Degeneracy Datasets fog/tunnel sequences, plus a HILTI 2022
+exp07 negative-result check). Read that page for the full methodology.
+
+## Is your odometry degenerating?
+
+| Symptom | Root cause | Preset | Sensors needed |
+| --- | --- | --- | --- |
+| Trajectory reach is much shorter than the true traveled distance in a long, straight, self-similar corridor/tunnel | Single-axis (translation-along-travel) degeneracy: ICP's Hessian is genuinely weak along the corridor axis, so small residuals get absorbed as "no motion" | [`tunnel_radar.ros.yaml`](../lidarslam/param/presets/tunnel_radar.ros.yaml) if you have radar; [`tunnel_intensity_no_radar.ros.yaml`](../lidarslam/param/presets/tunnel_intensity_no_radar.ros.yaml) if you don't **and** the corridor has distinctive reflectivity markings (see limitations) | LiDAR + IMU (+ radar, strongly preferred) |
+| Pose freezes in fog/dust/smoke despite real motion: point count drops, IMU still shows walking/driving vibration, reported velocity goes to ~0 | "Clutter lock" -- aerosol returns travel with the sensor, so ICP sees a **healthy, well-conditioned** Hessian and confidently reports near-zero motion. Eigenvalue-based weak-direction gates never fire in this mode -- only a second, disagreeing sensor can catch it | [`corridor_fog_radar.ros.yaml`](../lidarslam/param/presets/corridor_fog_radar.ros.yaml) | LiDAR + IMU + radar (required -- no radar-less fix is validated for this failure mode) |
+| Otherwise-good tracking but consistent drift along just one axis (e.g. lateral creep down a flat-walled corridor, or vertical creep under a low, featureless ceiling) | A single Hessian eigenvalue is persistently weak along that one world-frame axis. Confirm with `degeneracy_persistence.csv` (dumped when `dump_results: true`; columns include `confirmed`, `axis_tx..axis_rz`) before reaching for a preset -- it tells you which axis and how often it's confirmed | Same as the corridor/tunnel row if an external sensor (radar or a distinctively textured surface) observes that axis; otherwise `degeneracy_aware_solve` alone (in `tunnel_radar.ros.yaml` / `tunnel_intensity_no_radar.ros.yaml`, minus the radar/intensity gates) still blends a geometric/IMU prior into the confirmed weak direction, with no cross-sensor validation behind it | LiDAR + IMU, cross-sensor gate only if the weak axis is externally observable |
+
+If none of these match -- registration is failing outright, or you were
+"kidnapped" (jumped/lost track) -- see
+[Honest limitations](#honest-limitations) below; this guide is about
+graceful *degradation*, not recovery from a lost track.
+
+## How to enable
+
+Preset files under `lidarslam/param/presets/` contain **only** the
+degeneracy-feature parameters (Hessian gates, radar fusion, intensity
+gates). They deliberately do not set extrinsics, `voxel_size`,
+`min_range`/`max_range`, or other base sensor parameters -- those stay in
+your own sensor config. Layer a preset as a **second** `--params-file`,
+after your sensor config, so its values win:
+
+```bash
+# Offline (rosbag) -- fog / clutter-lock example
+ros2 run rko_lio offline_node --ros-args \
+  --params-file <your_sensor_config>.ros.yaml \
+  --params-file lidarslam/param/presets/corridor_fog_radar.ros.yaml \
+  -p bag_path:=/path/to/bag \
+  -p imu_topic:=/imu -p lidar_topic:=/lidar/points -p base_frame:=base_link \
+  -p radar_topic:=/radar/cloud \
+  -p dump_results:=true -p results_dir:=results -p run_name:=fog_run
+```
+
+```bash
+# Online (live topics) -- tunnel example
+ros2 run rko_lio online_node --ros-args \
+  --params-file <your_sensor_config>.ros.yaml \
+  --params-file lidarslam/param/presets/tunnel_radar.ros.yaml \
+  -p imu_topic:=/imu -p lidar_topic:=/lidar/points -p base_frame:=base_link \
+  -p radar_topic:=/radar/cloud
+```
+
+You can also drive this through
+[`lidarslam/launch/rko_lio_slam.launch.py`](../lidarslam/launch/rko_lio_slam.launch.py)
+by passing `rko_param_file:=<merged_yaml>` (that launch file accepts only
+one RKO-LIO param file argument, so merge your sensor config and the chosen
+preset into one file first if you use it instead of `ros2 run`).
+
+Every preset (including `degeneracy_off.ros.yaml`, the documented no-op
+baseline) has TODO-USER-marked knobs where the value is placeholder or
+rig-specific -- search each file for `TODO-USER` before running it.
+
+`offline_node` hangs at end-of-bag by design (it waits forever for a scan
+past the last IMU sample); stop it with `timeout -s INT <seconds> ros2 run
+...` so `dump_results` still fires on shutdown.
+
+## How to verify it's working
+
+With `dump_results: true`, `rko_lio` writes summary JSON files to
+`<results_dir>/<run_name>_<index>/` on shutdown:
+
+- **`radar_velocity_fusion_summary.json`** (written whenever
+  `radar_velocity_fusion: true`):
+  - `prior_attempt_count` -- scans where a radar ego-velocity estimate was
+    computed and offered as a prior.
+  - `fused_scan_count` -- scans where the Hessian-weak-direction prior
+    actually got blended in. In the tunnel run this fired on 1981 scans; in
+    fog it fired on only 84 scans and did not help by itself (fog's
+    degeneracy isn't a Hessian weak-direction problem -- see the symptom
+    table).
+  - `disagreement_corrected_scan_count` -- scans where
+    `radar_disagreement_gate` overrode ICP's translation. This is the
+    number that matters for fog/clutter-lock and for the tunnel's
+    remaining gap: healthy runs show hundreds of corrected scans over a
+    fog/tunnel-length sequence, not a handful.
+- **`intensity_constraint_summary.json`** (written whenever
+  `intensity_constraint: true` or `intensity_disagreement_gate: true`):
+  - `prior_attempt_count` / `prior_applied_count` -- persistence-gated
+    profile-prior activity (`intensity_constraint`).
+  - `disagreement_attempt_count` / `disagreement_valid_shift_count` --
+    expect roughly 40% of attempts to yield a valid shift correlation; this
+    is the normal hit rate for scan-to-scan reflectivity correlation, not a
+    fault.
+  - `disagreement_corrected_scan_count` -- scans where the gate overrode
+    ICP. The validated radar-less tunnel recovery corrected 635 scans.
+  - `disagreement_exceeded_threshold_count` -- **a high count here is not
+    automatically good news.** On HILTI exp07's self-similar corridor, 52%
+    of attempts exceeded the disagreement threshold and were "corrected" --
+    and every one of those corrections made the trajectory worse (APE
+    0.318 m -> 0.94-2.39 m). A busy counter means the gate is firing, not
+    that it's helping; you still need to A/B the actual trajectory error or
+    reach distance against `degeneracy_off.ros.yaml` before trusting a new
+    environment.
+- `degeneracy_persistence.csv` -- per-scan diagnostics for the
+  Hessian-eigenvalue gates (`confirmed`, `consecutive_scans`,
+  `matched_absolute_cosine`, `intervention_count`, and the weak-axis
+  vector). Use it to check *which* axis is degenerate before picking a
+  preset, per the third symptom-table row.
+
+There is no single "PASS" threshold -- these counters tell you the gates
+are engaging, not that engagement is correct for your data. Always compare
+against a ground truth or a known-good baseline run when moving to a new
+environment.
+
+## Honest limitations
+
+- **Intensity gate applicability is narrow and unforgiving.** It only helps
+  when geometry is self-similar but reflectivity texture is distinctive
+  (the NTNU tunnel). It is *harmful* when the texture is also
+  self-similar/periodic (HILTI exp07: 2.9-7.5x worse APE, at every
+  threshold tried) and harmful when the texture is fake/sensor-coupled
+  (fog aerosol: worse than baseline). There is no automatic detector for
+  which case you're in yet -- you have to look at the data and A/B it.
+- **Radar speed is systematically underestimated** by narrow-FOV
+  single-chip radar hardware (observed ~0.62 speed ratio vs. LIO in the fog
+  cross-check). `radar_velocity_scale` corrects this, but the correct value
+  is a rig/geometry-specific calibration (1.05 for the NTNU tunnel radar,
+  1.10 already overshoots), not a constant you can copy between rigs or
+  even between environments on the same rig -- the same 1.05 that helps the
+  tunnel makes fog slightly *worse*. Only tune it against a sequence with
+  trustworthy distance ground truth.
+- **Soft degeneracy without radar remains unsolved.** In the tunnel dataset,
+  confirmed Hessian-weak-direction windows cover only ~17% of the route;
+  the rest of the distance error accumulates during "soft" degeneracy that
+  never triggers a hard eigenvalue gate. The intensity disagreement gate
+  recovers *some* of this (radar-less tunnel: 98.67 m -> 153.75 m of ~500 m
+  true), but nowhere near what radar achieves (457-495 m), and only under
+  the narrow applicability condition above. There is currently no
+  radar-less fix for fog-style clutter lock at all.
+- **Kidnap/registration-failure handling is stop-and-split, not
+  relocalize, for mapping workflows.** All presets in this repo ship with
+  `enable_kidnap_relocalization` and `reset_on_registration_failure` left
+  at their defaults (off) in your own sensor config -- these presets don't
+  touch them. Automatic global relocalization after a lost track has been
+  observed to converge to a plausible-looking but wrong global pose in
+  earlier sweeps on this codebase; treat a registration failure or long
+  scan gap as a hard segment break to review and stitch manually (e.g. in
+  the pose graph) rather than trusting an automatic global relocalization
+  to silently recover the right pose.

--- a/docs/research/lidar-degeneracy-radar-intensity-ab-2026-07.md
+++ b/docs/research/lidar-degeneracy-radar-intensity-ab-2026-07.md
@@ -139,3 +139,21 @@ benchmark: `/media/sasaki/aiueo/benchmarks/hilti_exp07_intensity_disagreement_20
 - graph_based_slam をデフォルト param で並走させると event-driven ループ探索が
   詰まり DDS バックプレッシャで全体が停止する。退化ベンチは
   `lidarslam_lidar_degeneracy.yaml` (loop stride 1000000) を使う。
+
+## 知見 5 (2026-07-17): 連続情報重み付き radar 融合で fog 26.17 → 11.21 m
+
+不一致ゲートの構造的取り逃し (起動遅れ・閾値未満・radar 方向外) を解消する
+`radar_velocity_continuous_fusion` を実装: 毎スキャン post-ICP で ICP 速度と
+radar 速度を情報重み付きベイズ融合 (radar 側はセンサ軸別 σ: 前方 0.06 /
+横・縦 0.5 m/s、ICP 側は固定トラストスケール 0.2)。
+
+- fog: 26.17 → **11.21 m** (baseline 35.57 m、新アーキ)。tunnel: 505.0 m 維持。
+  決定論バイト一致、テスト全 green。
+- **実装上の発見**: 本実装の ICP Hessian 並進ブロックは対応点数正規化 +
+  並進ヤコビアン=単位行列のため**常に ≈I** で、幾何的信頼度を運ばない
+  (クラッタロックの「自信満々の誤り」と本物の確信を区別できない)。
+  情報重みの ICP 側は固定スケールとするしかなく、これが loose 結合の限界。
+- DR-LRIO (密結合) の <1 m には未達。残差は yaw ドリフト蓄積 + radar バイアス
+  で、逐次補正でなく同時最適化 (密結合) が必要という結論。
+- config: `rko_lio_lidar_degeneracy_radar_continuous.{yaml,ros.yaml}`、
+  プリセット `presets/corridor_fog_radar.ros.yaml` にも反映済み。

--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -373,6 +373,18 @@ if(BUILD_TESTING)
     target_compile_features(test_radar_ego_velocity PRIVATE cxx_std_17)
   endif()
   ament_add_gtest(
+    test_radar_continuous_fusion
+    test/test_radar_continuous_fusion.cpp
+  )
+  if(TARGET test_radar_continuous_fusion)
+    target_include_directories(
+      test_radar_continuous_fusion PRIVATE ../Thirdparty/rko_lio ${EIGEN3_INCLUDE_DIR}
+    )
+    # radar_ego_velocity.hpp uses std::optional; this package otherwise defaults to C++14
+    # (see test_radar_ego_velocity above).
+    target_compile_features(test_radar_continuous_fusion PRIVATE cxx_std_17)
+  endif()
+  ament_add_gtest(
     test_intensity_profile
     test/test_intensity_profile.cpp
   )

--- a/graph_based_slam/test/test_radar_continuous_fusion.cpp
+++ b/graph_based_slam/test/test_radar_continuous_fusion.cpp
@@ -1,0 +1,171 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following disclaimer
+//    in the documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include <Eigen/Core>
+
+#include <limits>
+
+#include "rko_lio/core/radar_ego_velocity.hpp"
+
+namespace
+{
+
+using rko_lio::core::blend_icp_radar_velocity;
+using rko_lio::core::diagonal_velocity_information;
+using rko_lio::core::RadarIcpVelocityBlendResult;
+
+}  // namespace
+
+// Equal (isotropic) informations should produce a plain average of the two velocity estimates.
+TEST(RadarContinuousFusion, IsotropicEqualInformationAverages)
+{
+  const Eigen::Vector3d icp_velocity(1.0, 0.0, 0.0);
+  const Eigen::Vector3d radar_velocity(3.0, 0.0, 0.0);
+  const Eigen::Matrix3d icp_information = Eigen::Matrix3d::Identity() * 10.0;
+  const Eigen::Matrix3d radar_information = Eigen::Matrix3d::Identity() * 10.0;
+
+  const RadarIcpVelocityBlendResult result =
+    blend_icp_radar_velocity(icp_velocity, icp_information, radar_velocity, radar_information);
+
+  ASSERT_TRUE(result.valid);
+  EXPECT_TRUE(result.velocity.isApprox(Eigen::Vector3d(2.0, 0.0, 0.0), 1e-9));
+}
+
+// A much more confident sensor should dominate the fused estimate.
+TEST(RadarContinuousFusion, HigherInformationDominates)
+{
+  const Eigen::Vector3d icp_velocity(0.0, 0.0, 0.0);
+  const Eigen::Vector3d radar_velocity(5.0, 0.0, 0.0);
+  // Radar information 1000x the ICP information along x: fused value should land very close
+  // to the radar estimate.
+  const Eigen::Matrix3d icp_information = Eigen::Matrix3d::Identity() * 1.0;
+  const Eigen::Matrix3d radar_information = Eigen::Matrix3d::Identity() * 1000.0;
+
+  const RadarIcpVelocityBlendResult result =
+    blend_icp_radar_velocity(icp_velocity, icp_information, radar_velocity, radar_information);
+
+  ASSERT_TRUE(result.valid);
+  EXPECT_NEAR(result.velocity.x(), 5.0, 0.02);
+}
+
+// Anisotropic case: radar is confident (high information) only along a lateral axis where ICP
+// is weak (low information, e.g. a degenerate/near-singular direction), while ICP remains
+// trusted along its own strong forward axis. The fused result should follow the radar along the
+// weak axis but stay close to ICP along the strong axis -- this is the core behavior the
+// continuous fusion feature depends on (see Config::radar_velocity_continuous_fusion).
+TEST(RadarContinuousFusion, AnisotropicRadarDominatesOnlyWeakIcpAxis)
+{
+  const Eigen::Vector3d icp_velocity(2.0, 0.0, 0.0);    // ICP: confident forward motion
+  const Eigen::Vector3d radar_velocity(2.0, 1.5, 0.0);  // radar agrees on x, sees lateral drift
+
+  // ICP: strong information along x (forward), essentially zero along y (degenerate direction).
+  Eigen::Matrix3d icp_information = Eigen::Matrix3d::Zero();
+  icp_information(0, 0) = 1.0e4;
+  icp_information(1, 1) = 1.0e-6;
+  icp_information(2, 2) = 1.0e4;
+
+  // Radar: weaker along x than ICP, but the only real signal along y.
+  const Eigen::Matrix3d radar_information = diagonal_velocity_information(0.15, 0.5, 0.5);
+
+  const RadarIcpVelocityBlendResult result =
+    blend_icp_radar_velocity(icp_velocity, icp_information, radar_velocity, radar_information);
+
+  ASSERT_TRUE(result.valid);
+  // Forward axis: ICP's information swamps radar's, fused value stays close to ICP.
+  EXPECT_NEAR(result.velocity.x(), icp_velocity.x(), 0.05);
+  // Lateral axis: ICP contributes ~nothing, fused value should follow the radar's measurement.
+  EXPECT_NEAR(result.velocity.y(), radar_velocity.y(), 0.05);
+}
+
+// Degenerate case: both informations are exactly singular along some axis (e.g. a completely
+// unobserved direction for both sensors). The combined information is then singular too, so the
+// blend must fail cleanly (valid == false) rather than returning a garbage/non-finite velocity.
+TEST(RadarContinuousFusion, BothInformationsSingularFallsBackInvalid)
+{
+  const Eigen::Vector3d icp_velocity(1.0, 0.0, 0.0);
+  const Eigen::Vector3d radar_velocity(1.0, 0.0, 0.0);
+
+  Eigen::Matrix3d icp_information = Eigen::Matrix3d::Zero();
+  icp_information(0, 0) = 10.0;
+  icp_information(2, 2) = 10.0;
+  // y axis left at 0: totally unobserved by ICP.
+
+  Eigen::Matrix3d radar_information = Eigen::Matrix3d::Zero();
+  radar_information(0, 0) = 5.0;
+  radar_information(2, 2) = 5.0;
+  // y axis also left at 0: totally unobserved by radar too (e.g. a 2D radar).
+
+  const RadarIcpVelocityBlendResult result =
+    blend_icp_radar_velocity(icp_velocity, icp_information, radar_velocity, radar_information);
+
+  EXPECT_FALSE(result.valid);
+}
+
+// A single well-conditioned informative sensor plus a completely uninformative (zero) one should
+// still solve fine: the combined information is exactly the informative sensor's, which is
+// non-singular by construction.
+TEST(RadarContinuousFusion, ZeroRadarInformationFallsBackToIcpOnly)
+{
+  const Eigen::Vector3d icp_velocity(4.0, -1.0, 0.2);
+  const Eigen::Vector3d radar_velocity(0.0, 0.0, 0.0);  // irrelevant: zero information below
+
+  const Eigen::Matrix3d icp_information = Eigen::Matrix3d::Identity() * 50.0;
+  const Eigen::Matrix3d radar_information = Eigen::Matrix3d::Zero();
+
+  const RadarIcpVelocityBlendResult result =
+    blend_icp_radar_velocity(icp_velocity, icp_information, radar_velocity, radar_information);
+
+  ASSERT_TRUE(result.valid);
+  EXPECT_TRUE(result.velocity.isApprox(icp_velocity, 1e-9));
+}
+
+// Non-finite inputs must be rejected up front rather than propagating NaN/Inf.
+TEST(RadarContinuousFusion, NonFiniteInputsAreInvalid)
+{
+  const Eigen::Vector3d icp_velocity(1.0, 0.0, 0.0);
+  const Eigen::Vector3d bad_radar_velocity(std::numeric_limits<double>::quiet_NaN(), 0.0, 0.0);
+  const Eigen::Matrix3d info = Eigen::Matrix3d::Identity();
+
+  const RadarIcpVelocityBlendResult result =
+    blend_icp_radar_velocity(icp_velocity, info, bad_radar_velocity, info);
+
+  EXPECT_FALSE(result.valid);
+}
+
+TEST(RadarContinuousFusion, DiagonalVelocityInformationBuildsExpectedDiagonal)
+{
+  const Eigen::Matrix3d info = diagonal_velocity_information(0.1, 0.2, 0.5);
+  EXPECT_NEAR(info(0, 0), 1.0 / (0.1 * 0.1), 1e-9);
+  EXPECT_NEAR(info(1, 1), 1.0 / (0.2 * 0.2), 1e-9);
+  EXPECT_NEAR(info(2, 2), 1.0 / (0.5 * 0.5), 1e-9);
+  EXPECT_NEAR(info(0, 1), 0.0, 1e-12);
+  EXPECT_NEAR(info(0, 2), 0.0, 1e-12);
+  EXPECT_NEAR(info(1, 2), 0.0, 1e-12);
+}

--- a/lidarslam/param/presets/corridor_fog_radar.ros.yaml
+++ b/lidarslam/param/presets/corridor_fog_radar.ros.yaml
@@ -1,0 +1,115 @@
+# Degeneracy-resilience preset: fog / dust clutter-lock (radar disagreement gate).
+#
+# Symptom addressed: pose FREEZES despite real motion in fog, dust, smoke, or
+# heavy aerosol. Point count drops but ICP still reports a healthy Hessian
+# and near-zero motion -- this is "clutter lock", not a classic weak-direction
+# degeneracy. Eigenvalue-based gates (degeneracy_aware_solve and friends)
+# never fire in this failure mode; only a second sensor that disagrees with
+# ICP can catch it. See docs/research/lidar-degeneracy-radar-intensity-ab-2026-07.md
+# ("knowledge 1").
+#
+# Sensors required: LiDAR + IMU (as usual) + a mm-wave/FMCW radar publishing
+# a PointCloud2 with per-point x, y, z, intensity, and velocity (Doppler)
+# fields.
+#
+# TODO-USER knobs (search this file for TODO-USER):
+#   - radar_topic: point it at your radar driver's point-cloud topic.
+#   - extrinsic_radar2base_quat_xyzw_xyz: calibrate radar-to-base extrinsic
+#     for YOUR rig. The placeholder below is IDENTITY, not a real value.
+#   - radar_doppler_sign: verify against your radar's Doppler sign
+#     convention (see comment below).
+#
+# Validated numbers (NTNU "fog" corridor sequence, start-end drift; ground
+# truth 0 m, it's a loop):
+#   baseline (all off)                          32.798 m
+#   + radar Hessian-weak-direction prior only    32.864 m  (no improvement --
+#                                                             the eigenvalue
+#                                                             gate never fires
+#                                                             in fog; kept
+#                                                             enabled below
+#                                                             for defense in
+#                                                             depth, it is
+#                                                             harmless here)
+#   + radar disagreement gate, weight 0.25       30.976 m
+#   + radar disagreement gate, weight 0.7        26.835 m
+#   + radar disagreement gate, weight 1.0        22.684 m  (-31%, ADOPTED)
+# radar_velocity_scale is left at the shared default 1.0 here: the tunnel
+# geometry needed 1.05 to correct a narrow-FOV speed underestimate, but fog's
+# corrected direction is close to unbiased (1.05 made fog slightly WORSE,
+# 22.68 m -> 24.34 m). See tunnel_radar.ros.yaml for the scale-tuned variant.
+#
+# This file contains ONLY degeneracy-feature params -- it is meant to be
+# layered as a SECOND --params-file on top of your own sensor config
+# (extrinsics, voxel_size, min/max_range, etc. stay in your own file):
+#
+#   ros2 run rko_lio offline_node --ros-args \
+#     --params-file <your_sensor_config>.ros.yaml \
+#     --params-file lidarslam/param/presets/corridor_fog_radar.ros.yaml \
+#     -p bag_path:=/path/to/bag -p radar_topic:=/your/radar/topic
+#
+# See docs/degeneracy-guide.md for the symptom -> preset table, how to
+# verify the gate is firing, and honest limitations.
+/**:
+  ros__parameters:
+    # Hessian-eigenvalue weak-direction gates. Harmless defense-in-depth for
+    # fog (they do not fire there -- see header) and required plumbing for
+    # the radar Hessian-weak-direction prior below.
+    degeneracy_aware_solve: true
+    degeneracy_well_conditioned_ratio: 1.5e-5
+    degeneracy_multiplicity_relative_gap: 1.0e-8
+    degeneracy_prior_weight: 0.25
+    degeneracy_persistence_gate: true
+    degeneracy_persistence_min_scans: 3
+    degeneracy_persistence_tracking_ratio: 1.5e-5
+    degeneracy_persistence_min_absolute_cosine: 0.98
+    degeneracy_persistence_min_translation_fraction: 0.99
+    degeneracy_multiscan_observability_gate: true
+    degeneracy_observability_window_scans: 10
+    degeneracy_observability_min_scans: 5
+    degeneracy_observability_max_directional_ratio: 1.0e-5
+
+    # TODO-USER: your radar point-cloud topic (needs x, y, z, intensity,
+    # velocity fields).
+    radar_topic: /radar/cloud
+    # TODO-USER: IDENTITY placeholder -- replace with your radar-to-base
+    # extrinsic [qx, qy, qz, qw, x, y, z]. Do not run with identity unless
+    # your radar really is co-located and co-aligned with base_frame. The
+    # NTNU dataset's published value (for reference only, NOT your rig) was
+    # [0.953717, 0.0, -0.3007058, 0.0, 0.07771, 0.02141, -0.03631].
+    extrinsic_radar2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
+    radar_velocity_fusion: true
+    # TODO-USER: -1.0 was confirmed empirically for the NTNU dataset radar
+    # (Wahba cross-check agreed with the published extrinsic to within
+    # 7.75 deg). Verify the Doppler sign convention for your radar model --
+    # a wrong sign will make the disagreement gate fight ICP instead of
+    # correcting it.
+    radar_doppler_sign: -1.0
+    radar_ransac_inlier_threshold: 0.15
+    radar_ransac_iterations: 100
+    radar_min_inliers: 8
+    radar_prior_max_time_offset_sec: 0.15
+    # Keep at 1.0 for fog; see header. radar_velocity_scale is a rig/geometry
+    # calibration value, not a universal constant.
+    radar_velocity_scale: 1.0
+
+    # The gate that actually recovers fog: radar-vs-ICP velocity disagreement.
+    # Full replacement (weight 1.0) along the radar-observed direction once
+    # disagreement exceeds radar_disagreement_min_mps for
+    # radar_disagreement_min_scans consecutive scans.
+    radar_disagreement_gate: true
+    radar_disagreement_min_mps: 0.2
+    radar_disagreement_min_scans: 10
+    radar_disagreement_weight: 1.0
+    # Continuous information-weighted radar/ICP velocity blend. Strictly
+    # stronger than the disagreement gate on fog (start-end drift
+    # 26.17 m -> 11.21 m on the new architecture); when enabled the
+    # disagreement gate above is skipped per-scan automatically. The sigma
+    # and trust-scale values were calibrated on the NTNU fog sequence --
+    # TODO-USER: re-tune radar_sigma_forward_mps (radar forward-axis noise)
+    # and radar_fusion_icp_information_scale for your radar if results
+    # regress with your rig.
+    radar_velocity_continuous_fusion: true
+    radar_sigma_forward_mps: 0.06
+    radar_sigma_lateral_mps: 0.5
+    radar_sigma_vertical_mps: 0.5
+    radar_fusion_icp_information_scale: 0.2

--- a/lidarslam/param/presets/corridor_fog_radar.yaml
+++ b/lidarslam/param/presets/corridor_fog_radar.yaml
@@ -1,0 +1,108 @@
+# Degeneracy-resilience preset: fog / dust clutter-lock (radar disagreement gate).
+#
+# Symptom addressed: pose FREEZES despite real motion in fog, dust, smoke, or
+# heavy aerosol. Point count drops but ICP still reports a healthy Hessian
+# and near-zero motion -- this is "clutter lock", not a classic weak-direction
+# degeneracy. Eigenvalue-based gates (degeneracy_aware_solve and friends)
+# never fire in this failure mode; only a second sensor that disagrees with
+# ICP can catch it. See docs/research/lidar-degeneracy-radar-intensity-ab-2026-07.md
+# ("knowledge 1").
+#
+# Sensors required: LiDAR + IMU (as usual) + a mm-wave/FMCW radar publishing
+# a PointCloud2 with per-point x, y, z, intensity, and velocity (Doppler)
+# fields.
+#
+# TODO-USER knobs (search this file for TODO-USER):
+#   - radar_topic: point it at your radar driver's point-cloud topic.
+#   - extrinsic_radar2base_quat_xyzw_xyz: calibrate radar-to-base extrinsic
+#     for YOUR rig. The placeholder below is IDENTITY, not a real value.
+#   - radar_doppler_sign: verify against your radar's Doppler sign
+#     convention (see comment below).
+#
+# Validated numbers (NTNU "fog" corridor sequence, start-end drift; ground
+# truth 0 m, it's a loop):
+#   baseline (all off)                          32.798 m
+#   + radar Hessian-weak-direction prior only    32.864 m  (no improvement --
+#                                                             the eigenvalue
+#                                                             gate never fires
+#                                                             in fog; kept
+#                                                             enabled below
+#                                                             for defense in
+#                                                             depth, it is
+#                                                             harmless here)
+#   + radar disagreement gate, weight 0.25       30.976 m
+#   + radar disagreement gate, weight 0.7        26.835 m
+#   + radar disagreement gate, weight 1.0        22.684 m  (-31%, ADOPTED)
+# radar_velocity_scale is left at the shared default 1.0 here: the tunnel
+# geometry needed 1.05 to correct a narrow-FOV speed underestimate, but fog's
+# corrected direction is close to unbiased (1.05 made fog slightly WORSE,
+# 22.68 m -> 24.34 m). See tunnel_radar.yaml for the scale-tuned variant.
+#
+# This file contains ONLY degeneracy-feature params -- it is meant to be
+# layered as a SECOND --params-file on top of your own sensor config
+# (extrinsics, voxel_size, min/max_range, etc. stay in your own file).
+#
+# See docs/degeneracy-guide.md for the symptom -> preset table, how to
+# verify the gate is firing, and honest limitations.
+
+# Hessian-eigenvalue weak-direction gates. Harmless defense-in-depth for fog
+# (they do not fire there -- see header) and required plumbing for the radar
+# Hessian-weak-direction prior below.
+degeneracy_aware_solve: true
+degeneracy_well_conditioned_ratio: 1.5e-5
+degeneracy_multiplicity_relative_gap: 1.0e-8
+degeneracy_prior_weight: 0.25
+degeneracy_persistence_gate: true
+degeneracy_persistence_min_scans: 3
+degeneracy_persistence_tracking_ratio: 1.5e-5
+degeneracy_persistence_min_absolute_cosine: 0.98
+degeneracy_persistence_min_translation_fraction: 0.99
+degeneracy_multiscan_observability_gate: true
+degeneracy_observability_window_scans: 10
+degeneracy_observability_min_scans: 5
+degeneracy_observability_max_directional_ratio: 1.0e-5
+
+# TODO-USER: your radar point-cloud topic (needs x, y, z, intensity,
+# velocity fields).
+radar_topic: /radar/cloud
+# TODO-USER: IDENTITY placeholder -- replace with your radar-to-base
+# extrinsic [qx, qy, qz, qw, x, y, z]. Do not run with identity unless your
+# radar really is co-located and co-aligned with base_frame. The NTNU
+# dataset's published value (for reference only, NOT your rig) was
+# [0.953717, 0.0, -0.3007058, 0.0, 0.07771, 0.02141, -0.03631].
+extrinsic_radar2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
+radar_velocity_fusion: true
+# TODO-USER: -1.0 was confirmed empirically for the NTNU dataset radar
+# (Wahba cross-check agreed with the published extrinsic to within 7.75
+# deg). Verify the Doppler sign convention for your radar model -- a wrong
+# sign will make the disagreement gate fight ICP instead of correcting it.
+radar_doppler_sign: -1.0
+radar_ransac_inlier_threshold: 0.15
+radar_ransac_iterations: 100
+radar_min_inliers: 8
+radar_prior_max_time_offset_sec: 0.15
+# Keep at 1.0 for fog; see header. radar_velocity_scale is a rig/geometry
+# calibration value, not a universal constant.
+radar_velocity_scale: 1.0
+
+# The gate that actually recovers fog: radar-vs-ICP velocity disagreement.
+# Full replacement (weight 1.0) along the radar-observed direction once
+# disagreement exceeds radar_disagreement_min_mps for
+# radar_disagreement_min_scans consecutive scans.
+radar_disagreement_gate: true
+radar_disagreement_min_mps: 0.2
+radar_disagreement_min_scans: 10
+radar_disagreement_weight: 1.0
+# Continuous information-weighted radar/ICP velocity blend. Strictly
+# stronger than the disagreement gate on fog (start-end drift
+# 26.17 m -> 11.21 m on the new architecture); when enabled the
+# disagreement gate above is skipped per-scan automatically. The sigma
+# and trust-scale values were calibrated on the NTNU fog sequence --
+# TODO-USER: re-tune radar_sigma_forward_mps (radar forward-axis noise)
+# and radar_fusion_icp_information_scale for your radar if results
+# regress with your rig.
+radar_velocity_continuous_fusion: true
+radar_sigma_forward_mps: 0.06
+radar_sigma_lateral_mps: 0.5
+radar_sigma_vertical_mps: 0.5
+radar_fusion_icp_information_scale: 0.2

--- a/lidarslam/param/presets/degeneracy_off.ros.yaml
+++ b/lidarslam/param/presets/degeneracy_off.ros.yaml
@@ -1,0 +1,34 @@
+# Degeneracy-resilience preset: OFF (documented no-op baseline).
+#
+# Symptoms addressed: none -- this is the control arm for A/B testing the
+# other presets in this directory against unmodified rko_lio behavior.
+# Sensors required: none beyond your normal LiDAR + IMU rig.
+# Knobs to touch: none.
+#
+# Every flag below already matches the rko_lio default (see
+# Thirdparty/rko_lio/rko_lio/core/lio.hpp), so layering this file changes
+# nothing versus not layering any degeneracy preset at all. It exists so you
+# can diff it against corridor_fog_radar.ros.yaml / tunnel_radar.ros.yaml /
+# tunnel_intensity_no_radar.ros.yaml and see exactly which knobs each
+# preset flips.
+#
+# This file contains ONLY degeneracy-feature params -- it is meant to be
+# layered as a SECOND --params-file on top of your own sensor config
+# (extrinsics, voxel_size, min/max_range, etc. stay in your own file):
+#
+#   ros2 run rko_lio offline_node --ros-args \
+#     --params-file <your_sensor_config>.ros.yaml \
+#     --params-file lidarslam/param/presets/degeneracy_off.ros.yaml \
+#     -p bag_path:=/path/to/bag
+#
+# See docs/degeneracy-guide.md for the symptom -> preset table and the
+# validated numbers behind each feature.
+/**:
+  ros__parameters:
+    degeneracy_aware_solve: false
+    degeneracy_persistence_gate: false
+    degeneracy_multiscan_observability_gate: false
+    radar_velocity_fusion: false
+    radar_disagreement_gate: false
+    intensity_constraint: false
+    intensity_disagreement_gate: false

--- a/lidarslam/param/presets/degeneracy_off.yaml
+++ b/lidarslam/param/presets/degeneracy_off.yaml
@@ -1,0 +1,27 @@
+# Degeneracy-resilience preset: OFF (documented no-op baseline).
+#
+# Symptoms addressed: none -- this is the control arm for A/B testing the
+# other presets in this directory against unmodified rko_lio behavior.
+# Sensors required: none beyond your normal LiDAR + IMU rig.
+# Knobs to touch: none.
+#
+# Every flag below already matches the rko_lio default (see
+# Thirdparty/rko_lio/rko_lio/core/lio.hpp), so layering this file changes
+# nothing versus not layering any degeneracy preset at all. It exists so you
+# can diff it against corridor_fog_radar.yaml / tunnel_radar.yaml /
+# tunnel_intensity_no_radar.yaml and see exactly which knobs each preset
+# flips.
+#
+# This file contains ONLY degeneracy-feature params -- it is meant to be
+# layered as a SECOND --params-file on top of your own sensor config
+# (extrinsics, voxel_size, min/max_range, etc. stay in your own file).
+#
+# See docs/degeneracy-guide.md for the symptom -> preset table and the
+# validated numbers behind each feature.
+degeneracy_aware_solve: false
+degeneracy_persistence_gate: false
+degeneracy_multiscan_observability_gate: false
+radar_velocity_fusion: false
+radar_disagreement_gate: false
+intensity_constraint: false
+intensity_disagreement_gate: false

--- a/lidarslam/param/presets/tunnel_intensity_no_radar.ros.yaml
+++ b/lidarslam/param/presets/tunnel_intensity_no_radar.ros.yaml
@@ -1,0 +1,109 @@
+# =============================================================================
+# WARNING -- READ BEFORE ENABLING. Environment-specific; validated HARMFUL in
+# two of the three environments it has been tested on. Default-off for a
+# reason. This is the radar-less fallback, not a general-purpose fix.
+# =============================================================================
+#
+# Symptom addressed: trajectory falls far short of the true traveled
+# distance in a long, geometrically self-similar corridor/tunnel, and you
+# have NO radar available (see tunnel_radar.ros.yaml if you do -- radar is
+# strictly better where both apply).
+#
+# APPLICABILITY CONDITION (this is the entire point of this preset -- do not
+# skip it): only enable this when the corridor's GEOMETRY is self-similar
+# but its REFLECTIVITY TEXTURE is distinctive -- irregular paint, cabling,
+# signage, lighting fixtures, wet patches, etc. at irregular intervals along
+# the travel axis. This was true of the NTNU tunnel sequence.
+#
+# It is HARMFUL when:
+#   - the reflectivity texture is ALSO self-similar/periodic along the
+#     travel axis. Validated on HILTI 2022 exp07 (a long, self-similar
+#     corridor with mm-ground-truth control points): baseline APE 0.318 m,
+#     this gate made it 0.94-2.39 m -- 2.9x to 7.5x WORSE, at EVERY
+#     disagreement-min-mps threshold tried (0.2, 0.05, 0.02). Root cause is
+#     correlation aliasing: periodic texture produces plausible-looking but
+#     wrong shift estimates that exceed the correlation threshold on 52% of
+#     attempts and get injected at full weight.
+#   - the texture is fake / sensor-coupled, e.g. fog or dust aerosol
+#     returns. Validated on the NTNU "fog" sequence: start-end drift went
+#     from 32.80 m baseline to 36.97 m -- WORSE than baseline, even though
+#     the intensity correlation itself looked plausible (706/744 valid).
+#
+# Bottom line: visually confirm your corridor has irregular reflectivity
+# markings on real 3D data (not just "it looks like a boring hallway") before
+# turning this on, and A/B it against degeneracy_off.ros.yaml on a held-out
+# run before trusting it operationally. See
+# docs/research/lidar-degeneracy-radar-intensity-ab-2026-07.md ("knowledge 3",
+# "knowledge 4", and the 2026-07-17 HILTI exp07 addendum) for the full
+# analysis, and the negative-result reference config at
+# configs/hilti2022/rko_lio_hilti2022_pandar_intensity_disagreement.yaml.
+#
+# Sensors required: LiDAR + IMU only (the LiDAR must report a per-point
+# "intensity" or "reflectivity" float field).
+#
+# TODO-USER knobs: none required to enable this preset, but you should
+# re-tune intensity_min_correlation / intensity_disagreement_min_mps if you
+# see it misfiring on your own corridor's texture statistics.
+#
+# Validated numbers (NTNU "tunnel" sequence, radar-less, one-way reach; true
+# distance ~500 m):
+#   baseline (all off)               98.67 m,  path 233.8 m
+#   + this preset                   153.75 m,  path 413.8 m (635 scans
+#                                                              corrected)
+# Does not reach the radar-assisted 457-495 m of tunnel_radar.ros.yaml, but
+# meaningfully recovers a radar-less rig where the applicability condition
+# holds.
+#
+# This file contains ONLY degeneracy-feature params -- it is meant to be
+# layered as a SECOND --params-file on top of your own sensor config
+# (extrinsics, voxel_size, min/max_range, etc. stay in your own file):
+#
+#   ros2 run rko_lio offline_node --ros-args \
+#     --params-file <your_sensor_config>.ros.yaml \
+#     --params-file lidarslam/param/presets/tunnel_intensity_no_radar.ros.yaml \
+#     -p bag_path:=/path/to/bag
+#
+# See docs/degeneracy-guide.md for the symptom -> preset table, how to
+# verify the gate is firing, and honest limitations.
+/**:
+  ros__parameters:
+    # Hessian-eigenvalue weak-direction gates -- these fire in tunnels and
+    # matter here.
+    degeneracy_aware_solve: true
+    degeneracy_well_conditioned_ratio: 1.5e-5
+    degeneracy_multiplicity_relative_gap: 1.0e-8
+    degeneracy_prior_weight: 0.25
+    degeneracy_persistence_gate: true
+    degeneracy_persistence_min_scans: 3
+    degeneracy_persistence_tracking_ratio: 1.5e-5
+    degeneracy_persistence_min_absolute_cosine: 0.98
+    degeneracy_persistence_min_translation_fraction: 0.99
+    degeneracy_multiscan_observability_gate: true
+    degeneracy_observability_window_scans: 10
+    degeneracy_observability_min_scans: 5
+    degeneracy_observability_max_directional_ratio: 1.0e-5
+
+    # Persistence-confirmed reflectivity-profile prior. Independent of the
+    # disagreement gate below (core/lio.cpp builds the intensity profile
+    # once and both features share it), but only engages along a
+    # persistence-confirmed weak Hessian direction.
+    intensity_constraint: true
+    intensity_bin_size_m: 0.25
+    intensity_profile_half_length_m: 30.0
+    intensity_max_shift_m: 1.5
+    intensity_min_correlation: 0.6
+    intensity_min_filled_bins: 40
+
+    # Hessian-gate-free intensity-vs-ICP disagreement gate: the radar-less
+    # analogue of radar_disagreement_gate. Tracks the scan's own ICP motion
+    # axis every scan instead of waiting for degeneracy_persistence_gate to
+    # confirm a weak direction, so it also catches "soft" degeneracy between
+    # confirmations -- and this is what actually recovers the tunnel number
+    # above. min_scans is 3, not 10 (unlike radar_disagreement_min_scans):
+    # valid shift correlations only land on ~40% of scans here (vs radar's
+    # near-every-scan Doppler), so requiring 10 consecutive valid+disagreeing
+    # scans essentially never accumulates.
+    intensity_disagreement_gate: true
+    intensity_disagreement_min_mps: 0.2
+    intensity_disagreement_min_scans: 3
+    intensity_disagreement_weight: 1.0

--- a/lidarslam/param/presets/tunnel_intensity_no_radar.yaml
+++ b/lidarslam/param/presets/tunnel_intensity_no_radar.yaml
@@ -1,0 +1,103 @@
+# =============================================================================
+# WARNING -- READ BEFORE ENABLING. Environment-specific; validated HARMFUL in
+# two of the three environments it has been tested on. Default-off for a
+# reason. This is the radar-less fallback, not a general-purpose fix.
+# =============================================================================
+#
+# Symptom addressed: trajectory falls far short of the true traveled
+# distance in a long, geometrically self-similar corridor/tunnel, and you
+# have NO radar available (see tunnel_radar.yaml if you do -- radar is
+# strictly better where both apply).
+#
+# APPLICABILITY CONDITION (this is the entire point of this preset -- do not
+# skip it): only enable this when the corridor's GEOMETRY is self-similar
+# but its REFLECTIVITY TEXTURE is distinctive -- irregular paint, cabling,
+# signage, lighting fixtures, wet patches, etc. at irregular intervals along
+# the travel axis. This was true of the NTNU tunnel sequence.
+#
+# It is HARMFUL when:
+#   - the reflectivity texture is ALSO self-similar/periodic along the
+#     travel axis. Validated on HILTI 2022 exp07 (a long, self-similar
+#     corridor with mm-ground-truth control points): baseline APE 0.318 m,
+#     this gate made it 0.94-2.39 m -- 2.9x to 7.5x WORSE, at EVERY
+#     disagreement-min-mps threshold tried (0.2, 0.05, 0.02). Root cause is
+#     correlation aliasing: periodic texture produces plausible-looking but
+#     wrong shift estimates that exceed the correlation threshold on 52% of
+#     attempts and get injected at full weight.
+#   - the texture is fake / sensor-coupled, e.g. fog or dust aerosol
+#     returns. Validated on the NTNU "fog" sequence: start-end drift went
+#     from 32.80 m baseline to 36.97 m -- WORSE than baseline, even though
+#     the intensity correlation itself looked plausible (706/744 valid).
+#
+# Bottom line: visually confirm your corridor has irregular reflectivity
+# markings on real 3D data (not just "it looks like a boring hallway") before
+# turning this on, and A/B it against degeneracy_off.yaml on a held-out run
+# before trusting it operationally. See
+# docs/research/lidar-degeneracy-radar-intensity-ab-2026-07.md ("knowledge 3",
+# "knowledge 4", and the 2026-07-17 HILTI exp07 addendum) for the full
+# analysis, and the negative-result reference config at
+# configs/hilti2022/rko_lio_hilti2022_pandar_intensity_disagreement.yaml.
+#
+# Sensors required: LiDAR + IMU only (the LiDAR must report a per-point
+# "intensity" or "reflectivity" float field).
+#
+# TODO-USER knobs: none required to enable this preset, but you should
+# re-tune intensity_min_correlation / intensity_disagreement_min_mps if you
+# see it misfiring on your own corridor's texture statistics.
+#
+# Validated numbers (NTNU "tunnel" sequence, radar-less, one-way reach; true
+# distance ~500 m):
+#   baseline (all off)               98.67 m,  path 233.8 m
+#   + this preset                   153.75 m,  path 413.8 m (635 scans
+#                                                              corrected)
+# Does not reach the radar-assisted 457-495 m of tunnel_radar.yaml, but
+# meaningfully recovers a radar-less rig where the applicability condition
+# holds.
+#
+# This file contains ONLY degeneracy-feature params -- it is meant to be
+# layered as a SECOND --params-file on top of your own sensor config
+# (extrinsics, voxel_size, min/max_range, etc. stay in your own file).
+#
+# See docs/degeneracy-guide.md for the symptom -> preset table, how to
+# verify the gate is firing, and honest limitations.
+
+# Hessian-eigenvalue weak-direction gates -- these fire in tunnels and
+# matter here.
+degeneracy_aware_solve: true
+degeneracy_well_conditioned_ratio: 1.5e-5
+degeneracy_multiplicity_relative_gap: 1.0e-8
+degeneracy_prior_weight: 0.25
+degeneracy_persistence_gate: true
+degeneracy_persistence_min_scans: 3
+degeneracy_persistence_tracking_ratio: 1.5e-5
+degeneracy_persistence_min_absolute_cosine: 0.98
+degeneracy_persistence_min_translation_fraction: 0.99
+degeneracy_multiscan_observability_gate: true
+degeneracy_observability_window_scans: 10
+degeneracy_observability_min_scans: 5
+degeneracy_observability_max_directional_ratio: 1.0e-5
+
+# Persistence-confirmed reflectivity-profile prior. Independent of the
+# disagreement gate below (core/lio.cpp builds the intensity profile once
+# and both features share it), but only engages along a
+# persistence-confirmed weak Hessian direction.
+intensity_constraint: true
+intensity_bin_size_m: 0.25
+intensity_profile_half_length_m: 30.0
+intensity_max_shift_m: 1.5
+intensity_min_correlation: 0.6
+intensity_min_filled_bins: 40
+
+# Hessian-gate-free intensity-vs-ICP disagreement gate: the radar-less
+# analogue of radar_disagreement_gate. Tracks the scan's own ICP motion axis
+# every scan instead of waiting for degeneracy_persistence_gate to confirm a
+# weak direction, so it also catches "soft" degeneracy between confirmations
+# -- and this is what actually recovers the tunnel number above. min_scans
+# is 3, not 10 (unlike radar_disagreement_min_scans): valid shift
+# correlations only land on ~40% of scans here (vs radar's near-every-scan
+# Doppler), so requiring 10 consecutive valid+disagreeing scans essentially
+# never accumulates.
+intensity_disagreement_gate: true
+intensity_disagreement_min_mps: 0.2
+intensity_disagreement_min_scans: 3
+intensity_disagreement_weight: 1.0

--- a/lidarslam/param/presets/tunnel_radar.ros.yaml
+++ b/lidarslam/param/presets/tunnel_radar.ros.yaml
@@ -1,0 +1,110 @@
+# Degeneracy-resilience preset: long straight tunnel/corridor (both radar gates).
+#
+# Symptom addressed: trajectory falls far short of the true traveled
+# distance in a long, geometrically self-similar, straight corridor/tunnel
+# -- classic single-axis (translation-along-travel) degeneracy. Unlike fog
+# clutter-lock, the Hessian eigenvalue gates DO fire here and are useful on
+# their own; the radar disagreement gate adds a complementary correction on
+# top. See docs/research/lidar-degeneracy-radar-intensity-ab-2026-07.md
+# ("knowledge 2").
+#
+# Sensors required: LiDAR + IMU (as usual) + a mm-wave/FMCW radar publishing
+# a PointCloud2 with per-point x, y, z, intensity, and velocity (Doppler)
+# fields.
+#
+# TODO-USER knobs (search this file for TODO-USER):
+#   - radar_topic: point it at your radar driver's point-cloud topic.
+#   - extrinsic_radar2base_quat_xyzw_xyz: calibrate radar-to-base extrinsic
+#     for YOUR rig. The placeholder below is IDENTITY, not a real value.
+#   - radar_doppler_sign: verify against your radar's Doppler sign
+#     convention (see comment below).
+#   - radar_velocity_scale: RIG/GEOMETRY-SPECIFIC. Default is 1.0. The value
+#     below (1.05) is the number that was calibrated for the NTNU tunnel
+#     sequence's narrow-FOV single-chip radar; it is NOT a universal
+#     constant. Re-sweep it for your own radar and site if you can get a
+#     distance ground truth, otherwise leave it at 1.0.
+#
+# Validated numbers (NTNU "tunnel" sequence, one-way reach; true distance
+# ~500 m):
+#   baseline (all off)                                    98.67 m  (20% of GT)
+#   + both radar gates (Hessian prior + disagreement),
+#     radar_velocity_scale 1.0                            457.05 m (91% of GT,
+#                                                                     -8.6% of
+#                                                                     the
+#                                                                     remaining
+#                                                                     gap)
+#     Hessian prior fired on 1981 scans, disagreement gate corrected 1011
+#     scans; lateral RMS 1.93 m.
+#   + same, radar_velocity_scale 1.05 (calibrated)        495.3 m (-0.9%,
+#                                                                    ADOPTED
+#                                                                    for this
+#                                                                    rig)
+#   + same, radar_velocity_scale 1.10                     519.8 m (+4.0%,
+#                                                                    overshoot)
+# The remaining -8.6% at scale 1.0 was traced to a systematic radar speed
+# underestimate (narrow-FOV single-chip radar observation limit, ~0.62
+# speed ratio in the fog cross-check); radar_velocity_scale corrects it.
+# radar_velocity_scale is applied uniformly (not gated), so re-tune it only
+# using a sequence where you trust the distance ground truth -- fog was
+# already close to unbiased and got slightly WORSE at 1.05 (22.68 m ->
+# 24.34 m start-end drift). See corridor_fog_radar.ros.yaml for that case.
+#
+# This file contains ONLY degeneracy-feature params -- it is meant to be
+# layered as a SECOND --params-file on top of your own sensor config
+# (extrinsics, voxel_size, min/max_range, etc. stay in your own file):
+#
+#   ros2 run rko_lio offline_node --ros-args \
+#     --params-file <your_sensor_config>.ros.yaml \
+#     --params-file lidarslam/param/presets/tunnel_radar.ros.yaml \
+#     -p bag_path:=/path/to/bag -p radar_topic:=/your/radar/topic
+#
+# See docs/degeneracy-guide.md for the symptom -> preset table, how to
+# verify the gates are firing, and honest limitations.
+/**:
+  ros__parameters:
+    # Hessian-eigenvalue weak-direction gates -- these fire in tunnels and
+    # matter here (unlike fog).
+    degeneracy_aware_solve: true
+    degeneracy_well_conditioned_ratio: 1.5e-5
+    degeneracy_multiplicity_relative_gap: 1.0e-8
+    degeneracy_prior_weight: 0.25
+    degeneracy_persistence_gate: true
+    degeneracy_persistence_min_scans: 3
+    degeneracy_persistence_tracking_ratio: 1.5e-5
+    degeneracy_persistence_min_absolute_cosine: 0.98
+    degeneracy_persistence_min_translation_fraction: 0.99
+    degeneracy_multiscan_observability_gate: true
+    degeneracy_observability_window_scans: 10
+    degeneracy_observability_min_scans: 5
+    degeneracy_observability_max_directional_ratio: 1.0e-5
+
+    # TODO-USER: your radar point-cloud topic (needs x, y, z, intensity,
+    # velocity fields).
+    radar_topic: /radar/cloud
+    # TODO-USER: IDENTITY placeholder -- replace with your radar-to-base
+    # extrinsic [qx, qy, qz, qw, x, y, z]. Do not run with identity unless
+    # your radar really is co-located and co-aligned with base_frame. The
+    # NTNU dataset's published value (for reference only, NOT your rig) was
+    # [0.953717, 0.0, -0.3007058, 0.0, 0.07771, 0.02141, -0.03631].
+    extrinsic_radar2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
+    radar_velocity_fusion: true
+    # TODO-USER: -1.0 was confirmed empirically for the NTNU dataset radar
+    # (Wahba cross-check agreed with the published extrinsic to within
+    # 7.75 deg). Verify the Doppler sign convention for your radar model --
+    # a wrong sign will make the disagreement gate fight ICP instead of
+    # correcting it.
+    radar_doppler_sign: -1.0
+    radar_ransac_inlier_threshold: 0.15
+    radar_ransac_iterations: 100
+    radar_min_inliers: 8
+    radar_prior_max_time_offset_sec: 0.15
+    # TODO-USER: rig/geometry-specific calibration, see header. Default is
+    # 1.0; 1.05 below is the NTNU tunnel-calibrated value.
+    radar_velocity_scale: 1.05
+
+    # Radar-vs-ICP velocity disagreement gate: complements the Hessian prior
+    # above by catching cases the eigenvalue gate misses.
+    radar_disagreement_gate: true
+    radar_disagreement_min_mps: 0.2
+    radar_disagreement_min_scans: 10
+    radar_disagreement_weight: 1.0

--- a/lidarslam/param/presets/tunnel_radar.yaml
+++ b/lidarslam/param/presets/tunnel_radar.yaml
@@ -1,0 +1,99 @@
+# Degeneracy-resilience preset: long straight tunnel/corridor (both radar gates).
+#
+# Symptom addressed: trajectory falls far short of the true traveled
+# distance in a long, geometrically self-similar, straight corridor/tunnel
+# -- classic single-axis (translation-along-travel) degeneracy. Unlike fog
+# clutter-lock, the Hessian eigenvalue gates DO fire here and are useful on
+# their own; the radar disagreement gate adds a complementary correction on
+# top. See docs/research/lidar-degeneracy-radar-intensity-ab-2026-07.md
+# ("knowledge 2").
+#
+# Sensors required: LiDAR + IMU (as usual) + a mm-wave/FMCW radar publishing
+# a PointCloud2 with per-point x, y, z, intensity, and velocity (Doppler)
+# fields.
+#
+# TODO-USER knobs (search this file for TODO-USER):
+#   - radar_topic: point it at your radar driver's point-cloud topic.
+#   - extrinsic_radar2base_quat_xyzw_xyz: calibrate radar-to-base extrinsic
+#     for YOUR rig. The placeholder below is IDENTITY, not a real value.
+#   - radar_doppler_sign: verify against your radar's Doppler sign
+#     convention (see comment below).
+#   - radar_velocity_scale: RIG/GEOMETRY-SPECIFIC. Default is 1.0. The value
+#     below (1.05) is the number that was calibrated for the NTNU tunnel
+#     sequence's narrow-FOV single-chip radar; it is NOT a universal
+#     constant. Re-sweep it for your own radar and site if you can get a
+#     distance ground truth, otherwise leave it at 1.0.
+#
+# Validated numbers (NTNU "tunnel" sequence, one-way reach; true distance
+# ~500 m):
+#   baseline (all off)                                    98.67 m  (20% of GT)
+#   + both radar gates (Hessian prior + disagreement),
+#     radar_velocity_scale 1.0                            457.05 m (91% of GT)
+#     Hessian prior fired on 1981 scans, disagreement gate corrected 1011
+#     scans; lateral RMS 1.93 m.
+#   + same, radar_velocity_scale 1.05 (calibrated)        495.3 m (-0.9%,
+#                                                                    ADOPTED
+#                                                                    for this
+#                                                                    rig)
+#   + same, radar_velocity_scale 1.10                     519.8 m (+4.0%,
+#                                                                    overshoot)
+# The remaining -8.6% at scale 1.0 was traced to a systematic radar speed
+# underestimate (narrow-FOV single-chip radar observation limit, ~0.62
+# speed ratio in the fog cross-check); radar_velocity_scale corrects it.
+# radar_velocity_scale is applied uniformly (not gated), so re-tune it only
+# using a sequence where you trust the distance ground truth -- fog was
+# already close to unbiased and got slightly WORSE at 1.05 (22.68 m ->
+# 24.34 m start-end drift). See corridor_fog_radar.yaml for that case.
+#
+# This file contains ONLY degeneracy-feature params -- it is meant to be
+# layered as a SECOND --params-file on top of your own sensor config
+# (extrinsics, voxel_size, min/max_range, etc. stay in your own file).
+#
+# See docs/degeneracy-guide.md for the symptom -> preset table, how to
+# verify the gates are firing, and honest limitations.
+
+# Hessian-eigenvalue weak-direction gates -- these fire in tunnels and
+# matter here (unlike fog).
+degeneracy_aware_solve: true
+degeneracy_well_conditioned_ratio: 1.5e-5
+degeneracy_multiplicity_relative_gap: 1.0e-8
+degeneracy_prior_weight: 0.25
+degeneracy_persistence_gate: true
+degeneracy_persistence_min_scans: 3
+degeneracy_persistence_tracking_ratio: 1.5e-5
+degeneracy_persistence_min_absolute_cosine: 0.98
+degeneracy_persistence_min_translation_fraction: 0.99
+degeneracy_multiscan_observability_gate: true
+degeneracy_observability_window_scans: 10
+degeneracy_observability_min_scans: 5
+degeneracy_observability_max_directional_ratio: 1.0e-5
+
+# TODO-USER: your radar point-cloud topic (needs x, y, z, intensity,
+# velocity fields).
+radar_topic: /radar/cloud
+# TODO-USER: IDENTITY placeholder -- replace with your radar-to-base
+# extrinsic [qx, qy, qz, qw, x, y, z]. Do not run with identity unless your
+# radar really is co-located and co-aligned with base_frame. The NTNU
+# dataset's published value (for reference only, NOT your rig) was
+# [0.953717, 0.0, -0.3007058, 0.0, 0.07771, 0.02141, -0.03631].
+extrinsic_radar2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
+radar_velocity_fusion: true
+# TODO-USER: -1.0 was confirmed empirically for the NTNU dataset radar
+# (Wahba cross-check agreed with the published extrinsic to within 7.75
+# deg). Verify the Doppler sign convention for your radar model -- a wrong
+# sign will make the disagreement gate fight ICP instead of correcting it.
+radar_doppler_sign: -1.0
+radar_ransac_inlier_threshold: 0.15
+radar_ransac_iterations: 100
+radar_min_inliers: 8
+radar_prior_max_time_offset_sec: 0.15
+# TODO-USER: rig/geometry-specific calibration, see header. Default is 1.0;
+# 1.05 below is the NTNU tunnel-calibrated value.
+radar_velocity_scale: 1.05
+
+# Radar-vs-ICP velocity disagreement gate: complements the Hessian prior
+# above by catching cases the eigenvalue gate misses.
+radar_disagreement_gate: true
+radar_disagreement_min_mps: 0.2
+radar_disagreement_min_scans: 10
+radar_disagreement_weight: 1.0

--- a/lidarslam/param/rko_lio_lidar_degeneracy_radar_continuous.ros.yaml
+++ b/lidarslam/param/rko_lio_lidar_degeneracy_radar_continuous.ros.yaml
@@ -1,0 +1,92 @@
+# NTNU LiDAR Degeneracy Datasets, "fog" corridor sequence: continuous,
+# information-weighted radar/ICP velocity fusion (see rko_lio/core/lio.cpp
+# register_scan(), radar_velocity_continuous_fusion block).
+#
+# Unlike rko_lio_lidar_degeneracy_radar_weak_direction.ros.yaml's
+# radar_disagreement_gate (10-scan disagreement streak required before any
+# correction starts, single-axis correction along the radar heading only,
+# only above a 0.2 m/s gap), this blends every scan with a fresh radar prior,
+# per axis, weighted by the relative confidence (information) of the ICP
+# solve vs. the radar measurement along that world-frame axis. Fixes fog
+# clutter-lock from scan 1 instead of after ~10 scans of accumulated drift,
+# and is not an all-or-nothing single-direction replacement.
+#
+# radar_sigma_forward/lateral/vertical_mps are the per-axis radar sensor-frame
+# velocity sigmas (m/s) used to build each prior's information matrix
+# (BaseNode::radar_callback): near-unbiased forward-velocity estimate, weak
+# lateral/vertical (narrow-FOV radar, limited direction diversity) -- see the
+# fog validation referenced in radar_weak_direction's header comment.
+#
+# radar_disagreement_gate is left enabled here for documentation/comparison
+# purposes only: LIO::register_scan skips that block entirely whenever
+# radar_velocity_continuous_fusion is on (continuous fusion subsumes it), so
+# its value has no runtime effect in this config.
+#
+# Same base sensor/calibration settings as
+# rko_lio_lidar_degeneracy_radar_weak_direction.ros.yaml; param names already
+# match current upstream (max_correspondence_distance, etc.).
+/**:
+  ros__parameters:
+    extrinsic_imu2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
+    extrinsic_lidar2base_quat_xyzw_xyz: [0.000462, 0.0008483, 0.0028835, 0.9999954, -0.00171, 0.02149, 0.0358]
+    lidar_timestamps.offset_seconds: 0.0
+    initialization_phase: true
+    deskew: true
+    voxel_size: 0.5
+    icp_keypoint_voxel_multiplier: 1.5
+    max_points_per_voxel: 20
+    min_range: 0.7
+    max_range: 100.0
+    max_correspondence_distance: 0.5
+    double_downsample: true
+    degeneracy_aware_solve: true
+    degeneracy_well_conditioned_ratio: 1.5e-5
+    degeneracy_multiplicity_relative_gap: 1.0e-8
+    degeneracy_prior_weight: 0.25
+    degeneracy_persistence_gate: true
+    degeneracy_persistence_min_scans: 3
+    degeneracy_persistence_tracking_ratio: 1.5e-5
+    degeneracy_persistence_min_absolute_cosine: 0.98
+    degeneracy_persistence_min_translation_fraction: 0.99
+    degeneracy_multiscan_observability_gate: true
+    degeneracy_observability_window_scans: 10
+    degeneracy_observability_min_scans: 5
+    degeneracy_observability_max_directional_ratio: 1.0e-5
+    # Radar topic + ego-velocity estimator. Extrinsic is the dataset authors'
+    # published radar-to-IMU calibration (imu2base is identity here); the
+    # -1.0 doppler sign was confirmed empirically against the fog LIO baseline.
+    radar_topic: /radar/cloud
+    extrinsic_radar2base_quat_xyzw_xyz: [0.953717, 0.0, -0.3007058, 0.0, 0.07771, 0.02141, -0.03631]
+    radar_doppler_sign: -1.0
+    radar_ransac_inlier_threshold: 0.15
+    radar_ransac_iterations: 100
+    radar_min_inliers: 8
+    radar_prior_max_time_offset_sec: 0.15
+    # Hessian-weak-direction radar prior (separate feature, see
+    # rko_lio_lidar_degeneracy_radar_weak_direction.ros.yaml): off here so the
+    # A/B isolates the continuous-fusion feature.
+    radar_velocity_fusion: false
+    # Disagreement gate: documented above as inert while continuous fusion is on.
+    radar_disagreement_gate: true
+    radar_disagreement_min_mps: 0.2
+    radar_disagreement_min_scans: 10
+    radar_disagreement_weight: 1.0
+    # Continuous, information-weighted radar/ICP velocity fusion (this config's feature).
+    # Tuning note: the ICP translation-translation Hessian block (icp_H's top-left 3x3) is
+    # ALWAYS ~Identity by construction -- build_icp_linear_system's per-point translation
+    # Jacobian is exactly Identity regardless of point geometry, and H is normalized by
+    # correspondence count, so H_tt carries no signal about clutter-lock (fog aerosol returns
+    # give ICP a perfectly well-conditioned, confidently WRONG Hessian). radar_fusion_icp_information_scale
+    # and the sigmas below were therefore tuned empirically as a fixed trust ratio rather than
+    # relying on H_tt to auto-detect degeneracy; see the fog A/B sweep in this feature's PR
+    # description. 0.06 m/s forward sigma with icp_information_scale 0.2 (icp info ~=0.2/dt^2,
+    # radar forward info ~=1/0.06^2=278) lets radar dominate the forward axis while ICP still
+    # dominates lateral/vertical (radar info there stays 1/0.5^2=4, well below icp's ~20).
+    radar_velocity_continuous_fusion: true
+    radar_sigma_forward_mps: 0.06
+    radar_sigma_lateral_mps: 0.5
+    radar_sigma_vertical_mps: 0.5
+    radar_fusion_icp_information_scale: 0.2
+    enable_kidnap_relocalization: false
+    reset_on_registration_failure: false
+    relocalize_after_scan_gap: false

--- a/lidarslam/param/rko_lio_lidar_degeneracy_radar_continuous.yaml
+++ b/lidarslam/param/rko_lio_lidar_degeneracy_radar_continuous.yaml
@@ -1,0 +1,61 @@
+# NTNU LiDAR Degeneracy Datasets, "fog" corridor sequence: continuous,
+# information-weighted radar/ICP velocity fusion. Flat (non-ROS-wrapped)
+# companion to rko_lio_lidar_degeneracy_radar_continuous.ros.yaml -- see that
+# file's header comment for the full rationale; this one mirrors
+# rko_lio_lidar_degeneracy_radar_weak_direction.yaml's flat format for tools
+# that load params directly rather than through a ROS launch file.
+extrinsic_imu2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
+extrinsic_lidar2base_quat_xyzw_xyz: [0.000462, 0.0008483, 0.0028835, 0.9999954, -0.00171, 0.02149, 0.0358]
+
+lidar_timestamps.offset_seconds: 0.0
+initialization_phase: true
+deskew: true
+voxel_size: 0.5
+icp_keypoint_voxel_multiplier: 1.5
+max_points_per_voxel: 20
+min_range: 0.7
+max_range: 100.0
+max_correspondence_distance: 0.5
+double_downsample: true
+
+degeneracy_aware_solve: true
+degeneracy_well_conditioned_ratio: 1.5e-5
+degeneracy_multiplicity_relative_gap: 1.0e-8
+degeneracy_prior_weight: 0.25
+degeneracy_persistence_gate: true
+degeneracy_persistence_min_scans: 3
+degeneracy_persistence_tracking_ratio: 1.5e-5
+degeneracy_persistence_min_absolute_cosine: 0.98
+degeneracy_persistence_min_translation_fraction: 0.99
+degeneracy_multiscan_observability_gate: true
+degeneracy_observability_window_scans: 10
+degeneracy_observability_min_scans: 5
+degeneracy_observability_max_directional_ratio: 1.0e-5
+
+# radar topic + ego-velocity estimator -- see header comment above.
+radar_topic: /radar/cloud
+extrinsic_radar2base_quat_xyzw_xyz: [0.953717, 0.0, -0.3007058, 0.0, 0.07771, 0.02141, -0.03631]
+radar_doppler_sign: -1.0
+radar_ransac_inlier_threshold: 0.15
+radar_ransac_iterations: 100
+radar_min_inliers: 8
+radar_prior_max_time_offset_sec: 0.15
+radar_velocity_fusion: false
+# Inert while radar_velocity_continuous_fusion is on; kept for documentation/comparison.
+radar_disagreement_gate: true
+radar_disagreement_min_mps: 0.2
+radar_disagreement_min_scans: 10
+radar_disagreement_weight: 1.0
+# Continuous, information-weighted radar/ICP velocity fusion (this config's feature). Tuned
+# empirically -- see rko_lio_lidar_degeneracy_radar_continuous.ros.yaml's header comment for why
+# (icp_H's translation block carries no clutter-lock signal, so this is a fixed trust ratio, not
+# an H-derived one).
+radar_velocity_continuous_fusion: true
+radar_sigma_forward_mps: 0.06
+radar_sigma_lateral_mps: 0.5
+radar_sigma_vertical_mps: 0.5
+radar_fusion_icp_information_scale: 0.2
+
+enable_kidnap_relocalization: false
+reset_on_registration_failure: false
+relocalize_after_scan_gap: false

--- a/lidarslam/param/rko_lio_lidar_degeneracy_radar_continuous_tunnel.ros.yaml
+++ b/lidarslam/param/rko_lio_lidar_degeneracy_radar_continuous_tunnel.ros.yaml
@@ -1,0 +1,56 @@
+# Tunnel variant of rko_lio_lidar_degeneracy_radar_continuous.ros.yaml:
+# radar_velocity_scale 1.05 corrects the sparse narrow-FOV radar's speed
+# underestimate on the tunnel geometry (see
+# rko_lio_lidar_degeneracy_radar_weak_direction_tunnel.ros.yaml, reach
+# 457.1 -> 495.3 m of ~500 m). Fog is near-unbiased along its corrected
+# direction, so the shared fog config keeps the default 1.0.
+/**:
+  ros__parameters:
+    extrinsic_imu2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
+    extrinsic_lidar2base_quat_xyzw_xyz: [0.000462, 0.0008483, 0.0028835, 0.9999954, -0.00171, 0.02149, 0.0358]
+    lidar_timestamps.offset_seconds: 0.0
+    initialization_phase: true
+    deskew: true
+    voxel_size: 0.5
+    icp_keypoint_voxel_multiplier: 1.5
+    max_points_per_voxel: 20
+    min_range: 0.7
+    max_range: 100.0
+    max_correspondence_distance: 0.5
+    double_downsample: true
+    degeneracy_aware_solve: true
+    degeneracy_well_conditioned_ratio: 1.5e-5
+    degeneracy_multiplicity_relative_gap: 1.0e-8
+    degeneracy_prior_weight: 0.25
+    degeneracy_persistence_gate: true
+    degeneracy_persistence_min_scans: 3
+    degeneracy_persistence_tracking_ratio: 1.5e-5
+    degeneracy_persistence_min_absolute_cosine: 0.98
+    degeneracy_persistence_min_translation_fraction: 0.99
+    degeneracy_multiscan_observability_gate: true
+    degeneracy_observability_window_scans: 10
+    degeneracy_observability_min_scans: 5
+    degeneracy_observability_max_directional_ratio: 1.0e-5
+    radar_topic: /radar/cloud
+    extrinsic_radar2base_quat_xyzw_xyz: [0.953717, 0.0, -0.3007058, 0.0, 0.07771, 0.02141, -0.03631]
+    radar_doppler_sign: -1.0
+    radar_ransac_inlier_threshold: 0.15
+    radar_ransac_iterations: 100
+    radar_min_inliers: 8
+    radar_prior_max_time_offset_sec: 0.15
+    radar_velocity_scale: 1.05
+    radar_velocity_fusion: false
+    radar_disagreement_gate: true
+    radar_disagreement_min_mps: 0.2
+    radar_disagreement_min_scans: 10
+    radar_disagreement_weight: 1.0
+    # Same tuned continuous-fusion trust ratio as the fog config -- see
+    # rko_lio_lidar_degeneracy_radar_continuous.ros.yaml's header comment.
+    radar_velocity_continuous_fusion: true
+    radar_sigma_forward_mps: 0.06
+    radar_sigma_lateral_mps: 0.5
+    radar_sigma_vertical_mps: 0.5
+    radar_fusion_icp_information_scale: 0.2
+    enable_kidnap_relocalization: false
+    reset_on_registration_failure: false
+    relocalize_after_scan_gap: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
   - Autoware Quickstart: autoware-quickstart.md
   - Autoware Foxglove: autoware-foxglove.md
   - Operator Workflows: workflows.md
+  - Degeneracy Resilience Guide: degeneracy-guide.md
   - 3DGS Photoreal Map: 3dgs-map-tutorial.md
   - 3DGS Map Viewer: 3dgs-viewer.md
   - Benchmarking And Release Gate: benchmarking.md


### PR DESCRIPTION
## Summary

Companion to rsasaki0109/rko_lio#4 (continuous information-weighted radar/ICP velocity fusion — fog start-end drift 26.17 → 11.21 m, tunnel 505.0 m of ~500 m):

- Submodule bump to the merged rko_lio master.
- Configs: `rko_lio_lidar_degeneracy_radar_continuous.{yaml,ros.yaml}` (+ tunnel variant).
- **User-friendliness**: `lidarslam/param/presets/` — four layerable degeneracy presets (off / fog radar / tunnel radar / tunnel intensity) containing only the feature params with TODO-USER markers for rig calibration; the intensity preset carries a loud applicability warning citing the HILTI exp07 negative result. `docs/degeneracy-guide.md` (symptom → preset table, verification via summary JSONs, honest limitations) + README section + mkdocs nav.
- Research note: knowledge 5 (continuous fusion; loose-coupling limits vs DR-LRIO's tightly-coupled <1 m).

All new features remain default-off; param names verified against `declare_parameter` declarations (zero mismatches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tRU7h2vZNcBHaFYWmZB5E