### PR TITLE
Gate coloured maps on appearance metrics

### DIFF
--- a/configs/colored_map_quality_profiles/hilti_exp04_report_only.yaml
+++ b/configs/colored_map_quality_profiles/hilti_exp04_report_only.yaml
@@ -11,3 +11,12 @@ colored_map_quality_profile:
     heldout_rgb_median_max: 40.0
     heldout_rgb_inlier_20_min: 0.30
     heldout_scored_fraction_min: 0.95
+    # Appearance battery (2026-07-18). Calibrated on the exp04 recolor A/B
+    # (public_validation/hilti_exp04_colored_map_recolor_20260718): the
+    # 7/12-era colours score coverage 0.768 / rough_median 2.83 /
+    # rough_p90 18.5 (all three violate), the current colorizer + margin 40
+    # scores 0.998 / 2.05 / 12.3. No appearance_chroma_retention_min on
+    # this rig: the alphasense views are mono, so retention is null.
+    appearance_coverage_min: 0.95
+    appearance_roughness_median_max: 2.5
+    appearance_roughness_p90_max: 15.0

--- a/graph_based_slam/test/test_colored_map_pipeline.py
+++ b/graph_based_slam/test/test_colored_map_pipeline.py
@@ -286,8 +286,9 @@ def test_quality_profile_adds_two_evaluators_and_gate(tmp_path):
         '--trajectory-report', str(tmp_path / 'metrics.json'),
         '--geometry-report', str(tmp_path / 'map_quality_report.yaml'))
     commands = cmp.build_commands(args)
-    assert [name for name, _ in commands][-3:] == [
-        'camera-LiDAR alignment', 'held-out colour', 'quality gate']
+    assert [name for name, _ in commands][-4:] == [
+        'camera-LiDAR alignment', 'held-out colour', 'appearance',
+        'quality gate']
     gate = commands[-1][1]
     assert gate[gate.index('--trajectory-report') + 1] == str(
         tmp_path / 'metrics.json')
@@ -320,3 +321,20 @@ def test_vignette_and_confidence_defaults_are_off(tmp_path):
     build = cmp.build_commands(_args(tmp_path))[1][1]
     assert build[build.index('--color-image-margin') + 1] == '0'
     assert build[build.index('--color-min-samples') + 1] == '1'
+
+
+def test_quality_profile_adds_appearance_stage_and_gate_wiring(tmp_path):
+    for name in ('profile.yaml', 'traj_report.json', 'geom_report.yaml'):
+        (tmp_path / name).write_text('{}')
+    commands = cmp.build_commands(_args(
+        tmp_path, '--quality-profile', str(tmp_path / 'profile.yaml'),
+        '--trajectory-report', str(tmp_path / 'traj_report.json'),
+        '--geometry-report', str(tmp_path / 'geom_report.yaml')))
+    names = [name for name, _ in commands]
+    assert 'appearance' in names
+    appearance = dict(commands)['appearance']
+    assert appearance[appearance.index('--out') + 1].endswith(
+        'colored_map_appearance.json')
+    gate_cmd = dict(commands)['quality gate']
+    assert gate_cmd[gate_cmd.index('--appearance-report') + 1].endswith(
+        'colored_map_appearance.json')

--- a/graph_based_slam/test/test_colored_map_quality_gate.py
+++ b/graph_based_slam/test/test_colored_map_quality_gate.py
@@ -51,6 +51,9 @@ def _reports():
                       'weighted_inlier_2px': 0.26},
         'colour': {'rgb_l2_median': 36.4, 'rgb_l2_inlier_20': 0.35,
                    'heldout_scored_fraction': 0.999},
+        'appearance': {'coverage': 0.998, 'chroma_retention': 1.01,
+                       'roughness': {'roughness_median': 2.05,
+                                     'roughness_p90': 12.3}},
     }
 
 
@@ -94,3 +97,29 @@ def test_missing_metric_is_actionable():
     del reports['alignment']['weighted_median_px']
     with pytest.raises(gate.QualityGateError, match='weighted_median_px'):
         gate.evaluate(reports, _profile())
+
+
+def test_appearance_domain_gates_pepper_and_coverage():
+    profile = {'colored_map_quality_profile': {
+        'name': 'test', 'enforcement': 'blocking', 'thresholds': {
+            'appearance_coverage_min': 0.95,
+            'appearance_roughness_median_max': 2.5,
+            'appearance_roughness_p90_max': 15.0,
+            'appearance_chroma_retention_min': 0.9}}}
+    result = gate.evaluate(_reports(), profile)
+    assert result['overall'] == 'OK'
+    peppered = _reports()
+    peppered['appearance']['roughness']['roughness_p90'] = 18.5
+    peppered['appearance']['coverage'] = 0.768
+    result = gate.evaluate(peppered, profile)
+    assert result['violations'] == 2
+
+
+def test_appearance_threshold_without_report_is_actionable():
+    reports = _reports()
+    del reports['appearance']
+    profile = {'colored_map_quality_profile': {
+        'name': 'test', 'enforcement': 'report_only', 'thresholds': {
+            'appearance_coverage_min': 0.95}}}
+    with pytest.raises(gate.QualityGateError, match='appearance-report'):
+        gate.evaluate(reports, profile)

--- a/scripts/check_colored_map_quality.py
+++ b/scripts/check_colored_map_quality.py
@@ -59,6 +59,14 @@ METRICS = {
         'colour', ('rgb_l2_inlier_20',), 'min'),
     'heldout_scored_fraction_min': (
         'colour', ('heldout_scored_fraction',), 'min'),
+    'appearance_coverage_min': (
+        'appearance', ('coverage',), 'min'),
+    'appearance_roughness_median_max': (
+        'appearance', ('roughness', 'roughness_median'), 'max'),
+    'appearance_roughness_p90_max': (
+        'appearance', ('roughness', 'roughness_p90'), 'max'),
+    'appearance_chroma_retention_min': (
+        'appearance', ('chroma_retention',), 'min'),
 }
 
 
@@ -117,6 +125,9 @@ def evaluate(reports: dict[str, dict[str, Any]],
         if isinstance(limit_value, bool) or not isinstance(limit_value, (int, float)):
             raise QualityGateError(f'threshold {key} must be numeric')
         report_name, metric_path, comparison = METRICS[key]
+        if report_name not in reports:
+            raise QualityGateError(
+                f'threshold {key} needs --{report_name}-report')
         value = nested_number(reports[report_name], metric_path)
         limit = float(limit_value)
         passed = value <= limit if comparison == 'max' else value >= limit
@@ -139,6 +150,10 @@ def main() -> int:
     parser.add_argument('--geometry-report', type=Path, required=True)
     parser.add_argument('--alignment-report', type=Path, required=True)
     parser.add_argument('--colour-report', type=Path, required=True)
+    parser.add_argument('--appearance-report', type=Path, default=None,
+                        help='evaluate_colored_map_appearance.py output; '
+                             'required when the profile sets appearance_* '
+                             'thresholds')
     parser.add_argument('--profile', type=Path, required=True)
     parser.add_argument('--out', type=Path, required=True)
     args = parser.parse_args()
@@ -149,6 +164,8 @@ def main() -> int:
             'alignment': load_mapping(args.alignment_report),
             'colour': load_mapping(args.colour_report),
         }
+        if args.appearance_report is not None:
+            reports['appearance'] = load_mapping(args.appearance_report)
         result = evaluate(reports, load_mapping(args.profile))
     except QualityGateError as exc:
         parser.error(str(exc))

--- a/tools/gaussian_splatting/COLORING_HANDOFF.md
+++ b/tools/gaussian_splatting/COLORING_HANDOFF.md
@@ -1,0 +1,172 @@
+# 点群着色 品質改善 引き継ぎ (2026-07-18)
+
+BIM 枝の `BIM_HANDOFF.md` と同じ趣旨の引き継ぎ文書。README の
+camera-coloured flythrough の色が濁っていた問題を起点に、着色パイプライン・
+リアルタイムノード・評価系を一気に改善した一連の作業(lidar_slam_ros2
+PR #363/#364/#365/#366、全て develop に merge 済み)の現状・API・ハマり所・
+再現手順・次の候補をまとめる。
+
+## 1. 何が問題で、何を入れたか
+
+README の RTK-SLAM flythrough (`lidarslam/images/map_flythrough_rtkslam.webp`)
+の着色が「白カブリ + 色滲み + 胡椒ノイズ」だった。原因は3つ:
+
+1. **アセットが着色改善前のコードで生成されていた** — 2026-07-12 20:33 生成の
+   直後に edge-aware 補間 (#348) / 観測色 medoid (#347) / 露出ゲインクランプ
+   (#349) が merge され、README には未反映のままだった。
+2. **レンズビネット** — RTK-SLAM cam0 (1600x1200) は四隅が完全に黒く落ちる。
+   縁の暗い/黒いピクセルがそのまま点に投影されていた。
+3. **Livox `offset_time` 未対応** — `build_lidar_init.py` のデスキュー対象
+   フィールド名に無く、mid360 bag は黙って剛体スキャン扱い
+   (歩行 ~1 m/s で最大 ~10 cm のスキャン内スミア)。
+
+入れたもの(全て default-off / default 値で既存挙動バイト同一):
+
+| 機能 | 場所 | PR |
+|---|---|---|
+| `image_margin`(色サンプルのビネット帯除外) | `pointcloud_io.colorize_by_projection_robust` + `--color-image-margin` | #363 |
+| `min_samples`(低観測数の色を unseen に降格) | `build_lidar_init._colorize` + `--color-min-samples` | #363 |
+| `offset_time` (整数 ns) デスキュー | `build_lidar_init._read_pointcloud_xyz_time` | #363 |
+| CPU レンダラ(CUDA/torch 不要) | `render_path.render_frames_cpu` + `--device cpu` | #363 |
+| 上記2オプションの realtime 移植 | `scanmatcher/include/scanmatcher/point_colorizer.hpp`(`insideImageMargin` / `PointColor::confirmed`)+ node param `image_margin` / `min_color_samples` | #364 |
+| 見た目指標(appearance) | `scripts/evaluate_colored_map_appearance.py` | #365 |
+| held-out のビネット除外 truth | `evaluate_heldout_point_colors.py --image-margin` | #365 |
+| appearance のゲート組込み | `check_colored_map_quality.py` `appearance_*` 閾値 + pipeline `appearance` ステージ + exp04 プロファイル | #366 |
+
+## 2. 設計上の要点(触る前に知るべき不変条件)
+
+- **margin の意味論**: z バッファ(遮蔽判定)は**フルフレームのまま**。
+  margin は「色サンプルの採否」だけを絞る。縁でしか見えない点は
+  他ビューの中央から色を得る。offline (`colorize_by_projection_robust`) と
+  realtime (`insideImageMargin`) で同一の意味論に揃えてある — 崩さないこと。
+- **min_samples は「降格」**: 色を書き換えるのではなく default_rgb (128,128,128)
+  に戻して unseen 扱いにする。`render_map_flythrough --color-mode rgb` は
+  unseen を drop する、という既存の流れに乗せている。
+- **決定論**: これらのオプションは default(0/1)で従来とバイト同一。
+  リポジトリの流儀として default-off を守る。
+- **この ICP/描画系に GPU は無い**(マシン sasaki-pc は Iris Xe、torch 無し)。
+  `render_frames(device='cpu')` が `render_frames_cpu` にディスパッチする。
+  仕組み: 量子化深度と点 ID を int64 にパック → `np.minimum.at` 一発で
+  ピクセル毎の可視性と勝者 ID を同時解決 → 2x supersample を box 縮小。
+  ~0.7 s/frame @600x450, 4.8M 点。gsplat の soft splat と違い不透明ディスク。
+
+## 3. 評価プロトコル(これで測ること)
+
+**3点セット**で評価する。単独指標は騙される:
+
+1. **忠実度**: `evaluate_heldout_point_colors.py --use-pointcloud-colors
+   --image-margin <px>`。**非マスク版はビネット画素を正解として数えるため
+   margin 付き着色を誤って劣位判定する**(RTK 実測: 非マスク 40.8 vs 42.7 で
+   margin なし優位 → マスク版 43.5 vs 40.1 で反転、inlier_20 0.257→0.296)。
+2. **見た目**: `evaluate_colored_map_appearance.py` —
+   `chroma_retention`(マップ彩度÷画像彩度; washout で <1、モノクロ画像は null)、
+   `roughness`(voxel 内色標準偏差 median/p90; 組織化テクスチャは低く
+   胡椒ノイズは高い)、`coverage`(点を捨てるチート防止)。
+   exp04 で視覚順位を再現済み: 旧着色→再着色→+margin で
+   rough_p90 18.5→17.6→12.3、coverage 0.768→0.999。
+3. **目視**: `render_map_flythrough.py --test-grid 4 --device cpu` の
+   同一視点グリッド比較。
+
+ゲート: `check_colored_map_quality.py --appearance-report ...`。
+`configs/colored_map_quality_profiles/hilti_exp04_report_only.yaml` に
+report-only の較正済み閾値あり(coverage≥0.95 / rough_med≤2.5 / rough_p90≤15。
+旧着色は3つとも violation、現行+margin は余裕 PASS)。
+
+## 4. 採用構成(README アセットの正)
+
+RTK-SLAM construction_seq1、窓 480–545 s(60 m 歩行ループ)、RKO-LIO 軌跡:
+
+```bash
+# 1) 軌跡 (CS2 実績の rko_params.ros.yaml を流用、deskew:false / dual_downsample)
+timeout -s INT 1800 ros2 run rko_lio offline_node --ros-args \
+  --params-file rko_params.ros.yaml -p bag_path:=<construction_seq1> \
+  -p imu_topic:=/livox/imu -p lidar_topic:=/livox/points -p base_frame:=base_link \
+  -p dump_results:=true -p results_dir:=<out> -p run_name:=seq1_rko
+# 2) posed images (time-offset 0 で良い; Kalibr -20.6ms は有意差なしを実測済み)
+python3 tools/gaussian_splatting/extract_posed_images.py \
+  --bag <bag> --traj <tum> --camera-topic /camera/image_raw/compressed \
+  --intrinsics-yaml configs/gaussian_splatting/rtk_slam_cam0_intrinsics.yaml \
+  --extrinsic configs/gaussian_splatting/rtk_slam_cam0_extrinsic.yaml \
+  --undistort --time-offset 0 --start-time 480 --end-time 545 --stride 5 \
+  --max-extrapolation 0.2 --out <out>/posed
+# 3) 着色点群 (採用パラメータ)
+python3 tools/gaussian_splatting/build_lidar_init.py \
+  --bag <bag> --traj <tum> --points-topic /livox/points \
+  --start-time 480 --end-time 545 --voxel 0.015 --min-range 1.5 --max-range 60 \
+  --max-points 5000000 --min-neighbors 8 --sparse-voxel 0.1 \
+  --color-transforms <out>/posed/transforms.json --color-robust \
+  --color-image-margin 140 --color-min-samples 3 --out colored.ply
+# 4) レンダ + README アセット
+python3 tools/gaussian_splatting/render_map_flythrough.py \
+  --pointcloud colored.ply --transforms <out>/posed/transforms.json \
+  --color-mode rgb --frames 240 --fps 30 --point-size 0.02 --scale 0.375 \
+  --loop-fade 12 --device cpu --mp4 master.mp4
+ffmpeg -i master.mp4 -vf "fps=15,scale=600:-2:flags=lanczos" -loop 0 \
+  -c:v libwebp -quality 78 map_flythrough_rtkslam.webp   # + crf26 mp4 / palette gif
+```
+
+## 5. データ・成果物の所在
+
+- **RTK-SLAM bag**: `/media/sasaki/aiueo/datasets/rtk_slam/ros2/construction_seq1`
+  (13,180,936,192 bytes)。**注意**: 一度 8.0/13.2 GB で切断破損していた
+  ("database disk image is malformed")。`wget -c` (`scripts/download_rtk_slam_dataset.py`
+  の URL) で再開修復できる。**使う前にサイズを SEQUENCES の期待値と照合**。
+- **今回の RTK 成果物一式**:
+  `/media/sasaki/aiueo/benchmarks/rtkslam_seq1_colored_map_20260718/`
+  (RKO-LIO TUM 軌跡 `results/seq1_rko_0/`、posed_t0(260 views)、
+  colored_{A,B,D}.ply(A=margin なし/B=margin140/D=採用構成)、
+  heldout/app/align の各 json、flythrough_master.mp4、新旧比較 PNG)。
+  D が README アセットの元。
+- **exp04 検証一式**:
+  `/media/sasaki/aiueo/datasets/public_validation/hilti_exp04_colored_map_recolor_20260718/`
+  (README.md に A/B 表、旧着色との比較 ply、heldout/app json)。
+- README アセット: `lidarslam/images/map_flythrough_rtkslam.{webp,mp4,gif}`。
+- 経緯の一次資料: `docs/research/3dgs-trajectory-flythrough-notes.md` 追補3、
+  `docs/3dgs-map-tutorial.md` の成果物例(再現コマンド)。
+
+## 6. ハマり所(実際に踏んだもの)
+
+- **非マスク held-out を信じない**(§3)。ビネット除外の効果測定には
+  `--image-margin` を正解側にも付けるか appearance 指標を使う。
+- **colcon の同名パッケージ衝突**: ws に `lidar_slam_ros2` と
+  `lidar_slam_ros2_candidate2` が並存し scanmatcher が重複。
+  ビルドは **ws ルートから** `source install/setup.bash` 後に
+  `colcon build --base-paths lidar_slam_ros2_candidate2 --packages-select scanmatcher`。
+  ws の `build/scanmatcher` キャッシュが旧 repo 由来だと
+  "does not match the source ... used to generate cache" で落ちる → 消して再生成。
+- **offline_node は bag 終端でハング**(仕様)→ `timeout -s INT`。
+- **`point_colorizer.hpp` は純ヘッダ** — g++ 単体
+  (`g++ -std=c++17 -I scanmatcher/include -I /usr/include/eigen3 ... -lgtest`)
+  で colcon なしに即テストできる。
+- **posed images のファイル名は `00000.png` 形式**(`frame_XXXXX.png` ではない)。
+- **appearance の chroma_retention はモノクロ画像で null** — プロファイルに
+  閾値を書くなら色付きリグのみ。
+- **exp04 の posed images はグレースケール**(alphasense)。色の議論には
+  RTK-SLAM か AIST bag (`/media/sasaki/aiueo/benchmarks/aist_rgb_map/`) を使う。
+
+## 7. 次の候補(未着手、優先度順の私見)
+
+1. **RTK-SLAM 用 colored_map_quality プロファイル**: 色付きリグなので
+   `appearance_chroma_retention_min`(~0.9)を初めて有効化できる。
+   `benchmarks/rtkslam_seq1_colored_map_20260718/` の json がそのまま較正データ。
+2. **ビネットの推定補正**: margin は「捨てる」対策(着色数 -8%)。多数ビューの
+   輝度中央値 vs 画像半径から radial gain を推定して「直す」方式なら
+   coverage を犠牲にせず縁まで使える。`_sample_pixels` の手前に挟むのが自然。
+3. **roughness の平面限定版**: 現行は全 voxel。`project_planar_voxels` で
+   平面 voxel に限定すればテクスチャ境界の偽陽性が減り、閾値をさらに絞れる。
+4. **CPU レンダラの soft 化**: 不透明ディスクゆえ未マップ領域の黒い隙間が
+   gsplat よりも目立つ。supersample 3 化 or 半径依存の soft edge。
+5. **リアルタイムノードの実 bag 検証**: #364 は unit test + build まで。
+   all-sensors-bag1(`/home/sasaki/autoware_data/all-sensors-bag1`、
+   lucid camera_0=camera_top/camera_optical_link、QoS は SensorDataQoS 対応済み)
+   で live A/B するとよい。
+6. **エクスポート枝への波及**: mesh/LAS/GIS(`mesh_export.py` 等)は改善前の
+   色で検証されたまま。D 構成の ply で再検証すると数値が上がるはず。
+
+## 8. 関連 PR / 経緯リンク
+
+- #345/#346–#349: 旧アセット生成と直後の colorizer 改善(すれ違いの原因)
+- #363: 着色品質改善 + README アセット再生成(比較画像は PR 参照)
+- #364: realtime 移植 + exp04 検証
+- #365: appearance 指標 + masked held-out
+- #366: appearance のゲート組込み(本文書を含む)

--- a/tools/gaussian_splatting/colored_map_pipeline.py
+++ b/tools/gaussian_splatting/colored_map_pipeline.py
@@ -194,6 +194,7 @@ def build_commands(args) -> list[tuple[str, list[str]]]:
     if args.quality_profile is not None:
         alignment_report = out_dir / 'lidar_camera_alignment.json'
         colour_report = out_dir / 'heldout_point_colors.json'
+        appearance_report = out_dir / 'colored_map_appearance.json'
         quality_report = out_dir / 'colored_map_quality_gate.json'
         rebuild_map = any(name == 'coloured map' for name, _ in commands)
         rebuild_images = any(name == 'posed images' for name, _ in commands)
@@ -216,11 +217,22 @@ def build_commands(args) -> list[tuple[str, list[str]]]:
                 '--transforms', str(transforms),
                 '--out', str(colour_report),
             ]))
+        if (rebuild_map or rebuild_images or args.force_quality or
+                is_stale(appearance_report, [colored_map, transforms])):
+            commands.append(('appearance', [
+                sys.executable,
+                str(REPO_ROOT / 'scripts' /
+                    'evaluate_colored_map_appearance.py'),
+                '--pointcloud', str(colored_map),
+                '--transforms', str(transforms),
+                '--out', str(appearance_report),
+            ]))
         gate_inputs = [Path(args.trajectory_report), Path(args.geometry_report),
-                       alignment_report, colour_report,
+                       alignment_report, colour_report, appearance_report,
                        Path(args.quality_profile)]
         if (args.force_quality or
-                any(name in ('camera-LiDAR alignment', 'held-out colour')
+                any(name in ('camera-LiDAR alignment', 'held-out colour',
+                             'appearance')
                     for name, _ in commands) or
                 is_stale(quality_report, gate_inputs)):
             commands.append(('quality gate', [
@@ -230,6 +242,7 @@ def build_commands(args) -> list[tuple[str, list[str]]]:
                 '--geometry-report', str(args.geometry_report),
                 '--alignment-report', str(alignment_report),
                 '--colour-report', str(colour_report),
+                '--appearance-report', str(appearance_report),
                 '--profile', str(args.quality_profile),
                 '--out', str(quality_report),
             ]))


### PR DESCRIPTION
## What

PR #365 の appearance 指標(彩度保持・voxel 内色ラフネス・coverage)を品質ゲートに組み込む:

- `check_colored_map_quality.py` に `appearance_*` 閾値4種と optional `--appearance-report` を追加(閾値があるのにレポートが無い場合は actionable error)
- `colored_map_pipeline.py --quality-profile` 実行時に `appearance` ステージが自動で走り、ゲートに配線される
- `hilti_exp04_report_only.yaml` に report-only の閾値を追加(exp04 recolor A/B で較正: 旧着色は coverage 0.768 / rough_median 2.83 / rough_p90 18.5 で3項目とも violation、現行着色+margin は 0.998 / 2.05 / 12.3 で余裕 PASS)。モノクロリグのため chroma_retention は未設定

## Validation

実 exp04 成果物での E2E: 再着色マップ **0 violations**、7/12 時代の着色 **3 appearance violations** — 見た目の劣化がゲートで検出可能に。

## Tests

新規3件を含む関連スイート 46 passed、ament flake8 clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tRU7h2vZNcBHaFYWmZB5E