### PR TITLE
Port vignette margin and colour-confidence gating to the realtime colorizer

### DIFF
--- a/scanmatcher/include/scanmatcher/point_colorizer.hpp
+++ b/scanmatcher/include/scanmatcher/point_colorizer.hpp
@@ -146,6 +146,23 @@ inline bool projectPoint(
          v >= 0.0f && v <= static_cast<float>(intr.height - 1);
 }
 
+// True when (u, v) sits at least `margin` pixels inside every image border.
+// Lens vignetting darkens the border band in a way per-frame exposure gains
+// cannot repair, so colour sampling can skip it while the z-buffer (occlusion
+// geometry, valid to the border) still uses the full frame — the streaming
+// counterpart of the offline `image_margin` option. `margin <= 0` keeps the
+// full frame.
+inline bool insideImageMargin(
+  const CameraIntrinsics & intr, float u, float v, int margin)
+{
+  if (margin <= 0) {
+    return true;
+  }
+  const float m = static_cast<float>(margin);
+  return u >= m && u <= static_cast<float>(intr.width - 1) - m &&
+         v >= m && v <= static_cast<float>(intr.height - 1) - m;
+}
+
 // Nearest-pixel colour sample into `rgb` (3 elements). Coordinates are clamped
 // to the image, so callers may pass any in-bounds (u, v).
 inline void sampleNearest(
@@ -261,6 +278,15 @@ struct PointColor
   }
 
   bool seen() const {return count > 0;}
+
+  // Colour backed by at least `min_count` accumulated observations. Colours
+  // confirmed only once or twice are usually occlusion-fringe or specular
+  // one-offs that pepper flat surfaces; consumers can require more before
+  // trusting the mean (min_count <= 1 degrades to `seen`).
+  bool confirmed(std::uint16_t min_count) const
+  {
+    return count >= std::max<std::uint16_t>(min_count, 1);
+  }
 
   // Rounded [0,255] mean colour into `out` (3 elements). Undefined if unseen.
   void mean(std::uint8_t out[3]) const

--- a/scanmatcher/param/colorization.yaml
+++ b/scanmatcher/param/colorization.yaml
@@ -7,6 +7,10 @@ pointcloud_colorization:
     zbuf_bin: 4               # per-frame z-buffer cell size [px] (occlusion)
     depth_tolerance: 0.15     # visible if within this (+2% range) of nearest [m]
     use_bilinear: true        # sub-pixel colour sampling (vs nearest)
+    image_margin: 0           # skip colour samples within N px of the border
+                              # (lens vignette; occlusion still uses full frame)
+    min_color_samples: 1      # voxel colour needs this many observations
+                              # before publishing (else grey; 1 keeps all)
     normalize_exposure: true  # rescale each frame toward a running median luma
     exposure_ema_alpha: 0.1   # smoothing of the exposure target
     publish_period: 2.0       # colored_map publish period [s]

--- a/scanmatcher/src/pointcloud_colorization_node.cpp
+++ b/scanmatcher/src/pointcloud_colorization_node.cpp
@@ -107,6 +107,8 @@ public:
     voxel_size_ = declare_parameter("voxel_size", 0.1);
     zbuf_bin_ = static_cast<int>(declare_parameter("zbuf_bin", 4));
     depth_tol_ = declare_parameter("depth_tolerance", 0.15);
+    image_margin_ = static_cast<int>(declare_parameter("image_margin", 0));
+    min_color_samples_ = static_cast<int>(declare_parameter("min_color_samples", 1));
     use_bilinear_ = declare_parameter("use_bilinear", true);
     normalize_exposure_ = declare_parameter("normalize_exposure", true);
     exposure_ema_alpha_ = declare_parameter("exposure_ema_alpha", 0.1);
@@ -321,6 +323,9 @@ private:
       if (!zbuf.visible(u, v, depth, static_cast<float>(depth_tol_))) {
         continue;
       }
+      if (!point_colorizer::insideImageMargin(intr, u, v, image_margin_)) {
+        continue;  // vignette band: geometry above still occludes, colour skips
+      }
       float rgb[3];
       if (use_bilinear_) {
         point_colorizer::sampleBilinear(view, u, v, rgb);
@@ -352,7 +357,7 @@ private:
         p.x = vox.x;
         p.y = vox.y;
         p.z = vox.z;
-        if (vox.color.seen()) {
+        if (vox.color.confirmed(static_cast<std::uint16_t>(min_color_samples_))) {
           std::uint8_t rgb[3];
           vox.color.mean(rgb);
           p.r = rgb[0];
@@ -380,6 +385,8 @@ private:
   double voxel_size_ {0.1};
   int zbuf_bin_ {4};
   double depth_tol_ {0.15};
+  int image_margin_ {0};
+  int min_color_samples_ {1};
   bool use_bilinear_ {true};
   bool normalize_exposure_ {true};
   double exposure_ema_alpha_ {0.1};

--- a/scanmatcher/test/test_point_colorizer.cpp
+++ b/scanmatcher/test/test_point_colorizer.cpp
@@ -266,6 +266,38 @@ TEST(PointColorizer, AveragesRepeatedObservations)
   EXPECT_EQ(out[2], 40);
 }
 
+TEST(PointColorizer, ImageMarginSkipsBorderBand)
+{
+  using graphslam::point_colorizer::insideImageMargin;
+  CameraIntrinsics intr;
+  intr.fx = intr.fy = 100.0f;
+  intr.cx = intr.cy = 50.0f;
+  intr.width = intr.height = 100;
+  // Centre passes any sane margin; a point 4 px from the border fails a
+  // 10 px margin but passes with the margin disabled.
+  EXPECT_TRUE(insideImageMargin(intr, 50.0f, 50.0f, 10));
+  EXPECT_FALSE(insideImageMargin(intr, 95.0f, 50.0f, 10));
+  EXPECT_FALSE(insideImageMargin(intr, 50.0f, 4.0f, 10));
+  EXPECT_TRUE(insideImageMargin(intr, 95.0f, 50.0f, 0));
+  EXPECT_TRUE(insideImageMargin(intr, 95.0f, 50.0f, -3));
+  // Boundary is inclusive at exactly `margin` pixels from the border.
+  EXPECT_TRUE(insideImageMargin(intr, 10.0f, 89.0f, 10));
+}
+
+TEST(PointColorizer, ConfirmedRequiresMinimumSamples)
+{
+  PointColor pc;
+  const float grey[3] = {100.0f, 100.0f, 100.0f};
+  EXPECT_FALSE(pc.confirmed(1));
+  pc.add(grey, 5.0f);
+  EXPECT_TRUE(pc.confirmed(1));
+  EXPECT_TRUE(pc.confirmed(0));  // degrades to seen()
+  EXPECT_FALSE(pc.confirmed(3));
+  pc.add(grey, 5.0f);
+  pc.add(grey, 5.0f);
+  EXPECT_TRUE(pc.confirmed(3));
+}
+
 TEST(PointColorizer, NearObservationDominatesFarOne)
 {
   PointColor pc;


### PR DESCRIPTION
## What

Streaming counterparts of PR #363's offline colouring options, applied to the C++ realtime colorization path so live `/colored_map` output matches offline quality:

- `point_colorizer::insideImageMargin()` — skip colour sampling within N px of the border (lens vignette) while the per-frame z-buffer still uses the full frame for occlusion.
- `PointColor::confirmed(n)` — publish a voxel colour only after n accumulated observations (occlusion-fringe / specular pepper suppression); unconfirmed voxels stay grey like unseen geometry.
- `pointcloud_colorization_node` parameters `image_margin` / `min_color_samples`, defaults `0` / `1` keep behaviour identical; documented in `param/colorization.yaml`.

## Validation

- 2 new gtests; `colcon test` scanmatcher: **94 tests, 0 failures**.
- HILTI exp04 recolor A/B (same geometry + views + held-out protocol): 7/12-era colours **49.7** → current colorizer **38.7** → margin 40 **38.1** rgb_l2_median (gate limit ≤ 40); inlier_20 0.276 → 0.336 (limit ≥ 0.3). Artefacts: `public_validation/hilti_exp04_colored_map_recolor_20260718/` (external disk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tRU7h2vZNcBHaFYWmZB5E