### PR TITLE
Add appearance metrics for coloured maps and vignette-aware held-out truth

### DIFF
--- a/docs/research/3dgs-trajectory-flythrough-notes.md
+++ b/docs/research/3dgs-trajectory-flythrough-notes.md
@@ -204,6 +204,13 @@ A/B: Kalibr の camera timeshift (-20.6ms) は depth-edge アライメントで
 RGB L2 はビネット領域を「正解」に含むため margin 適用側が僅かに悪く出る
 (64.5→66.3) が、目視では胡椒ノイズ・黒ずみが明確に減る — この指標は
 ビネット除外の評価には使えない、が学び。
+→ その後 `evaluate_heldout_point_colors.py --image-margin` で正解画素側も
+ビネット帯を除外できるようにしたところ順位は反転し、margin 版が忠実度でも
+勝つ (A 43.5 vs B 40.1 median、inlier_20 0.257→0.296)。「見た目」側は
+`scripts/evaluate_colored_map_appearance.py` (彩度保持率 chroma_retention +
+voxel 内色ラフネス roughness + coverage) が新設され、exp04 の旧着色→
+再着色→margin の視覚順位 (rough_p90 18.5→17.6→12.3、coverage 0.77→1.00)
+を数値で再現する。
 
 レンダは CUDA 不要になった: `render_path.render_frames_cpu` (深度量子化+
 点 ID を int64 に詰めて `np.minimum.at` 一発で可視性と色を同時解決する

--- a/graph_based_slam/test/test_colored_map_appearance.py
+++ b/graph_based_slam/test/test_colored_map_appearance.py
@@ -1,0 +1,141 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for the coloured-map appearance metrics (chroma / roughness)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import numpy as np
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_DIR = REPO_ROOT / 'scripts'
+
+
+def _load():
+    if str(SCRIPT_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPT_DIR))
+    import evaluate_colored_map_appearance
+
+    return evaluate_colored_map_appearance
+
+
+app = _load()
+
+
+def test_channel_range_chroma_grey_is_zero_and_saturated_is_high():
+    rgb = np.array([[100, 100, 100], [255, 0, 0], [10, 20, 30]])
+    chroma = app.channel_range_chroma(rgb)
+    np.testing.assert_allclose(chroma, [0.0, 255.0, 20.0])
+    with pytest.raises(ValueError):
+        app.channel_range_chroma(np.zeros((3, 4)))
+
+
+def test_image_chroma_mixes_mono_and_colour():
+    colour = np.zeros((8, 8, 3), dtype=np.uint8)
+    colour[:, :, 0] = 200  # constant red: channel range 200 everywhere
+    mono = np.full((8, 8), 90, dtype=np.uint8)
+    assert app.image_chroma([colour]) == pytest.approx(200.0)
+    assert app.image_chroma([mono]) == pytest.approx(0.0)
+    assert app.image_chroma([colour, mono]) == pytest.approx(100.0)
+    with pytest.raises(ValueError):
+        app.image_chroma([])
+    with pytest.raises(ValueError):
+        app.image_chroma([colour], pixel_stride=0)
+
+
+def test_roughness_zero_for_uniform_surface():
+    rng = np.random.default_rng(0)
+    xyz = rng.uniform(0.0, 1.0, (500, 3))
+    rgb = np.full((500, 3), 120, dtype=np.uint8)
+    result = app.voxel_color_roughness(xyz, rgb, voxel=0.25)
+    assert result['voxels_scored'] > 0
+    assert result['roughness_median'] == pytest.approx(0.0)
+
+
+def test_roughness_detects_pepper_noise():
+    rng = np.random.default_rng(1)
+    xyz = rng.uniform(0.0, 1.0, (2000, 3))
+    clean = np.full((2000, 3), 120, dtype=np.uint8)
+    peppered = clean.copy()
+    idx = rng.choice(2000, 200, replace=False)
+    peppered[idx] = rng.integers(0, 255, (200, 3))
+    quiet = app.voxel_color_roughness(xyz, clean, voxel=0.25)
+    noisy = app.voxel_color_roughness(xyz, peppered, voxel=0.25)
+    assert noisy['roughness_p90'] > quiet['roughness_p90'] + 10.0
+
+
+def test_roughness_low_for_organised_texture_gradient():
+    # A smooth colour gradient across the cloud is texture, not pepper:
+    # within a small voxel the colours barely differ.
+    n = 4000
+    rng = np.random.default_rng(2)
+    xyz = rng.uniform(0.0, 4.0, (n, 3))
+    rgb = np.clip(xyz[:, :1] * 60.0, 0, 255).astype(np.uint8).repeat(3, axis=1)
+    result = app.voxel_color_roughness(xyz, rgb, voxel=0.1)
+    assert result['roughness_median'] is not None
+    assert result['roughness_median'] < 5.0
+
+
+def test_roughness_validation_and_empty():
+    with pytest.raises(ValueError):
+        app.voxel_color_roughness(np.zeros((1, 3)), np.zeros((1, 3)), voxel=0.0)
+    with pytest.raises(ValueError):
+        app.voxel_color_roughness(np.zeros((1, 3)), np.zeros((1, 3)),
+                                  min_points=1)
+    with pytest.raises(ValueError):
+        app.voxel_color_roughness(np.zeros((2, 3)), np.zeros((3, 3)))
+    empty = app.voxel_color_roughness(np.zeros((0, 3)), np.zeros((0, 3)))
+    assert empty['voxels_scored'] == 0
+    assert empty['roughness_median'] is None
+
+
+def test_evaluate_reports_coverage_and_retention():
+    xyz = np.array([[0.0, 0.0, 0.0], [0.05, 0.0, 0.0], [5.0, 5.0, 5.0]])
+    rgb = np.array([[200, 40, 40], [200, 40, 40], [128, 128, 128]],
+                   dtype=np.uint8)  # third point carries the unseen default
+    colour_img = np.zeros((8, 8, 3), dtype=np.uint8)
+    colour_img[:, :, 0] = 160
+    report = app.evaluate(xyz, rgb, images=[colour_img])
+    assert report['points'] == 3
+    assert report['colored'] == 2
+    assert report['coverage'] == pytest.approx(2.0 / 3.0)
+    assert report['chroma_mean'] == pytest.approx(160.0)
+    assert report['chroma_retention'] == pytest.approx(1.0)
+
+
+def test_evaluate_mono_images_disable_retention():
+    xyz = np.zeros((2, 3))
+    rgb = np.array([[10, 10, 10], [20, 20, 20]], dtype=np.uint8)
+    mono = np.full((8, 8), 90, dtype=np.uint8)
+    report = app.evaluate(xyz, rgb, images=[mono])
+    assert report['chroma_retention'] is None

--- a/scripts/evaluate_colored_map_appearance.py
+++ b/scripts/evaluate_colored_map_appearance.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Score how a coloured map *looks*: washout, pepper noise, and coverage.
+
+The held-out reprojection error (``evaluate_heldout_point_colors.py``)
+measures fidelity to individual camera views, but it misses the two defects
+that dominate perceived quality: multi-view averaging that washes chroma out
+of the whole map, and isolated wrong-colour points ("pepper") sprinkled over
+smooth surfaces. This report measures both directly on the map:
+
+- ``chroma``: mean per-point RGB channel range of the coloured points, and,
+  when posed source images are given, ``chroma_retention`` — map chroma over
+  source-image chroma. Washed-out averaging drives retention well below 1.
+- ``roughness``: per-voxel colour standard deviation among the coloured
+  points that share a voxel (median / p90 across voxels). Real texture is
+  organised across voxels; pepper noise raises the *within*-voxel spread.
+- ``coverage``: the coloured fraction, so the two scores above cannot be
+  gamed by discarding points.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TOOL_DIR = REPO_ROOT / 'tools' / 'gaussian_splatting'
+if str(TOOL_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOL_DIR))
+
+import pointcloud_io as pcio  # noqa: E402
+
+
+def channel_range_chroma(rgb: np.ndarray) -> np.ndarray:
+    """Per-point chroma as the max-min spread across RGB channels."""
+    values = np.asarray(rgb)
+    if values.ndim != 2 or values.shape[1] != 3:
+        raise ValueError(f'rgb must be Nx3, got {values.shape}')
+    return np.ptp(values.astype(np.int16), axis=1).astype(np.float64)
+
+
+def image_chroma(images, pixel_stride: int = 4) -> float:
+    """Mean channel-range chroma over the sampled pixels of all images.
+
+    Mono images (2-D or single-channel) contribute zero chroma, matching how
+    they colour a map. ``pixel_stride`` subsamples rows and columns.
+    """
+    if pixel_stride < 1:
+        raise ValueError('pixel_stride must be >= 1')
+    totals = []
+    for image in images:
+        arr = np.asarray(image)
+        sub = arr[::pixel_stride, ::pixel_stride]
+        if sub.ndim == 2 or sub.shape[2] < 3:
+            totals.append(0.0)
+            continue
+        totals.append(float(np.mean(np.ptp(
+            sub[:, :, :3].astype(np.int16), axis=2))))
+    if not totals:
+        raise ValueError('no images given')
+    return float(np.mean(totals))
+
+
+def voxel_color_roughness(xyz: np.ndarray, rgb: np.ndarray,
+                          voxel: float = 0.08, min_points: int = 3) -> dict:
+    """Within-voxel colour spread of a coloured cloud.
+
+    Groups points into a ``voxel``-sized grid and, for every voxel holding at
+    least ``min_points`` points, computes the per-channel standard deviation
+    of its colours averaged over channels. Smooth, correctly coloured
+    surfaces score low even when the map as a whole is colourful; occlusion
+    fringes and specular one-offs ("pepper") raise the within-voxel spread.
+    Returns median and p90 across voxels plus the voxel count.
+    """
+    if voxel <= 0.0:
+        raise ValueError('voxel must be positive')
+    if min_points < 2:
+        raise ValueError('min_points must be >= 2')
+    pts = np.asarray(xyz, dtype=np.float64)
+    cols = np.asarray(rgb, dtype=np.float64)
+    if len(pts) != len(cols):
+        raise ValueError('xyz and rgb must have equal length')
+    empty = {'voxels_scored': 0, 'roughness_median': None, 'roughness_p90': None}
+    if len(pts) == 0:
+        return empty
+    keys = np.floor(pts / voxel).astype(np.int64)
+    _, inverse, counts = np.unique(keys, axis=0, return_inverse=True,
+                                   return_counts=True)
+    order = np.argsort(inverse, kind='stable')
+    grouped = cols[order]
+    boundaries = np.concatenate(([0], np.cumsum(counts)[:-1]))
+    sums = np.add.reduceat(grouped, boundaries, axis=0)
+    sq_sums = np.add.reduceat(grouped ** 2, boundaries, axis=0)
+    n = counts.astype(np.float64)[:, None]
+    variance = np.maximum(sq_sums / n - (sums / n) ** 2, 0.0)
+    stds = np.sqrt(variance).mean(axis=1)
+    scored = stds[counts >= min_points]
+    if scored.size == 0:
+        return empty
+    return {
+        'voxels_scored': int(scored.size),
+        'roughness_median': float(np.median(scored)),
+        'roughness_p90': float(np.percentile(scored, 90)),
+    }
+
+
+def evaluate(xyz: np.ndarray, rgb: np.ndarray, *,
+             default_rgb=(128, 128, 128), voxel: float = 0.08,
+             images=None, pixel_stride: int = 4) -> dict:
+    """Assemble the appearance report for one coloured cloud."""
+    default = np.asarray(default_rgb, dtype=np.uint8)
+    seen = np.any(np.asarray(rgb) != default[None, :], axis=1)
+    coloured = np.asarray(rgb)[seen]
+    chroma = channel_range_chroma(coloured) if len(coloured) else np.zeros(0)
+    report = {
+        'points': int(len(xyz)),
+        'colored': int(seen.sum()),
+        'coverage': float(seen.mean()) if len(seen) else 0.0,
+        'chroma_mean': float(chroma.mean()) if chroma.size else 0.0,
+        'chroma_p50': float(np.median(chroma)) if chroma.size else 0.0,
+        'roughness': voxel_color_roughness(
+            np.asarray(xyz)[seen], coloured, voxel=voxel),
+        'voxel': voxel,
+    }
+    if images is not None:
+        source = image_chroma(images, pixel_stride)
+        report['image_chroma_mean'] = source
+        report['chroma_retention'] = (
+            float(report['chroma_mean'] / source) if source >= 2.0 else None)
+    return report
+
+
+def main() -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0])
+    parser.add_argument('--pointcloud', type=Path, required=True)
+    parser.add_argument('--out', type=Path, required=True)
+    parser.add_argument('--transforms', type=Path, default=None,
+                        help='posed_images transforms.json; enables '
+                             'chroma_retention against the source images')
+    parser.add_argument('--voxel', type=float, default=0.08,
+                        help='roughness grouping voxel size (m)')
+    parser.add_argument('--view-stride', type=int, default=5,
+                        help='sample every Nth source image for image chroma')
+    parser.add_argument('--default-rgb', type=int, nargs=3,
+                        default=(128, 128, 128))
+    args = parser.parse_args()
+    if args.view_stride < 1:
+        raise SystemExit('--view-stride must be >= 1')
+
+    xyz, rgb = pcio.read_ply_xyz(args.pointcloud)
+    if rgb is None:
+        raise SystemExit('point cloud has no RGB colours')
+    images = None
+    if args.transforms is not None:
+        import imageio.v3 as iio
+        import train_gsplat as tg
+        dataset = tg.load_transforms(args.transforms)
+        images = [np.asarray(iio.imread(path))
+                  for path in dataset['image_paths'][::args.view_stride]]
+    report = evaluate(xyz, rgb, default_rgb=tuple(args.default_rgb),
+                      voxel=args.voxel, images=images)
+    report['pointcloud'] = str(args.pointcloud.resolve())
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(report, indent=2) + '\n')
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/evaluate_heldout_point_colors.py
+++ b/scripts/evaluate_heldout_point_colors.py
@@ -91,12 +91,22 @@ def exposure_scales(images: list[np.ndarray], limit: float = 1.5) -> np.ndarray:
 
 def score_heldout_view(points: np.ndarray, colors: np.ndarray, seen: np.ndarray,
                        viewmat: np.ndarray, K: np.ndarray, image: np.ndarray,
-                       exposure_scale: float = 1.0) -> tuple[np.ndarray, int]:
-    """Return per-visible-point RGB Euclidean errors and visible count."""
+                       exposure_scale: float = 1.0,
+                       image_margin: int = 0) -> tuple[np.ndarray, int]:
+    """Return per-visible-point RGB Euclidean errors and visible count.
+
+    ``image_margin`` excludes reference pixels within that many pixels of the
+    image border: lens vignetting darkens the border band, so treating those
+    pixels as colour ground truth penalises maps that (correctly) took their
+    colour from views that saw the surface centrally.
+    """
     height, width = image.shape[:2]
     ids, uf, vf = visible_point_samples(points, viewmat, K, width, height)
     visible_count = int(ids.size)
     keep = seen[ids]
+    if image_margin > 0:
+        keep &= ((uf >= image_margin) & (uf < width - image_margin) &
+                 (vf >= image_margin) & (vf < height - image_margin))
     ids, uf, vf = ids[keep], uf[keep], vf[keep]
     if ids.size == 0:
         return np.zeros(0, dtype=np.float32), visible_count
@@ -122,6 +132,9 @@ def main() -> int:
                         help='compare raw camera RGB without per-view exposure gains')
     parser.add_argument('--exposure-scale-limit', type=float, default=1.5,
                         help='maximum exposure gain and reciprocal loss')
+    parser.add_argument('--image-margin', type=int, default=0,
+                        help='ignore reference pixels within this many pixels '
+                             'of the border (lens vignette; 0 keeps all)')
     args = parser.parse_args()
     if args.folds < 2 or not 0 <= args.holdout_fold < args.folds:
         raise SystemExit('--folds must be >= 2 and --holdout-fold must be valid')
@@ -157,7 +170,7 @@ def main() -> int:
     for index in holdout[::args.view_stride]:
         values, visible = score_heldout_view(
             points, colors, seen, viewmats[index], K,
-            images[index], float(scales[index]))
+            images[index], float(scales[index]), args.image_margin)
         errors.append(values)
         visible_total += visible
         per_view.append({'view_index': index, 'visible_points': visible,
@@ -173,6 +186,7 @@ def main() -> int:
         'color_source': ('pointcloud' if args.use_pointcloud_colors else 'train'),
         'normalize_exposure': args.normalize_exposure,
         'exposure_scale_limit': args.exposure_scale_limit,
+        'image_margin': args.image_margin,
         'visible_points': visible_total, 'scored_points': int(combined.size),
         'training_coverage': float(seen.mean()),
         'heldout_scored_fraction': float(combined.size / visible_total),


### PR DESCRIPTION
## Why

「着色の綺麗さ」を測る指標が無かった。既存の held-out RGB L2 は (a) ビネットで暗くなった縁の画素を正解として数える、(b) 多視点平均による彩度落ち(白カブリ)を罰しない、(c) 平面上の孤立誤色(胡椒ノイズ)を平均に埋もれさせる — 今回の A/B で目視順位と乖離することが実測で判明していた。

## What

- **`scripts/evaluate_colored_map_appearance.py`** (new): 見た目の3指標
  - `chroma_mean` / `chroma_retention` — マップの彩度 ÷ ソース画像の彩度。washout で 1 を大きく割る(モノクロ画像では null)
  - `roughness` — voxel 内の色標準偏差の median/p90。組織化されたテクスチャは voxel を跨いで変化するので低く、胡椒ノイズは voxel 内分散を上げる
  - `coverage` — 点を捨てて上2指標を稼ぐのを防ぐ
- **`evaluate_heldout_point_colors.py --image-margin`**: 正解画素側でもビネット帯を除外

## Validation(既存 A/B 成果物で視覚順位を再現するか)

| exp04 variant | coverage | rough_p90 |
|---|---:|---:|
| 7/12 着色 | 0.768 | 18.5 |
| 再着色(現行コード) | 0.999 | 17.6 |
| + margin 40 | 0.998 | **12.3** |

RTK-SLAM: 非マスク held-out は margin なしを優位(40.8 vs 42.7)としていたが、ビネット除外 truth では**順位が反転**(43.5 vs 40.1、inlier_20 0.257→0.296)— 目視判断と一致。

## Tests

8 new tests (chroma / roughness / evaluate report); flake8 (ament config) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tRU7h2vZNcBHaFYWmZB5E