### PR TITLE
Refactor Graph SLAM configuration and composition root

### DIFF
--- a/docs/degeneracy-guide.md
+++ b/docs/degeneracy-guide.md
@@ -2,7 +2,7 @@
 
 RKO-LIO's degeneracy-resilience feature set is ~30 expert-tuned parameters
 spread across several files. This page turns that into four presets under
-[`lidarslam/param/presets/`](../lidarslam/param/presets/) plus a symptom
+[`lidarslam/param/presets/`](https://github.com/rsasaki0109/lidar_slam_ros2/tree/develop/lidarslam/param/presets) plus a symptom
 lookup so you don't have to read the research notes to pick a config.
 
 Everything here is opt-in and default-off; unmodified `rko_lio` behavior is
@@ -16,8 +16,8 @@ exp07 negative-result check). Read that page for the full methodology.
 
 | Symptom | Root cause | Preset | Sensors needed |
 | --- | --- | --- | --- |
-| Trajectory reach is much shorter than the true traveled distance in a long, straight, self-similar corridor/tunnel | Single-axis (translation-along-travel) degeneracy: ICP's Hessian is genuinely weak along the corridor axis, so small residuals get absorbed as "no motion" | [`tunnel_radar.ros.yaml`](../lidarslam/param/presets/tunnel_radar.ros.yaml) if you have radar; [`tunnel_intensity_no_radar.ros.yaml`](../lidarslam/param/presets/tunnel_intensity_no_radar.ros.yaml) if you don't **and** the corridor has distinctive reflectivity markings (see limitations) | LiDAR + IMU (+ radar, strongly preferred) |
-| Pose freezes in fog/dust/smoke despite real motion: point count drops, IMU still shows walking/driving vibration, reported velocity goes to ~0 | "Clutter lock" -- aerosol returns travel with the sensor, so ICP sees a **healthy, well-conditioned** Hessian and confidently reports near-zero motion. Eigenvalue-based weak-direction gates never fire in this mode -- only a second, disagreeing sensor can catch it | [`corridor_fog_radar.ros.yaml`](../lidarslam/param/presets/corridor_fog_radar.ros.yaml) | LiDAR + IMU + radar (required -- no radar-less fix is validated for this failure mode) |
+| Trajectory reach is much shorter than the true traveled distance in a long, straight, self-similar corridor/tunnel | Single-axis (translation-along-travel) degeneracy: ICP's Hessian is genuinely weak along the corridor axis, so small residuals get absorbed as "no motion" | [`tunnel_radar.ros.yaml`](https://github.com/rsasaki0109/lidar_slam_ros2/blob/develop/lidarslam/param/presets/tunnel_radar.ros.yaml) if you have radar; [`tunnel_intensity_no_radar.ros.yaml`](https://github.com/rsasaki0109/lidar_slam_ros2/blob/develop/lidarslam/param/presets/tunnel_intensity_no_radar.ros.yaml) if you don't **and** the corridor has distinctive reflectivity markings (see limitations) | LiDAR + IMU (+ radar, strongly preferred) |
+| Pose freezes in fog/dust/smoke despite real motion: point count drops, IMU still shows walking/driving vibration, reported velocity goes to ~0 | "Clutter lock" -- aerosol returns travel with the sensor, so ICP sees a **healthy, well-conditioned** Hessian and confidently reports near-zero motion. Eigenvalue-based weak-direction gates never fire in this mode -- only a second, disagreeing sensor can catch it | [`corridor_fog_radar.ros.yaml`](https://github.com/rsasaki0109/lidar_slam_ros2/blob/develop/lidarslam/param/presets/corridor_fog_radar.ros.yaml) | LiDAR + IMU + radar (required -- no radar-less fix is validated for this failure mode) |
 | Otherwise-good tracking but consistent drift along just one axis (e.g. lateral creep down a flat-walled corridor, or vertical creep under a low, featureless ceiling) | A single Hessian eigenvalue is persistently weak along that one world-frame axis. Confirm with `degeneracy_persistence.csv` (dumped when `dump_results: true`; columns include `confirmed`, `axis_tx..axis_rz`) before reaching for a preset -- it tells you which axis and how often it's confirmed | Same as the corridor/tunnel row if an external sensor (radar or a distinctively textured surface) observes that axis; otherwise `degeneracy_aware_solve` alone (in `tunnel_radar.ros.yaml` / `tunnel_intensity_no_radar.ros.yaml`, minus the radar/intensity gates) still blends a geometric/IMU prior into the confirmed weak direction, with no cross-sensor validation behind it | LiDAR + IMU, cross-sensor gate only if the weak axis is externally observable |
 
 If none of these match -- registration is failing outright, or you were
@@ -55,7 +55,7 @@ ros2 run rko_lio online_node --ros-args \
 ```
 
 You can also drive this through
-[`lidarslam/launch/rko_lio_slam.launch.py`](../lidarslam/launch/rko_lio_slam.launch.py)
+[`lidarslam/launch/rko_lio_slam.launch.py`](https://github.com/rsasaki0109/lidar_slam_ros2/blob/develop/lidarslam/launch/rko_lio_slam.launch.py)
 by passing `rko_param_file:=<merged_yaml>` (that launch file accepts only
 one RKO-LIO param file argument, so merge your sensor config and the chosen
 preset into one file first if you use it instead of `ros2 run`).

--- a/docs/graph-slam-architecture.md
+++ b/docs/graph-slam-architecture.md
@@ -1,0 +1,81 @@
+# Graph SLAM architecture
+
+The Graph SLAM package is being split into a thin ROS shell and a deterministic
+mapping engine. The dependency direction is one way:
+
+```text
+ROS component / offline adapters
+              |
+              v
+      GraphSlamApplication
+              |
+              v
+     deterministic backend
+              ^
+              |
+ clock, storage, and output ports
+```
+
+The backend must not include ROS APIs, read a clock, or access the filesystem.
+Online and offline execution must enter through the same application API. ROS
+messages, parameters, services, and executors belong at the outer boundary.
+
+## Configuration and composition root
+
+`GraphSlamConfig` is a source-private snapshot of the ROS parameters. Startup
+has four explicit phases:
+
+1. declare and load every parameter;
+2. normalize compatibility values;
+3. validate the complete snapshot;
+4. compose the backend's domain-specific configuration objects.
+
+The validated snapshot is immutable after construction. Adaptive edge weights
+and other live values are separate runtime state. Pure builders in
+`graph_slam_composition` translate the snapshot into descriptor, loop-search,
+pose-graph, filtering, grid, and GNSS configuration. This keeps ROS parameter
+names and defaults out of backend code and makes configuration mapping directly
+unit-testable.
+
+Filesystem setup, publishers, subscriptions, and services still occur in the
+component during this first milestone. They are effects to move behind ports;
+they are not configuration work.
+
+## Migration milestones
+
+### 1. Configuration and composition root
+
+- one typed parameter snapshot and one startup validation path;
+- pure domain configuration builders;
+- immutable startup intent separated from runtime state;
+- no hand-written backend DTO copying in the ROS component.
+
+### 2. Unified application
+
+- introduce `GraphSlamApplication` as the only mapping workflow entry point;
+- route online callbacks and offline replay through the same commands;
+- move orchestration and state transitions out of the ROS component.
+
+### 3. Backend engine ownership
+
+- make the application own graph, registration, optimization, and scheduling;
+- expose immutable result snapshots instead of shared mutable containers;
+- keep ordering and tie-breaking explicit for deterministic output.
+
+### 4. External I/O ports
+
+- define clock, cache/storage, diagnostics, and map-output ports;
+- provide ROS/filesystem adapters outside the backend;
+- use in-memory adapters for deterministic unit and replay tests.
+
+### 5. Architecture hardening
+
+- keep the ROS component at 300 lines or fewer;
+- enforce forbidden dependencies for backend targets in CI;
+- require online/offline parity and byte-identical loop-edge and trajectory
+  artifacts for identical ordered input;
+- run default CI and release gates for every milestone.
+
+Each milestone is delivered as one reviewable pull request. Compatibility is
+preserved at its boundary: existing parameter names, defaults, topics, and
+services remain stable unless a migration is explicitly documented.

--- a/graph_based_slam/CHANGELOG.rst
+++ b/graph_based_slam/CHANGELOG.rst
@@ -17,6 +17,12 @@ Forthcoming
 * Complete the component PImpl boundary: ROS subscriptions, configuration,
   graph state, and sensor/cache implementation details now live in a private
   source header, reducing the installed component header from 518 to 78 lines.
+* Centralize all 143 ROS parameters in a typed, source-private
+  ``GraphSlamConfig`` loader with startup validation, keeping parameter
+  declaration separate from live graph and sensor state.
+* Add pure composition builders for descriptor, loop-search, pose-graph,
+  filtering, grid, and GNSS configuration, and freeze the validated startup
+  snapshot before runtime initialization begins.
 
 0.6.0 (2026-06-12)
 ------------------

--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -112,6 +112,13 @@ if(OPENMP_FOUND)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 endif()
 
+add_library(graph_slam_config STATIC
+  src/graph_slam_config.cpp
+)
+set_target_properties(graph_slam_config PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_include_directories(graph_slam_config PRIVATE src)
+ament_target_dependencies(graph_slam_config rclcpp)
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   find_package(ament_cmake_gtest REQUIRED)
@@ -125,6 +132,15 @@ if(BUILD_TESTING)
     list(APPEND AMENT_LINT_AUTO_EXCLUDE ament_cmake_uncrustify)
   endif()
   ament_lint_auto_find_test_dependencies()
+  ament_add_gtest(
+    test_graph_slam_config
+    test/test_graph_slam_config.cpp
+  )
+  if(TARGET test_graph_slam_config)
+    target_include_directories(test_graph_slam_config PRIVATE src)
+    target_link_libraries(test_graph_slam_config graph_slam_config)
+    ament_target_dependencies(test_graph_slam_config rclcpp)
+  endif()
   ament_add_gtest(
     test_gnss_weighting
     test/test_gnss_weighting.cpp
@@ -1020,6 +1036,7 @@ endif()
 
 add_library(graph_based_slam_component SHARED
   src/graph_based_slam_component.cpp
+  src/graph_slam_composition.cpp
   src/three_d_bbs_loop_verifier.cpp
 )
 
@@ -1047,6 +1064,7 @@ ament_target_dependencies(graph_based_slam_component
 )
 
 target_link_libraries(graph_based_slam_component
+  graph_slam_config
   g2o::core
   g2o::types_slam3d
   g2o::solver_eigen
@@ -1120,6 +1138,21 @@ include_directories(
   include
   ${PCL_INCLUDE_DIRS}
 )
+
+if(BUILD_TESTING)
+  ament_add_gtest(
+    test_graph_slam_composition
+    test/test_graph_slam_composition.cpp
+  )
+  if(TARGET test_graph_slam_composition)
+    target_include_directories(
+      test_graph_slam_composition PRIVATE src include ${EIGEN3_INCLUDE_DIR}
+    )
+    target_link_libraries(test_graph_slam_composition graph_based_slam_component)
+    ament_target_dependencies(test_graph_slam_composition rclcpp)
+  endif()
+endif()
+
 link_directories(
   ${PCL_LIBRARY_DIRS}
 )

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -28,12 +28,14 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "graph_based_slam_component_impl.hpp"
+#include "graph_slam_composition.hpp"
 
 #include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <filesystem>
 #include <fstream>
+#include <stdexcept>
 #include <unordered_map>
 
 #include <pcl/io/pcd_io.h>  // NOLINT(build/include_order)
@@ -67,6 +69,27 @@ using namespace std::chrono_literals;
 
 namespace graphslam
 {
+namespace
+{
+GraphSlamConfig loadValidatedGraphSlamConfig(rclcpp::Node & node)
+{
+  GraphSlamConfig config = loadGraphSlamConfig(node);
+  const ConfigNormalization normalization = normalizeGraphSlamConfig(config);
+  for (const auto & warning : normalization.warnings) {
+    RCLCPP_WARN(node.get_logger(), "graph SLAM config: %s", warning.c_str());
+  }
+
+  const auto errors = validateGraphSlamConfig(config);
+  if (!errors.empty()) {
+    for (const auto & error : errors) {
+      RCLCPP_ERROR(node.get_logger(), "invalid graph SLAM configuration: %s", error.c_str());
+    }
+    throw std::invalid_argument(errors.front());
+  }
+  return config;
+}
+}  // namespace
+
 struct GraphBasedSlamComponent::Impl::BackendWorkspace
 {
   backend_core::BackendCore core;
@@ -85,6 +108,7 @@ GraphBasedSlamComponent::~GraphBasedSlamComponent() = default;
 
 GraphBasedSlamComponent::Impl::Impl(GraphBasedSlamComponent & node)
 : node_(node),
+  config_(loadValidatedGraphSlamConfig(node_)),
   clock_(RCL_ROS_TIME),
   tfbuffer_(std::make_shared<rclcpp::Clock>(clock_)),
   listener_(tfbuffer_),
@@ -92,1183 +116,41 @@ GraphBasedSlamComponent::Impl::Impl(GraphBasedSlamComponent & node)
   backend_(std::make_unique<BackendWorkspace>())
 {
   RCLCPP_INFO(node_.get_logger(), "initialization start");
-  std::string registration_method;
-  double voxel_leaf_size;
-  double ndt_resolution;
-  int ndt_num_threads;
 
-  node_.declare_parameter("registration_method", "NDT");
-  node_.get_parameter("registration_method", registration_method);
-  node_.declare_parameter("voxel_leaf_size", 0.2);
-  node_.get_parameter("voxel_leaf_size", voxel_leaf_size);
-  node_.declare_parameter("ndt_resolution", 5.0);
-  node_.get_parameter("ndt_resolution", ndt_resolution);
-  node_.declare_parameter("ndt_num_threads", 0);
-  node_.get_parameter("ndt_num_threads", ndt_num_threads);
-  node_.declare_parameter("threshold_loop_closure_score", 1.0);
-  node_.get_parameter("threshold_loop_closure_score", threshold_loop_closure_score_);
-  node_.declare_parameter("scan_context_loop_closure_score_threshold", -1.0);
-  node_.get_parameter(
-    "scan_context_loop_closure_score_threshold",
-    scan_context_loop_closure_score_threshold_);
-  node_.declare_parameter("distance_loop_closure", 20.0);
-  node_.get_parameter("distance_loop_closure", distance_loop_closure_);
-  node_.declare_parameter("range_of_searching_loop_closure", 20.0);
-  node_.get_parameter("range_of_searching_loop_closure", range_of_searching_loop_closure_);
-  node_.declare_parameter("search_submap_num", 3);
-  node_.get_parameter("search_submap_num", search_submap_num_);
-  node_.declare_parameter("loop_search_query_stride", 1);
-  node_.get_parameter("loop_search_query_stride", loop_search_query_stride_);
-  node_.declare_parameter("max_loop_candidate_count", 3);
-  node_.get_parameter("max_loop_candidate_count", max_loop_candidate_count_);
-  node_.declare_parameter("loop_edge_dedup_index_window", 8);
-  node_.get_parameter("loop_edge_dedup_index_window", loop_edge_dedup_index_window_);
-  node_.declare_parameter("loop_max_translation_delta", 15.0);
-  node_.get_parameter("loop_max_translation_delta", loop_max_translation_delta_);
-  node_.declare_parameter("loop_max_rotation_delta_deg", 45.0);
-  node_.get_parameter("loop_max_rotation_delta_deg", loop_max_rotation_delta_deg_);
-  node_.declare_parameter("loop_min_overlap_ratio", 0.0);
-  node_.get_parameter("loop_min_overlap_ratio", loop_min_overlap_ratio_);
-  node_.declare_parameter("loop_min_overlap_ratio_large_correction", 0.0);
-  node_.get_parameter(
-    "loop_min_overlap_ratio_large_correction",
-    loop_min_overlap_ratio_large_correction_);
-  node_.declare_parameter("loop_overlap_large_correction_translation_m", 0.0);
-  node_.get_parameter(
-    "loop_overlap_large_correction_translation_m",
-    loop_overlap_large_correction_translation_m_);
-  node_.declare_parameter("loop_overlap_max_distance_m", 0.5);
-  node_.get_parameter("loop_overlap_max_distance_m", loop_overlap_max_distance_m_);
-  node_.declare_parameter("loop_max_translation_delta_descriptor", -1.0);
-  node_.get_parameter(
-    "loop_max_translation_delta_descriptor", loop_max_translation_delta_descriptor_);
-  node_.declare_parameter("loop_max_rotation_delta_deg_descriptor", -1.0);
-  node_.get_parameter(
-    "loop_max_rotation_delta_deg_descriptor", loop_max_rotation_delta_deg_descriptor_);
-  node_.declare_parameter("num_adjacent_pose_cnstraints", 5);
-  node_.get_parameter("num_adjacent_pose_cnstraints", num_adjacent_pose_cnstraints_);
-  node_.declare_parameter("use_save_map_in_loop", true);
-  node_.get_parameter("use_save_map_in_loop", use_save_map_in_loop_);
-  node_.declare_parameter("debug_flag", false);
-  node_.get_parameter("debug_flag", debug_flag_);
-  node_.declare_parameter("adjacent_edge_info_weight", 1000.0);
-  node_.get_parameter("adjacent_edge_info_weight", adjacent_edge_info_weight_);
-  node_.declare_parameter("adjacent_edge_info_auto_scale", false);
-  node_.get_parameter("adjacent_edge_info_auto_scale", adjacent_edge_info_auto_scale_);
-  node_.declare_parameter("adjacent_edge_info_auto_scale_target_nis", 6.0);
-  node_.get_parameter(
-    "adjacent_edge_info_auto_scale_target_nis",
-    adjacent_edge_info_auto_scale_target_nis_);
-  node_.declare_parameter("adjacent_edge_info_auto_scale_ema_alpha", 0.3);
-  node_.get_parameter(
-    "adjacent_edge_info_auto_scale_ema_alpha",
-    adjacent_edge_info_auto_scale_ema_alpha_);
-  node_.declare_parameter("adjacent_edge_info_auto_scale_min", 1.0);
-  node_.get_parameter("adjacent_edge_info_auto_scale_min", adjacent_edge_info_auto_scale_min_);
-  node_.declare_parameter("adjacent_edge_info_auto_scale_max", 1.0e6);
-  node_.get_parameter("adjacent_edge_info_auto_scale_max", adjacent_edge_info_auto_scale_max_);
-  node_.declare_parameter("adjacent_edge_info_auto_scale_split_trans_rot", false);
-  node_.get_parameter(
-    "adjacent_edge_info_auto_scale_split_trans_rot",
-    adjacent_edge_info_auto_scale_split_trans_rot_);
-  node_.declare_parameter("adjacent_edge_info_weight_trans", -1.0);
-  node_.get_parameter("adjacent_edge_info_weight_trans", adjacent_edge_info_weight_trans_);
-  node_.declare_parameter("adjacent_edge_info_weight_rot", -1.0);
-  node_.get_parameter("adjacent_edge_info_weight_rot", adjacent_edge_info_weight_rot_);
-  node_.declare_parameter("adjacent_edge_info_auto_scale_target_nis_trans", 3.0);
-  node_.get_parameter(
-    "adjacent_edge_info_auto_scale_target_nis_trans",
-    adjacent_edge_info_auto_scale_target_nis_trans_);
-  node_.declare_parameter("adjacent_edge_info_auto_scale_target_nis_rot", 3.0);
-  node_.get_parameter(
-    "adjacent_edge_info_auto_scale_target_nis_rot",
-    adjacent_edge_info_auto_scale_target_nis_rot_);
-  // Trans/rot weights default to the unified weight when negative (i.e., user
-  // has not provided an explicit per-block override). This keeps the split
-  // mode safe to enable on existing YAMLs that only set
-  // adjacent_edge_info_weight.
-  if (adjacent_edge_info_weight_trans_ <= 0.0) {
-    adjacent_edge_info_weight_trans_ = adjacent_edge_info_weight_;
-  }
-  if (adjacent_edge_info_weight_rot_ <= 0.0) {
-    adjacent_edge_info_weight_rot_ = adjacent_edge_info_weight_;
-  }
-  node_.declare_parameter("loop_edge_info_weight", 100.0);
-  node_.get_parameter("loop_edge_info_weight", loop_edge_info_weight_);
-  node_.declare_parameter("loop_edge_robust_kernel_delta", 1.0);
-  node_.get_parameter("loop_edge_robust_kernel_delta", loop_edge_robust_kernel_delta_);
-  node_.declare_parameter("loop_edge_robust_kernel_type", std::string("huber"));
-  node_.get_parameter("loop_edge_robust_kernel_type", loop_edge_robust_kernel_type_);
-  node_.declare_parameter("use_scan_context", false);
-  node_.get_parameter("use_scan_context", use_scan_context_);
-  node_.declare_parameter("use_bev_descriptor", false);
-  node_.get_parameter("use_bev_descriptor", use_bev_descriptor_);
-  node_.declare_parameter("use_solid_descriptor", false);
-  node_.get_parameter("use_solid_descriptor", use_solid_descriptor_);
-  node_.declare_parameter("use_triangle_descriptor", false);
-  node_.get_parameter("use_triangle_descriptor", use_triangle_descriptor_);
-  node_.declare_parameter("triangle_descriptor_grid_size_m", 60.0);
-  node_.get_parameter("triangle_descriptor_grid_size_m", triangle_descriptor_grid_size_m_);
-  node_.declare_parameter("triangle_descriptor_grid_cells", 100);
-  node_.get_parameter("triangle_descriptor_grid_cells", triangle_descriptor_grid_cells_);
-  node_.declare_parameter("triangle_descriptor_max_keypoints", 40);
-  node_.get_parameter("triangle_descriptor_max_keypoints", triangle_descriptor_max_keypoints_);
-  node_.declare_parameter("triangle_descriptor_min_salience_m", 0.8);
-  node_.get_parameter("triangle_descriptor_min_salience_m", triangle_descriptor_min_salience_m_);
-  node_.declare_parameter("triangle_descriptor_min_edge_m", 2.0);
-  node_.get_parameter("triangle_descriptor_min_edge_m", triangle_descriptor_min_edge_m_);
-  node_.declare_parameter("triangle_descriptor_max_edge_m", 50.0);
-  node_.get_parameter("triangle_descriptor_max_edge_m", triangle_descriptor_max_edge_m_);
-  node_.declare_parameter("triangle_descriptor_max_triangles", 3000);
-  node_.get_parameter("triangle_descriptor_max_triangles", triangle_descriptor_max_triangles_);
-  node_.declare_parameter("triangle_descriptor_edge_bin_m", 0.5);
-  node_.get_parameter("triangle_descriptor_edge_bin_m", triangle_descriptor_edge_bin_m_);
-  node_.declare_parameter("triangle_descriptor_quad_feature_bin_m", 0.0);
-  node_.get_parameter(
-    "triangle_descriptor_quad_feature_bin_m",
-    triangle_descriptor_quad_feature_bin_m_);
-  node_.declare_parameter<std::string>(
-    "triangle_descriptor_keypoint_mode", triangle_descriptor_keypoint_mode_);
-  node_.get_parameter("triangle_descriptor_keypoint_mode", triangle_descriptor_keypoint_mode_);
-  node_.declare_parameter("triangle_descriptor_edge_voxel_size_m", 0.4);
-  node_.get_parameter(
-    "triangle_descriptor_edge_voxel_size_m", triangle_descriptor_edge_voxel_size_m_);
-  node_.declare_parameter("triangle_descriptor_edge_neighbor_radius_m", 1.0);
-  node_.get_parameter(
-    "triangle_descriptor_edge_neighbor_radius_m",
-    triangle_descriptor_edge_neighbor_radius_m_);
-  node_.declare_parameter("triangle_descriptor_edge_min_neighbors", 6);
-  node_.get_parameter(
-    "triangle_descriptor_edge_min_neighbors", triangle_descriptor_edge_min_neighbors_);
-  node_.declare_parameter("triangle_descriptor_edge_min_edgeness", 0.5);
-  node_.get_parameter(
-    "triangle_descriptor_edge_min_edgeness", triangle_descriptor_edge_min_edgeness_);
-  node_.declare_parameter("triangle_descriptor_edge_nms_radius_m", 2.0);
-  node_.get_parameter(
-    "triangle_descriptor_edge_nms_radius_m", triangle_descriptor_edge_nms_radius_m_);
-  node_.declare_parameter("triangle_descriptor_min_votes", 6);
-  node_.get_parameter("triangle_descriptor_min_votes", triangle_descriptor_min_votes_);
-  node_.declare_parameter("triangle_descriptor_min_inliers", 4);
-  node_.get_parameter("triangle_descriptor_min_inliers", triangle_descriptor_min_inliers_);
-  node_.declare_parameter("triangle_descriptor_min_inlier_ratio", 0.0);
-  node_.get_parameter(
-    "triangle_descriptor_min_inlier_ratio",
-    triangle_descriptor_min_inlier_ratio_);
-  node_.declare_parameter("triangle_descriptor_max_pairs", 64);
-  node_.get_parameter("triangle_descriptor_max_pairs", triangle_descriptor_max_pairs_);
-  node_.declare_parameter("triangle_descriptor_min_4th_point_agreements", 0);
-  node_.get_parameter(
-    "triangle_descriptor_min_4th_point_agreements",
-    triangle_descriptor_min_4th_point_agreements_);
-  node_.declare_parameter("triangle_descriptor_fourth_point_max_distance_m", 2.0);
-  node_.get_parameter(
-    "triangle_descriptor_fourth_point_max_distance_m",
-    triangle_descriptor_fourth_point_max_distance_m_);
-  node_.declare_parameter("triangle_descriptor_refine_se3_with_all_inliers", false);
-  node_.get_parameter(
-    "triangle_descriptor_refine_se3_with_all_inliers",
-    triangle_descriptor_refine_se3_with_all_inliers_);
-  node_.declare_parameter("triangle_descriptor_skip_ransac", false);
-  node_.get_parameter(
-    "triangle_descriptor_skip_ransac",
-    triangle_descriptor_skip_ransac_);
-  node_.declare_parameter("triangle_descriptor_inlier_translation_m", 2.0);
-  node_.get_parameter(
-    "triangle_descriptor_inlier_translation_m",
-    triangle_descriptor_inlier_translation_m_);
-  node_.declare_parameter("triangle_descriptor_inlier_rotation_deg", 5.0);
-  node_.get_parameter(
-    "triangle_descriptor_inlier_rotation_deg",
-    triangle_descriptor_inlier_rotation_deg_);
-  node_.declare_parameter("triangle_descriptor_exclude_recent", 4);
-  node_.get_parameter("triangle_descriptor_exclude_recent", triangle_descriptor_exclude_recent_);
-  node_.declare_parameter("triangle_verify_with_bev", false);
-  node_.get_parameter("triangle_verify_with_bev", triangle_verify_with_bev_);
-  node_.declare_parameter("triangle_verify_bev_max_distance", 0.30);
-  node_.get_parameter("triangle_verify_bev_max_distance", triangle_verify_bev_max_distance_);
-  node_.declare_parameter("use_pcd_cache", false);
-  node_.get_parameter("use_pcd_cache", use_pcd_cache_);
-  node_.declare_parameter("pcd_cache_dir", std::string("/tmp/graph_slam_pcd_cache"));
-  node_.get_parameter("pcd_cache_dir", pcd_cache_dir_);
-  if (use_pcd_cache_) {
-    std::filesystem::create_directories(pcd_cache_dir_);
-    std::cout << "pcd_cache_dir:" << pcd_cache_dir_ << std::endl;
-  }
-  node_.declare_parameter("scan_context_threshold", 0.3);
-  node_.get_parameter("scan_context_threshold", scan_context_threshold_);
-  node_.declare_parameter("scan_context_query_stride", 1);
-  node_.get_parameter("scan_context_query_stride", scan_context_query_stride_);
-  node_.declare_parameter("scan_context_exclude_recent", ScanContext::EXCLUDE_RECENT);
-  node_.get_parameter("scan_context_exclude_recent", scan_context_exclude_recent_);
-  node_.declare_parameter("bev_descriptor_threshold", 0.20);
-  node_.get_parameter("bev_descriptor_threshold", bev_descriptor_threshold_);
-  node_.declare_parameter("bev_descriptor_grid_size_m", 80.0);
-  node_.get_parameter("bev_descriptor_grid_size_m", bev_descriptor_grid_size_m_);
-  node_.declare_parameter("bev_descriptor_grid_cells", 40);
-  node_.get_parameter("bev_descriptor_grid_cells", bev_descriptor_grid_cells_);
-  node_.declare_parameter("bev_descriptor_yaw_bins", 24);
-  node_.get_parameter("bev_descriptor_yaw_bins", bev_descriptor_yaw_bins_);
-  node_.declare_parameter("bev_descriptor_sequence_window", 0);
-  node_.get_parameter("bev_descriptor_sequence_window", bev_descriptor_sequence_window_);
-  node_.declare_parameter("bev_descriptor_sequence_threshold", -1.0);
-  node_.get_parameter("bev_descriptor_sequence_threshold", bev_descriptor_sequence_threshold_);
-  node_.declare_parameter("bev_descriptor_pose_consistency_threshold_m", -1.0);
-  node_.get_parameter(
-    "bev_descriptor_pose_consistency_threshold_m",
-    bev_descriptor_pose_consistency_threshold_m_);
-  node_.declare_parameter("bev_descriptor_max_euclidean_distance_m", -1.0);
-  node_.get_parameter(
-    "bev_descriptor_max_euclidean_distance_m",
-    bev_descriptor_max_euclidean_distance_m_);
-  node_.declare_parameter("bev_descriptor_rerank_weight_m", 100.0);
-  node_.get_parameter("bev_descriptor_rerank_weight_m", bev_descriptor_rerank_weight_m_);
-  node_.declare_parameter("bev_use_mutual_visibility", false);
-  node_.get_parameter("bev_use_mutual_visibility", bev_use_mutual_visibility_);
-  node_.declare_parameter("bev_mutual_visibility_min_overlap_ratio", 0.05);
-  node_.get_parameter(
-    "bev_mutual_visibility_min_overlap_ratio",
-    bev_mutual_visibility_min_overlap_ratio_);
-  node_.declare_parameter("bev_mutual_visibility_occupancy_eps", 0.5);
-  node_.get_parameter(
-    "bev_mutual_visibility_occupancy_eps",
-    bev_mutual_visibility_occupancy_eps_);
-  node_.declare_parameter("solid_descriptor_min_similarity", 0.70);
-  node_.get_parameter("solid_descriptor_min_similarity", solid_descriptor_min_similarity_);
-  node_.declare_parameter("solid_descriptor_sequence_window", 0);
-  node_.get_parameter("solid_descriptor_sequence_window", solid_descriptor_sequence_window_);
-  node_.declare_parameter("solid_descriptor_sequence_min_similarity", -1.0);
-  node_.get_parameter(
-    "solid_descriptor_sequence_min_similarity",
-    solid_descriptor_sequence_min_similarity_);
-  node_.declare_parameter("solid_descriptor_pose_consistency_threshold_m", -1.0);
-  node_.get_parameter(
-    "solid_descriptor_pose_consistency_threshold_m",
-    solid_descriptor_pose_consistency_threshold_m_);
-  node_.declare_parameter("solid_descriptor_max_euclidean_distance_m", -1.0);
-  node_.get_parameter(
-    "solid_descriptor_max_euclidean_distance_m",
-    solid_descriptor_max_euclidean_distance_m_);
-  node_.declare_parameter("prefer_scan_context_candidates", false);
-  node_.get_parameter("prefer_scan_context_candidates", prefer_scan_context_candidates_);
-  node_.declare_parameter("use_3d_bbs_for_scan_context", false);
-  node_.get_parameter("use_3d_bbs_for_scan_context", use_3d_bbs_for_scan_context_);
-  node_.declare_parameter("three_d_bbs_min_level_res", 1.0);
-  node_.get_parameter("three_d_bbs_min_level_res", three_d_bbs_min_level_res_);
-  node_.declare_parameter("three_d_bbs_max_level", 3);
-  node_.get_parameter("three_d_bbs_max_level", three_d_bbs_max_level_);
-  node_.declare_parameter("three_d_bbs_score_threshold_percentage", 0.25);
-  node_.get_parameter(
-    "three_d_bbs_score_threshold_percentage",
-    three_d_bbs_score_threshold_percentage_);
-  node_.declare_parameter("three_d_bbs_timeout_msec", 50);
-  node_.get_parameter("three_d_bbs_timeout_msec", three_d_bbs_timeout_msec_);
-  node_.declare_parameter("three_d_bbs_num_threads", 0);
-  node_.get_parameter("three_d_bbs_num_threads", three_d_bbs_num_threads_);
-  node_.declare_parameter("three_d_bbs_voxel_leaf_size", 1.0);
-  node_.get_parameter("three_d_bbs_voxel_leaf_size", three_d_bbs_voxel_leaf_size_);
-  node_.declare_parameter("three_d_bbs_source_submap_num", 2);
-  node_.get_parameter("three_d_bbs_source_submap_num", three_d_bbs_source_submap_num_);
-  node_.declare_parameter("three_d_bbs_target_submap_radius", 1);
-  node_.get_parameter("three_d_bbs_target_submap_radius", three_d_bbs_target_submap_radius_);
-  node_.declare_parameter("three_d_bbs_translation_search_margin_m", 15.0);
-  node_.get_parameter(
-    "three_d_bbs_translation_search_margin_m",
-    three_d_bbs_translation_search_margin_m_);
-  node_.declare_parameter("three_d_bbs_roll_pitch_search_deg", 10.0);
-  node_.get_parameter(
-    "three_d_bbs_roll_pitch_search_deg",
-    three_d_bbs_roll_pitch_search_deg_);
-  node_.declare_parameter("three_d_bbs_yaw_search_deg", 180.0);
-  node_.get_parameter("three_d_bbs_yaw_search_deg", three_d_bbs_yaw_search_deg_);
-  node_.declare_parameter("use_dynamic_object_filter", false);
-  node_.get_parameter("use_dynamic_object_filter", use_dynamic_object_filter_);
-  node_.declare_parameter("dynamic_object_filter_voxel_size", 0.3);
-  node_.get_parameter("dynamic_object_filter_voxel_size", dynamic_object_filter_voxel_size_);
-  node_.declare_parameter("dynamic_object_filter_min_observations", 2);
-  node_.get_parameter(
-    "dynamic_object_filter_min_observations",
-    dynamic_object_filter_min_observations_);
-  node_.declare_parameter("dynamic_object_filter_temporal_window", 5);
-  node_.get_parameter(
-    "dynamic_object_filter_temporal_window",
-    dynamic_object_filter_temporal_window_);
-  node_.declare_parameter("dynamic_object_filter_max_range_from_sensor_m", 30.0);
-  node_.get_parameter(
-    "dynamic_object_filter_max_range_from_sensor_m",
-    dynamic_object_filter_max_range_from_sensor_m_);
-  node_.declare_parameter("use_planar_map_filter", false);
-  node_.get_parameter("use_planar_map_filter", use_planar_map_filter_);
-  node_.declare_parameter("planar_map_filter_voxel_size", 0.1);
-  node_.get_parameter("planar_map_filter_voxel_size", planar_map_filter_voxel_size_);
-  node_.declare_parameter("planar_map_filter_min_neighbors", 3);
-  node_.get_parameter("planar_map_filter_min_neighbors", planar_map_filter_min_neighbors_);
-  node_.declare_parameter("planar_map_filter_max_small_eigenvalue_ratio", 0.24);
-  node_.get_parameter(
-    "planar_map_filter_max_small_eigenvalue_ratio",
-    planar_map_filter_max_small_eigenvalue_ratio_);
-  node_.declare_parameter("planar_map_filter_min_middle_eigenvalue_ratio", 0.0);
-  node_.get_parameter(
-    "planar_map_filter_min_middle_eigenvalue_ratio",
-    planar_map_filter_min_middle_eigenvalue_ratio_);
-  node_.declare_parameter("planar_map_filter_min_retained_ratio", 0.90);
-  node_.get_parameter(
-    "planar_map_filter_min_retained_ratio", planar_map_filter_min_retained_ratio_);
-  node_.declare_parameter("map_save_dir", std::string("."));
-  node_.get_parameter("map_save_dir", map_save_dir_);
-  // The launch files have always passed this; until v0.6 Phase 1 it was
-  // silently ignored and the graph went to the CWD. The default keeps the
-  // historical CWD behaviour.
-  node_.declare_parameter("save_pose_graph_path", std::string("pose_graph.g2o"));
-  node_.get_parameter("save_pose_graph_path", save_pose_graph_path_);
-  node_.declare_parameter("map_grid_size_x", 20.0);
-  node_.get_parameter("map_grid_size_x", map_grid_size_x_);
-  node_.declare_parameter("map_grid_size_y", 20.0);
-  node_.get_parameter("map_grid_size_y", map_grid_size_y_);
-  node_.declare_parameter("map_leaf_size", 0.2);
-  node_.get_parameter("map_leaf_size", map_leaf_size_);
-  node_.declare_parameter("use_gnss", false);
-  node_.get_parameter("use_gnss", use_gnss_);
-  node_.declare_parameter("gnss_topic", std::string("/gnss/fix"));
-  node_.get_parameter("gnss_topic", gnss_topic_);
-  node_.declare_parameter("gnss_info_weight", 1.0);
-  node_.get_parameter("gnss_info_weight", gnss_info_weight_);
-  node_.declare_parameter("gnss_use_covariance_weighting", true);
-  node_.get_parameter("gnss_use_covariance_weighting", gnss_use_covariance_weighting_);
-  node_.declare_parameter("gnss_covariance_min_variance_m2", 0.01);
-  node_.get_parameter("gnss_covariance_min_variance_m2", gnss_covariance_min_variance_m2_);
-  node_.declare_parameter("gnss_covariance_max_variance_m2", 25.0);
-  node_.get_parameter("gnss_covariance_max_variance_m2", gnss_covariance_max_variance_m2_);
-  node_.declare_parameter("gnss_rtk_fix_max_horizontal_stddev_m", 0.3);
-  node_.get_parameter(
-    "gnss_rtk_fix_max_horizontal_stddev_m",
-    gnss_rtk_fix_max_horizontal_stddev_m_);
-  node_.declare_parameter("gnss_rtk_fix_weight_scale", 3.0);
-  node_.get_parameter("gnss_rtk_fix_weight_scale", gnss_rtk_fix_weight_scale_);
-  node_.declare_parameter("gnss_non_rtk_weight_scale", 1.0);
-  node_.get_parameter("gnss_non_rtk_weight_scale", gnss_non_rtk_weight_scale_);
-  node_.declare_parameter("gnss_header_stamp_max_skew_sec", 30.0);
-  node_.get_parameter("gnss_header_stamp_max_skew_sec", gnss_header_stamp_max_skew_sec_);
-  node_.declare_parameter("gnss_align_yaw", true);
-  node_.get_parameter("gnss_align_yaw", gnss_align_yaw_);
-  node_.declare_parameter("gnss_yaw_alignment_min_anchors", 10);
-  node_.get_parameter("gnss_yaw_alignment_min_anchors", gnss_yaw_alignment_min_anchors_);
-  node_.declare_parameter("gnss_yaw_alignment_min_baseline_m", 5.0);
-  node_.get_parameter("gnss_yaw_alignment_min_baseline_m", gnss_yaw_alignment_min_baseline_m_);
-  node_.declare_parameter("gnss_origin_min_samples", 3);
-  node_.get_parameter("gnss_origin_min_samples", gnss_origin_min_samples_);
-  node_.declare_parameter("gnss_origin_consistency_threshold_m", 20.0);
-  node_.get_parameter(
-    "gnss_origin_consistency_threshold_m",
-    gnss_origin_consistency_threshold_m_);
-  node_.declare_parameter("use_imu_preintegration", false);
-  node_.get_parameter("use_imu_preintegration", use_imu_preintegration_);
-  node_.declare_parameter("imu_rotation_info_roll_pitch", 100.0);
-  node_.get_parameter("imu_rotation_info_roll_pitch", imu_rotation_info_roll_pitch_);
-  node_.declare_parameter("imu_rotation_info_yaw", 10.0);
-  node_.get_parameter("imu_rotation_info_yaw", imu_rotation_info_yaw_);
+  adjacent_edge_info_weight_ = config_.adjacent_edge_info_weight_;
+  adjacent_edge_info_weight_trans_ = config_.adjacent_edge_info_weight_trans_;
+  adjacent_edge_info_weight_rot_ = config_.adjacent_edge_info_weight_rot_;
 
-  if (gnss_origin_min_samples_ < 1) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "gnss_origin_min_samples must be >= 1, clamping %d to 1",
-      gnss_origin_min_samples_);
-    gnss_origin_min_samples_ = 1;
-  }
-  if (gnss_origin_consistency_threshold_m_ <= 0.0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "gnss_origin_consistency_threshold_m must be positive, resetting %.3f to 20.0",
-      gnss_origin_consistency_threshold_m_);
-    gnss_origin_consistency_threshold_m_ = 20.0;
+  if (config_.use_pcd_cache_) {
+    std::filesystem::create_directories(config_.pcd_cache_dir_);
   }
   gnss_origin_accumulator_.configure(
-    gnss_origin_min_samples_, gnss_origin_consistency_threshold_m_);
-  if (gnss_covariance_min_variance_m2_ <= 0.0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "gnss_covariance_min_variance_m2 must be positive, resetting %.6f to 0.01",
-      gnss_covariance_min_variance_m2_);
-    gnss_covariance_min_variance_m2_ = 0.01;
-  }
-  if (gnss_covariance_max_variance_m2_ < gnss_covariance_min_variance_m2_) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "gnss_covariance_max_variance_m2 must be >= min variance, resetting %.6f to %.6f",
-      gnss_covariance_max_variance_m2_, gnss_covariance_min_variance_m2_);
-    gnss_covariance_max_variance_m2_ = gnss_covariance_min_variance_m2_;
-  }
-  if (gnss_rtk_fix_max_horizontal_stddev_m_ <= 0.0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "gnss_rtk_fix_max_horizontal_stddev_m must be positive, resetting %.3f to 0.3",
-      gnss_rtk_fix_max_horizontal_stddev_m_);
-    gnss_rtk_fix_max_horizontal_stddev_m_ = 0.3;
-  }
-  if (gnss_rtk_fix_weight_scale_ <= 0.0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "gnss_rtk_fix_weight_scale must be positive, resetting %.3f to 3.0",
-      gnss_rtk_fix_weight_scale_);
-    gnss_rtk_fix_weight_scale_ = 3.0;
-  }
-  if (gnss_non_rtk_weight_scale_ <= 0.0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "gnss_non_rtk_weight_scale must be positive, resetting %.3f to 1.0",
-      gnss_non_rtk_weight_scale_);
-    gnss_non_rtk_weight_scale_ = 1.0;
-  }
-  if (gnss_header_stamp_max_skew_sec_ <= 0.0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "gnss_header_stamp_max_skew_sec must be positive, resetting %.3f to 30.0",
-      gnss_header_stamp_max_skew_sec_);
-    gnss_header_stamp_max_skew_sec_ = 30.0;
-  }
-  if (search_submap_num_ < 1) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "search_submap_num must be >= 1, clamping %d to 1",
-      search_submap_num_);
-    search_submap_num_ = 1;
-  }
-  if (loop_search_query_stride_ < 1) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "loop_search_query_stride must be >= 1, clamping %d to 1",
-      loop_search_query_stride_);
-    loop_search_query_stride_ = 1;
-  }
-  if (max_loop_candidate_count_ < 1) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "max_loop_candidate_count must be >= 1, clamping %d to 1",
-      max_loop_candidate_count_);
-    max_loop_candidate_count_ = 1;
-  }
-  if (loop_edge_dedup_index_window_ < 0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "loop_edge_dedup_index_window must be >= 0, clamping %d to 0",
-      loop_edge_dedup_index_window_);
-    loop_edge_dedup_index_window_ = 0;
-  }
-  graph_state_.configureLoopEdgeDedupWindow(loop_edge_dedup_index_window_);
-  if (loop_max_translation_delta_ <= 0.0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "loop_max_translation_delta must be positive, resetting %.3f to 15.0",
-      loop_max_translation_delta_);
-    loop_max_translation_delta_ = 15.0;
-  }
-  if (loop_max_rotation_delta_deg_ <= 0.0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "loop_max_rotation_delta_deg must be positive, resetting %.3f to 45.0",
-      loop_max_rotation_delta_deg_);
-    loop_max_rotation_delta_deg_ = 45.0;
-  }
-  if (loop_min_overlap_ratio_ < 0.0 || loop_min_overlap_ratio_ > 1.0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "loop_min_overlap_ratio must be in [0, 1], resetting %.3f to 0 (disabled)",
-      loop_min_overlap_ratio_);
-    loop_min_overlap_ratio_ = 0.0;
-  }
-  if (
-    loop_min_overlap_ratio_large_correction_ < 0.0 ||
-    loop_min_overlap_ratio_large_correction_ > 1.0)
-  {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "loop_min_overlap_ratio_large_correction must be in [0, 1], "
-      "resetting %.3f to 0 (disabled)",
-      loop_min_overlap_ratio_large_correction_);
-    loop_min_overlap_ratio_large_correction_ = 0.0;
-  }
-  if (loop_overlap_large_correction_translation_m_ < 0.0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "loop_overlap_large_correction_translation_m must be non-negative, "
-      "resetting %.3f to 0 (disabled)",
-      loop_overlap_large_correction_translation_m_);
-    loop_overlap_large_correction_translation_m_ = 0.0;
-  }
-  if (loop_overlap_max_distance_m_ <= 0.0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "loop_overlap_max_distance_m must be positive, resetting %.3f to 0.5",
-      loop_overlap_max_distance_m_);
-    loop_overlap_max_distance_m_ = 0.5;
-  }
-  // Descriptor overrides: -1.0 = disabled (fall back to generic cap).
-  // Any other non-positive value is treated as invalid and clamped to -1.0
-  // so that operators see clear feedback instead of silently disabling the
-  // generic cap for descriptor sources.
-  if (loop_max_translation_delta_descriptor_ <= 0.0 &&
-    loop_max_translation_delta_descriptor_ != -1.0)
-  {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "loop_max_translation_delta_descriptor must be > 0 (override) or -1 "
-      "(disabled); resetting %.3f to -1",
-      loop_max_translation_delta_descriptor_);
-    loop_max_translation_delta_descriptor_ = -1.0;
-  }
-  if (loop_max_rotation_delta_deg_descriptor_ <= 0.0 &&
-    loop_max_rotation_delta_deg_descriptor_ != -1.0)
-  {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "loop_max_rotation_delta_deg_descriptor must be > 0 (override) or -1 "
-      "(disabled); resetting %.3f to -1",
-      loop_max_rotation_delta_deg_descriptor_);
-    loop_max_rotation_delta_deg_descriptor_ = -1.0;
-  }
-  if (num_adjacent_pose_cnstraints_ < 1) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "num_adjacent_pose_cnstraints must be >= 1, clamping %d to 1",
-      num_adjacent_pose_cnstraints_);
-    num_adjacent_pose_cnstraints_ = 1;
-  }
-  if (adjacent_edge_info_weight_ <= 0.0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "adjacent_edge_info_weight must be positive, resetting %.3f to 1000.0",
-      adjacent_edge_info_weight_);
-    adjacent_edge_info_weight_ = 1000.0;
-  }
-  if (adjacent_edge_info_weight_trans_ <= 0.0) {
-    adjacent_edge_info_weight_trans_ = adjacent_edge_info_weight_;
-  }
-  if (adjacent_edge_info_weight_rot_ <= 0.0) {
-    adjacent_edge_info_weight_rot_ = adjacent_edge_info_weight_;
-  }
-  if (adjacent_edge_info_auto_scale_target_nis_trans_ <= 0.0) {
-    adjacent_edge_info_auto_scale_target_nis_trans_ = 3.0;
-  }
-  if (adjacent_edge_info_auto_scale_target_nis_rot_ <= 0.0) {
-    adjacent_edge_info_auto_scale_target_nis_rot_ = 3.0;
-  }
-  if (loop_edge_info_weight_ <= 0.0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "loop_edge_info_weight must be positive, resetting %.3f to 100.0",
-      loop_edge_info_weight_);
-    loop_edge_info_weight_ = 100.0;
-  }
-  if (loop_edge_robust_kernel_delta_ <= 0.0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "loop_edge_robust_kernel_delta must be positive, resetting %.3f to 1.0",
-      loop_edge_robust_kernel_delta_);
-    loop_edge_robust_kernel_delta_ = 1.0;
-  }
-  if (bev_descriptor_threshold_ <= 0.0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "bev_descriptor_threshold must be positive, resetting %.3f to 0.20",
-      bev_descriptor_threshold_);
-    bev_descriptor_threshold_ = 0.20;
-  }
-  if (bev_descriptor_grid_size_m_ <= 0.0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "bev_descriptor_grid_size_m must be positive, resetting %.3f to 80.0",
-      bev_descriptor_grid_size_m_);
-    bev_descriptor_grid_size_m_ = 80.0;
-  }
-  if (bev_descriptor_grid_cells_ < 8) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "bev_descriptor_grid_cells must be >= 8, clamping %d to 8",
-      bev_descriptor_grid_cells_);
-    bev_descriptor_grid_cells_ = 8;
-  }
-  if (bev_descriptor_yaw_bins_ < 1) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "bev_descriptor_yaw_bins must be >= 1, clamping %d to 1",
-      bev_descriptor_yaw_bins_);
-    bev_descriptor_yaw_bins_ = 1;
-  }
-  if (bev_descriptor_sequence_window_ < 0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "bev_descriptor_sequence_window must be >= 0, clamping %d to 0",
-      bev_descriptor_sequence_window_);
-    bev_descriptor_sequence_window_ = 0;
-  }
-  if (bev_descriptor_sequence_threshold_ <= 0.0) {
-    bev_descriptor_sequence_threshold_ = bev_descriptor_threshold_;
-  }
-  if (bev_descriptor_rerank_weight_m_ < 0.0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "bev_descriptor_rerank_weight_m must be >= 0.0, clamping %.3f to 0.0",
-      bev_descriptor_rerank_weight_m_);
-    bev_descriptor_rerank_weight_m_ = 0.0;
-  }
-  if (bev_descriptor_pose_consistency_threshold_m_ == 0.0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "bev_descriptor_pose_consistency_threshold_m must be negative (disabled) or positive, "
-      "resetting 0.0 to disabled");
-    bev_descriptor_pose_consistency_threshold_m_ = -1.0;
-  }
-  if (triangle_descriptor_keypoint_mode_ != "bev_max_height" &&
-    triangle_descriptor_keypoint_mode_ != "edge_3d")
-  {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "triangle_descriptor_keypoint_mode must be 'bev_max_height' or 'edge_3d', "
-      "got '%s'; falling back to 'bev_max_height'",
-      triangle_descriptor_keypoint_mode_.c_str());
-    triangle_descriptor_keypoint_mode_ = "bev_max_height";
-  }
-  if (triangle_descriptor_edge_voxel_size_m_ < 0.0) {
-    triangle_descriptor_edge_voxel_size_m_ = 0.0;
-  }
-  if (triangle_descriptor_edge_neighbor_radius_m_ <= 0.05) {
-    triangle_descriptor_edge_neighbor_radius_m_ = 0.05;
-  }
-  if (triangle_descriptor_edge_min_neighbors_ < 4) {
-    triangle_descriptor_edge_min_neighbors_ = 4;
-  }
-  if (triangle_descriptor_edge_min_edgeness_ < 0.0) {
-    triangle_descriptor_edge_min_edgeness_ = 0.0;
-  } else if (triangle_descriptor_edge_min_edgeness_ > 1.0) {
-    triangle_descriptor_edge_min_edgeness_ = 1.0;
-  }
-  if (triangle_descriptor_edge_nms_radius_m_ < 0.0) {
-    triangle_descriptor_edge_nms_radius_m_ = 0.0;
-  }
-  if (triangle_descriptor_grid_size_m_ <= 0.0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "triangle_descriptor_grid_size_m must be positive, resetting %.3f to 60.0",
-      triangle_descriptor_grid_size_m_);
-    triangle_descriptor_grid_size_m_ = 60.0;
-  }
-  if (triangle_descriptor_grid_cells_ < 8) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "triangle_descriptor_grid_cells must be >= 8, clamping %d to 8",
-      triangle_descriptor_grid_cells_);
-    triangle_descriptor_grid_cells_ = 8;
-  }
-  if (triangle_descriptor_max_keypoints_ < 4) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "triangle_descriptor_max_keypoints must be >= 4, clamping %d to 4",
-      triangle_descriptor_max_keypoints_);
-    triangle_descriptor_max_keypoints_ = 4;
-  }
-  if (triangle_descriptor_min_edge_m_ <= 0.0) {
-    triangle_descriptor_min_edge_m_ = 2.0;
-  }
-  if (triangle_descriptor_max_edge_m_ <= triangle_descriptor_min_edge_m_) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "triangle_descriptor_max_edge_m (%.3f) must exceed min_edge_m (%.3f); using min*5",
-      triangle_descriptor_max_edge_m_, triangle_descriptor_min_edge_m_);
-    triangle_descriptor_max_edge_m_ = triangle_descriptor_min_edge_m_ * 5.0;
-  }
-  if (triangle_descriptor_max_triangles_ < 100) {
-    triangle_descriptor_max_triangles_ = 100;
-  }
-  if (triangle_descriptor_edge_bin_m_ <= 0.0) {
-    triangle_descriptor_edge_bin_m_ = 1.0;
-  }
-  if (triangle_descriptor_quad_feature_bin_m_ < 0.0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "triangle_descriptor_quad_feature_bin_m must be >= 0 (0 = disabled); "
-      "resetting %.3f to 0",
-      triangle_descriptor_quad_feature_bin_m_);
-    triangle_descriptor_quad_feature_bin_m_ = 0.0;
-  }
-  if (triangle_descriptor_min_votes_ < 1) {
-    triangle_descriptor_min_votes_ = 1;
-  }
-  if (triangle_descriptor_min_inliers_ < 1) {
-    triangle_descriptor_min_inliers_ = 1;
-  }
-  if (triangle_descriptor_min_inlier_ratio_ < 0.0) {
-    triangle_descriptor_min_inlier_ratio_ = 0.0;
-  } else if (triangle_descriptor_min_inlier_ratio_ > 1.0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "triangle_descriptor_min_inlier_ratio must be in [0, 1]; clamping %.3f to 1.0",
-      triangle_descriptor_min_inlier_ratio_);
-    triangle_descriptor_min_inlier_ratio_ = 1.0;
-  }
-  if (triangle_descriptor_max_pairs_ < 3) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "triangle_descriptor_max_pairs must be >= 3; clamping %d to 3",
-      triangle_descriptor_max_pairs_);
-    triangle_descriptor_max_pairs_ = 3;
-  }
-  if (triangle_descriptor_min_4th_point_agreements_ < 0) {
-    triangle_descriptor_min_4th_point_agreements_ = 0;
-  }
-  if (triangle_descriptor_fourth_point_max_distance_m_ <= 0.0) {
-    triangle_descriptor_fourth_point_max_distance_m_ = 2.0;
-  }
-  if (triangle_descriptor_inlier_translation_m_ <= 0.0) {
-    triangle_descriptor_inlier_translation_m_ = 2.0;
-  }
-  if (triangle_descriptor_inlier_rotation_deg_ <= 0.0) {
-    triangle_descriptor_inlier_rotation_deg_ = 5.0;
-  }
-  if (triangle_descriptor_exclude_recent_ < 0) {
-    triangle_descriptor_exclude_recent_ = 0;
-  }
-  if (triangle_verify_bev_max_distance_ <= 0.0) {
-    triangle_verify_bev_max_distance_ = 0.30;
-  }
-  if (
-    solid_descriptor_min_similarity_ <= -1.0 ||
-    solid_descriptor_min_similarity_ > 1.0)
-  {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "solid_descriptor_min_similarity must be in (-1, 1], resetting %.3f to 0.70",
-      solid_descriptor_min_similarity_);
-    solid_descriptor_min_similarity_ = 0.70;
-  }
-  if (solid_descriptor_sequence_window_ < 0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "solid_descriptor_sequence_window must be >= 0, clamping %d to 0",
-      solid_descriptor_sequence_window_);
-    solid_descriptor_sequence_window_ = 0;
-  }
-  if (
-    solid_descriptor_sequence_min_similarity_ <= -1.0 ||
-    solid_descriptor_sequence_min_similarity_ > 1.0)
-  {
-    solid_descriptor_sequence_min_similarity_ = solid_descriptor_min_similarity_;
-  }
-  if (solid_descriptor_pose_consistency_threshold_m_ == 0.0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "solid_descriptor_pose_consistency_threshold_m must be negative (disabled) or positive, "
-      "resetting 0.0 to disabled");
-    solid_descriptor_pose_consistency_threshold_m_ = -1.0;
-  }
-  if (three_d_bbs_min_level_res_ <= 0.0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "three_d_bbs_min_level_res must be positive, resetting %.3f to 1.0",
-      three_d_bbs_min_level_res_);
-    three_d_bbs_min_level_res_ = 1.0;
-  }
-  if (three_d_bbs_max_level_ < 1) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "three_d_bbs_max_level must be >= 1, clamping %d to 1",
-      three_d_bbs_max_level_);
-    three_d_bbs_max_level_ = 1;
-  }
-  if (three_d_bbs_score_threshold_percentage_ <= 0.0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "three_d_bbs_score_threshold_percentage must be positive, resetting %.3f to 0.25",
-      three_d_bbs_score_threshold_percentage_);
-    three_d_bbs_score_threshold_percentage_ = 0.25;
-  }
-  if (three_d_bbs_voxel_leaf_size_ <= 0.0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "three_d_bbs_voxel_leaf_size must be positive, resetting %.3f to 1.0",
-      three_d_bbs_voxel_leaf_size_);
-    three_d_bbs_voxel_leaf_size_ = 1.0;
-  }
-  if (three_d_bbs_source_submap_num_ < 1) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "three_d_bbs_source_submap_num must be >= 1, clamping %d to 1",
-      three_d_bbs_source_submap_num_);
-    three_d_bbs_source_submap_num_ = 1;
-  }
-  if (three_d_bbs_target_submap_radius_ < 0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "three_d_bbs_target_submap_radius must be >= 0, clamping %d to 0",
-      three_d_bbs_target_submap_radius_);
-    three_d_bbs_target_submap_radius_ = 0;
-  }
-  if (three_d_bbs_translation_search_margin_m_ <= 0.0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "three_d_bbs_translation_search_margin_m must be positive, resetting %.3f to 15.0",
-      three_d_bbs_translation_search_margin_m_);
-    three_d_bbs_translation_search_margin_m_ = 15.0;
-  }
-  if (three_d_bbs_roll_pitch_search_deg_ <= 0.0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "three_d_bbs_roll_pitch_search_deg must be positive, resetting %.3f to 10.0",
-      three_d_bbs_roll_pitch_search_deg_);
-    three_d_bbs_roll_pitch_search_deg_ = 10.0;
-  }
-  if (three_d_bbs_yaw_search_deg_ <= 0.0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "three_d_bbs_yaw_search_deg must be positive, resetting %.3f to 180.0",
-      three_d_bbs_yaw_search_deg_);
-    three_d_bbs_yaw_search_deg_ = 180.0;
-  }
-  if (dynamic_object_filter_voxel_size_ <= 0.0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "dynamic_object_filter_voxel_size must be positive, resetting %.3f to 0.3",
-      dynamic_object_filter_voxel_size_);
-    dynamic_object_filter_voxel_size_ = 0.3;
-  }
-  if (dynamic_object_filter_min_observations_ < 1) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "dynamic_object_filter_min_observations must be >= 1, clamping %d to 1",
-      dynamic_object_filter_min_observations_);
-    dynamic_object_filter_min_observations_ = 1;
-  }
-  if (dynamic_object_filter_temporal_window_ < 0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "dynamic_object_filter_temporal_window must be >= 0, clamping %d to 0",
-      dynamic_object_filter_temporal_window_);
-    dynamic_object_filter_temporal_window_ = 0;
-  }
-  if (dynamic_object_filter_max_range_from_sensor_m_ <= 0.0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "dynamic_object_filter_max_range_from_sensor_m must be positive, resetting %.3f to 30.0",
-      dynamic_object_filter_max_range_from_sensor_m_);
-    dynamic_object_filter_max_range_from_sensor_m_ = 30.0;
-  }
-  if (planar_map_filter_voxel_size_ <= 0.0) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "planar_map_filter_voxel_size must be positive, resetting %.3f to 0.1",
-      planar_map_filter_voxel_size_);
-    planar_map_filter_voxel_size_ = 0.1;
-  }
-  if (planar_map_filter_min_neighbors_ < 3) {
-    RCLCPP_WARN(
-      node_.get_logger(),
-      "planar_map_filter_min_neighbors must be >= 3, clamping %d to 3",
-      planar_map_filter_min_neighbors_);
-    planar_map_filter_min_neighbors_ = 3;
-  }
-  planar_map_filter_max_small_eigenvalue_ratio_ = std::max(
-    0.0, std::min(1.0, planar_map_filter_max_small_eigenvalue_ratio_));
-  planar_map_filter_min_middle_eigenvalue_ratio_ = std::max(
-    0.0, std::min(1.0, planar_map_filter_min_middle_eigenvalue_ratio_));
-  planar_map_filter_min_retained_ratio_ = std::max(
-    0.0, std::min(1.0, planar_map_filter_min_retained_ratio_));
-  std::cout << "registration_method:" << registration_method << std::endl;
-  std::cout << "voxel_leaf_size[m]:" << voxel_leaf_size << std::endl;
-  std::cout << "ndt_resolution[m]:" << ndt_resolution << std::endl;
-  std::cout << "ndt_num_threads:" << ndt_num_threads << std::endl;
-  std::cout << "threshold_loop_closure_score:" << threshold_loop_closure_score_ << std::endl;
-  std::cout << "scan_context_loop_closure_score_threshold:" <<
-    scan_context_loop_closure_score_threshold_ << std::endl;
-  std::cout << "distance_loop_closure[m]:" << distance_loop_closure_ << std::endl;
-  std::cout << "range_of_searching_loop_closure[m]:" << range_of_searching_loop_closure_ <<
-    std::endl;
-  std::cout << "search_submap_num:" << search_submap_num_ << std::endl;
-  std::cout << "loop_search_query_stride:" << loop_search_query_stride_ << std::endl;
-  std::cout << "max_loop_candidate_count:" << max_loop_candidate_count_ << std::endl;
-  std::cout << "loop_edge_dedup_index_window:" << loop_edge_dedup_index_window_ << std::endl;
-  std::cout << "loop_max_translation_delta[m]:" << loop_max_translation_delta_ << std::endl;
-  std::cout << "loop_max_rotation_delta[deg]:" << loop_max_rotation_delta_deg_ << std::endl;
-  std::cout << "loop_min_overlap_ratio:" << loop_min_overlap_ratio_ << std::endl;
-  std::cout << "loop_min_overlap_ratio_large_correction:" <<
-    loop_min_overlap_ratio_large_correction_ << std::endl;
-  std::cout << "loop_overlap_large_correction_translation_m[m]:" <<
-    loop_overlap_large_correction_translation_m_ << std::endl;
-  std::cout << "loop_overlap_max_distance_m[m]:" << loop_overlap_max_distance_m_ << std::endl;
-  std::cout << "loop_max_translation_delta_descriptor[m]:" <<
-    loop_max_translation_delta_descriptor_ << std::endl;
-  std::cout << "loop_max_rotation_delta_deg_descriptor[deg]:" <<
-    loop_max_rotation_delta_deg_descriptor_ << std::endl;
-  std::cout << "num_adjacent_pose_cnstraints:" << num_adjacent_pose_cnstraints_ << std::endl;
-  std::cout << "adjacent_edge_info_weight:" << adjacent_edge_info_weight_ << std::endl;
-  std::cout << "adjacent_edge_info_auto_scale:" << std::boolalpha
-            << adjacent_edge_info_auto_scale_ << std::endl;
-  if (adjacent_edge_info_auto_scale_) {
-    std::cout << "adjacent_edge_info_auto_scale_split_trans_rot:" << std::boolalpha
-              << adjacent_edge_info_auto_scale_split_trans_rot_ << std::endl;
-    if (adjacent_edge_info_auto_scale_split_trans_rot_) {
-      std::cout << "adjacent_edge_info_weight_trans:"
-                << adjacent_edge_info_weight_trans_ << std::endl;
-      std::cout << "adjacent_edge_info_weight_rot:"
-                << adjacent_edge_info_weight_rot_ << std::endl;
-      std::cout << "adjacent_edge_info_auto_scale_target_nis_trans:"
-                << adjacent_edge_info_auto_scale_target_nis_trans_ << std::endl;
-      std::cout << "adjacent_edge_info_auto_scale_target_nis_rot:"
-                << adjacent_edge_info_auto_scale_target_nis_rot_ << std::endl;
-    } else {
-      std::cout << "adjacent_edge_info_auto_scale_target_nis:"
-                << adjacent_edge_info_auto_scale_target_nis_ << std::endl;
-    }
-  }
-  std::cout << "loop_edge_info_weight:" << loop_edge_info_weight_ << std::endl;
-  std::cout << "loop_edge_robust_kernel_delta:" << loop_edge_robust_kernel_delta_ << std::endl;
-  std::cout << "loop_edge_robust_kernel_type:"
-            << graphslam::robust::loopEdgeKernelTypeName(
-    graphslam::robust::parseLoopEdgeKernelType(loop_edge_robust_kernel_type_))
-            << std::endl;
-  std::cout << "use_save_map_in_loop:" << std::boolalpha << use_save_map_in_loop_ << std::endl;
-  std::cout << "debug_flag:" << std::boolalpha << debug_flag_ << std::endl;
-  std::cout << "use_scan_context:" << std::boolalpha << use_scan_context_ << std::endl;
-  if (use_scan_context_) {
-    std::cout << "scan_context_threshold:" << scan_context_threshold_ << std::endl;
-    std::cout << "scan_context_query_stride:" <<
-      std::max(1, scan_context_query_stride_) << std::endl;
-    std::cout << "scan_context_exclude_recent:" <<
-      std::max(1, scan_context_exclude_recent_) << std::endl;
-    std::cout << "prefer_scan_context_candidates:" << std::boolalpha <<
-      prefer_scan_context_candidates_ << std::endl;
-    std::cout << "use_3d_bbs_for_scan_context:" << std::boolalpha <<
-      use_3d_bbs_for_scan_context_ << std::endl;
-    if (use_3d_bbs_for_scan_context_) {
-      std::cout << "three_d_bbs_min_level_res:" << three_d_bbs_min_level_res_ << std::endl;
-      std::cout << "three_d_bbs_max_level:" << three_d_bbs_max_level_ << std::endl;
-      std::cout << "three_d_bbs_score_threshold_percentage:" <<
-        three_d_bbs_score_threshold_percentage_ << std::endl;
-      std::cout << "three_d_bbs_timeout_msec:" << three_d_bbs_timeout_msec_ << std::endl;
-      std::cout << "three_d_bbs_num_threads:" << three_d_bbs_num_threads_ << std::endl;
-      std::cout << "three_d_bbs_voxel_leaf_size:" << three_d_bbs_voxel_leaf_size_ << std::endl;
-      std::cout << "three_d_bbs_source_submap_num:" << three_d_bbs_source_submap_num_ <<
-        std::endl;
-      std::cout << "three_d_bbs_target_submap_radius:" << three_d_bbs_target_submap_radius_ <<
-        std::endl;
-      std::cout << "three_d_bbs_translation_search_margin_m:" <<
-        three_d_bbs_translation_search_margin_m_ << std::endl;
-      std::cout << "three_d_bbs_roll_pitch_search_deg:" <<
-        three_d_bbs_roll_pitch_search_deg_ << std::endl;
-      std::cout << "three_d_bbs_yaw_search_deg:" << three_d_bbs_yaw_search_deg_ << std::endl;
-    }
-  }
-  std::cout << "use_bev_descriptor:" << std::boolalpha << use_bev_descriptor_ << std::endl;
-  if (use_bev_descriptor_) {
-    std::cout << "bev_descriptor_threshold:" << bev_descriptor_threshold_ << std::endl;
-    std::cout << "bev_descriptor_grid_size_m:" << bev_descriptor_grid_size_m_ << std::endl;
-    std::cout << "bev_descriptor_grid_cells:" << bev_descriptor_grid_cells_ << std::endl;
-    std::cout << "bev_descriptor_yaw_bins:" << bev_descriptor_yaw_bins_ << std::endl;
-    std::cout << "bev_descriptor_sequence_window:" << bev_descriptor_sequence_window_ <<
-      std::endl;
-    std::cout << "bev_descriptor_sequence_threshold:" << bev_descriptor_sequence_threshold_ <<
-      std::endl;
-    std::cout << "bev_descriptor_pose_consistency_threshold_m:" <<
-      bev_descriptor_pose_consistency_threshold_m_ << std::endl;
-    std::cout << "bev_descriptor_max_euclidean_distance_m:" <<
-      bev_descriptor_max_euclidean_distance_m_ << std::endl;
-    std::cout << "bev_descriptor_rerank_weight_m:" << bev_descriptor_rerank_weight_m_ <<
-      std::endl;
-    std::cout << "bev_use_mutual_visibility:" << std::boolalpha <<
-      bev_use_mutual_visibility_ << std::endl;
-    if (bev_use_mutual_visibility_) {
-      std::cout << "bev_mutual_visibility_min_overlap_ratio:" <<
-        bev_mutual_visibility_min_overlap_ratio_ << std::endl;
-      std::cout << "bev_mutual_visibility_occupancy_eps:" <<
-        bev_mutual_visibility_occupancy_eps_ << std::endl;
-    }
-  }
-  std::cout << "use_solid_descriptor:" << std::boolalpha << use_solid_descriptor_ << std::endl;
-  if (use_solid_descriptor_) {
-    std::cout << "solid_descriptor_min_similarity:" << solid_descriptor_min_similarity_ <<
-      std::endl;
-    std::cout << "solid_descriptor_sequence_window:" << solid_descriptor_sequence_window_ <<
-      std::endl;
-    std::cout << "solid_descriptor_sequence_min_similarity:" <<
-      solid_descriptor_sequence_min_similarity_ << std::endl;
-    std::cout << "solid_descriptor_pose_consistency_threshold_m:" <<
-      solid_descriptor_pose_consistency_threshold_m_ << std::endl;
-    std::cout << "solid_descriptor_max_euclidean_distance_m:" <<
-      solid_descriptor_max_euclidean_distance_m_ << std::endl;
-  }
-  std::cout << "use_triangle_descriptor:" << std::boolalpha <<
-    use_triangle_descriptor_ << std::endl;
-  if (use_triangle_descriptor_) {
-    std::cout << "triangle_descriptor_keypoint_mode:" <<
-      triangle_descriptor_keypoint_mode_ << std::endl;
-    std::cout << "triangle_descriptor_grid_size_m:" <<
-      triangle_descriptor_grid_size_m_ << std::endl;
-    std::cout << "triangle_descriptor_grid_cells:" <<
-      triangle_descriptor_grid_cells_ << std::endl;
-    std::cout << "triangle_descriptor_max_keypoints:" <<
-      triangle_descriptor_max_keypoints_ << std::endl;
-    std::cout << "triangle_descriptor_min_salience_m:" <<
-      triangle_descriptor_min_salience_m_ << std::endl;
-    std::cout << "triangle_descriptor_edge_voxel_size_m:" <<
-      triangle_descriptor_edge_voxel_size_m_ << std::endl;
-    std::cout << "triangle_descriptor_edge_neighbor_radius_m:" <<
-      triangle_descriptor_edge_neighbor_radius_m_ << std::endl;
-    std::cout << "triangle_descriptor_edge_min_neighbors:" <<
-      triangle_descriptor_edge_min_neighbors_ << std::endl;
-    std::cout << "triangle_descriptor_edge_min_edgeness:" <<
-      triangle_descriptor_edge_min_edgeness_ << std::endl;
-    std::cout << "triangle_descriptor_edge_nms_radius_m:" <<
-      triangle_descriptor_edge_nms_radius_m_ << std::endl;
-    std::cout << "triangle_descriptor_min_edge_m:" <<
-      triangle_descriptor_min_edge_m_ << std::endl;
-    std::cout << "triangle_descriptor_max_edge_m:" <<
-      triangle_descriptor_max_edge_m_ << std::endl;
-    std::cout << "triangle_descriptor_max_triangles:" <<
-      triangle_descriptor_max_triangles_ << std::endl;
-    std::cout << "triangle_descriptor_edge_bin_m:" <<
-      triangle_descriptor_edge_bin_m_ << std::endl;
-    std::cout << "triangle_descriptor_quad_feature_bin_m:" <<
-      triangle_descriptor_quad_feature_bin_m_ << std::endl;
-    std::cout << "triangle_descriptor_min_votes:" <<
-      triangle_descriptor_min_votes_ << std::endl;
-    std::cout << "triangle_descriptor_min_inliers:" <<
-      triangle_descriptor_min_inliers_ << std::endl;
-    std::cout << "triangle_descriptor_min_inlier_ratio:" <<
-      triangle_descriptor_min_inlier_ratio_ << std::endl;
-    std::cout << "triangle_descriptor_max_pairs:" <<
-      triangle_descriptor_max_pairs_ << std::endl;
-    std::cout << "triangle_descriptor_min_4th_point_agreements:" <<
-      triangle_descriptor_min_4th_point_agreements_ << std::endl;
-    std::cout << "triangle_descriptor_fourth_point_max_distance_m:" <<
-      triangle_descriptor_fourth_point_max_distance_m_ << std::endl;
-    std::cout << "triangle_descriptor_refine_se3_with_all_inliers:" <<
-      std::boolalpha << triangle_descriptor_refine_se3_with_all_inliers_ << std::endl;
-    std::cout << "triangle_descriptor_skip_ransac:" <<
-      std::boolalpha << triangle_descriptor_skip_ransac_ << std::endl;
-    std::cout << "triangle_descriptor_inlier_translation_m:" <<
-      triangle_descriptor_inlier_translation_m_ << std::endl;
-    std::cout << "triangle_descriptor_inlier_rotation_deg:" <<
-      triangle_descriptor_inlier_rotation_deg_ << std::endl;
-    std::cout << "triangle_descriptor_exclude_recent:" <<
-      triangle_descriptor_exclude_recent_ << std::endl;
-  }
-  std::cout << "use_dynamic_object_filter:" << std::boolalpha << use_dynamic_object_filter_ <<
-    std::endl;
-  if (use_dynamic_object_filter_) {
-    std::cout << "dynamic_object_filter_voxel_size:" << dynamic_object_filter_voxel_size_ <<
-      std::endl;
-    std::cout << "dynamic_object_filter_min_observations:" <<
-      dynamic_object_filter_min_observations_ << std::endl;
-    std::cout << "dynamic_object_filter_temporal_window:" <<
-      dynamic_object_filter_temporal_window_ << std::endl;
-    std::cout << "dynamic_object_filter_max_range_from_sensor_m:" <<
-      dynamic_object_filter_max_range_from_sensor_m_ << std::endl;
-  }
-  std::cout << "use_planar_map_filter:" << std::boolalpha << use_planar_map_filter_ << std::endl;
-  if (use_planar_map_filter_) {
-    std::cout << "planar_map_filter_voxel_size:" << planar_map_filter_voxel_size_ << std::endl;
-    std::cout << "planar_map_filter_min_neighbors:" << planar_map_filter_min_neighbors_ <<
-      std::endl;
-    std::cout << "planar_map_filter_max_small_eigenvalue_ratio:" <<
-      planar_map_filter_max_small_eigenvalue_ratio_ << std::endl;
-    std::cout << "planar_map_filter_min_middle_eigenvalue_ratio:" <<
-      planar_map_filter_min_middle_eigenvalue_ratio_ << std::endl;
-    std::cout << "planar_map_filter_min_retained_ratio:" <<
-      planar_map_filter_min_retained_ratio_ << std::endl;
-  }
-  node_.declare_parameter("use_odom_input", false);
-  node_.get_parameter("use_odom_input", use_odom_input_);
-  node_.declare_parameter("submap_distance_threshold", 1.5);
-  node_.get_parameter("submap_distance_threshold", submap_distance_threshold_);
-  node_.declare_parameter("odom_cloud_sync_queue_size", 100);
-  node_.get_parameter("odom_cloud_sync_queue_size", odom_cloud_sync_queue_size_);
-  // v0.8 Phase 1 report-only degeneracy diagnostics (opt-in, default off:
-  // empty path / false flag leaves default behavior untouched).
-  node_.declare_parameter("degeneracy_diagnostics_csv_path", std::string(""));
-  node_.get_parameter("degeneracy_diagnostics_csv_path", degeneracy_diagnostics_csv_path_);
-  node_.declare_parameter("save_degeneracy_report", false);
-  node_.get_parameter("save_degeneracy_report", save_degeneracy_report_);
-  std::cout << "use_odom_input:" << std::boolalpha << use_odom_input_ << std::endl;
-  if (use_odom_input_) {
-    std::cout << "submap_distance_threshold[m]:" << submap_distance_threshold_ << std::endl;
-  }
-  if (!degeneracy_diagnostics_csv_path_.empty()) {
-    std::cout << "degeneracy_diagnostics_csv_path:" << degeneracy_diagnostics_csv_path_ <<
-      std::endl;
-  }
-  std::cout << "save_degeneracy_report:" << std::boolalpha << save_degeneracy_report_ <<
-    std::endl;
-  if (!degeneracy_diagnostics_csv_path_.empty()) {
-    degeneracy_csv_ofs_.open(degeneracy_diagnostics_csv_path_);
+    config_.gnss_origin_min_samples_, config_.gnss_origin_consistency_threshold_m_);
+  graph_state_.configureLoopEdgeDedupWindow(config_.loop_edge_dedup_index_window_);
+  logGraphSlamConfig(config_, node_.get_logger());
+  if (!config_.degeneracy_diagnostics_csv_path_.empty()) {
+    degeneracy_csv_ofs_.open(config_.degeneracy_diagnostics_csv_path_);
     if (degeneracy_csv_ofs_.is_open()) {
       degeneracy_csv_ofs_ << degeneracy::degeneracyDiagnosticsCsvHeaderLine() << "\n";
     } else {
       RCLCPP_WARN(
         node_.get_logger(), "failed to open degeneracy_diagnostics_csv_path: %s (CSV disabled)",
-        degeneracy_diagnostics_csv_path_.c_str());
-      degeneracy_diagnostics_csv_path_.clear();
+        config_.degeneracy_diagnostics_csv_path_.c_str());
     }
   }
-  std::cout << "use_imu_preintegration:" << std::boolalpha << use_imu_preintegration_ << std::endl;
-  if (use_imu_preintegration_) {
-    std::cout << "imu_rotation_info_roll_pitch:" << imu_rotation_info_roll_pitch_ << std::endl;
-    std::cout << "imu_rotation_info_yaw:" << imu_rotation_info_yaw_ << std::endl;
-  }
-  if (use_gnss_) {
-    std::cout << "gnss_topic:" << gnss_topic_ << std::endl;
-    std::cout << "gnss_info_weight:" << gnss_info_weight_ << std::endl;
-    std::cout << "gnss_use_covariance_weighting:" << std::boolalpha <<
-      gnss_use_covariance_weighting_ << std::endl;
-    std::cout << "gnss_covariance_min_variance_m2:" << gnss_covariance_min_variance_m2_ <<
-      std::endl;
-    std::cout << "gnss_covariance_max_variance_m2:" << gnss_covariance_max_variance_m2_ <<
-      std::endl;
-    std::cout << "gnss_rtk_fix_max_horizontal_stddev_m:" <<
-      gnss_rtk_fix_max_horizontal_stddev_m_ << std::endl;
-    std::cout << "gnss_rtk_fix_weight_scale:" << gnss_rtk_fix_weight_scale_ << std::endl;
-    std::cout << "gnss_non_rtk_weight_scale:" << gnss_non_rtk_weight_scale_ << std::endl;
-    std::cout << "gnss_origin_min_samples:" << gnss_origin_min_samples_ << std::endl;
-    std::cout << "gnss_origin_consistency_threshold_m:"
-              << gnss_origin_consistency_threshold_m_ << std::endl;
-  }
-  std::cout << "------------------" << std::endl;
 
-  backend_->voxelgrid.setLeafSize(voxel_leaf_size, voxel_leaf_size, voxel_leaf_size);
+  backend_->voxelgrid.setLeafSize(
+    config_.voxel_leaf_size, config_.voxel_leaf_size, config_.voxel_leaf_size);
 
   backend_->registration =
-    backend_core::makeLoopRegistration(registration_method, ndt_resolution, ndt_num_threads);
+    backend_core::makeLoopRegistration(
+    config_.registration_method, config_.ndt_resolution, config_.ndt_num_threads);
   if (!backend_->registration) {
     RCLCPP_ERROR(node_.get_logger(), "invalid registration_method");
     exit(1);
   }
 
-  backend_core::DescriptorConfig descriptor_config;
-  descriptor_config.use_scan_context = use_scan_context_;
-  descriptor_config.use_bev_descriptor = use_bev_descriptor_;
-  descriptor_config.use_solid_descriptor = use_solid_descriptor_;
-  descriptor_config.use_triangle_descriptor = use_triangle_descriptor_;
-  descriptor_config.bev_descriptor_grid_size_m = bev_descriptor_grid_size_m_;
-  descriptor_config.bev_descriptor_grid_cells = bev_descriptor_grid_cells_;
-  descriptor_config.bev_descriptor_yaw_bins = bev_descriptor_yaw_bins_;
-  descriptor_config.triangle_descriptor_keypoint_mode = triangle_descriptor_keypoint_mode_;
-  descriptor_config.triangle_descriptor_grid_size_m = triangle_descriptor_grid_size_m_;
-  descriptor_config.triangle_descriptor_grid_cells = triangle_descriptor_grid_cells_;
-  descriptor_config.triangle_descriptor_min_salience_m = triangle_descriptor_min_salience_m_;
-  descriptor_config.triangle_descriptor_max_keypoints = triangle_descriptor_max_keypoints_;
-  descriptor_config.triangle_descriptor_edge_voxel_size_m =
-    triangle_descriptor_edge_voxel_size_m_;
-  descriptor_config.triangle_descriptor_edge_neighbor_radius_m =
-    triangle_descriptor_edge_neighbor_radius_m_;
-  descriptor_config.triangle_descriptor_edge_min_neighbors =
-    triangle_descriptor_edge_min_neighbors_;
-  descriptor_config.triangle_descriptor_edge_min_edgeness =
-    triangle_descriptor_edge_min_edgeness_;
-  descriptor_config.triangle_descriptor_edge_nms_radius_m =
-    triangle_descriptor_edge_nms_radius_m_;
-  descriptor_config.triangle_descriptor_min_edge_m = triangle_descriptor_min_edge_m_;
-  descriptor_config.triangle_descriptor_max_edge_m = triangle_descriptor_max_edge_m_;
-  descriptor_config.triangle_descriptor_max_triangles = triangle_descriptor_max_triangles_;
-  descriptor_config.triangle_descriptor_edge_bin_m = triangle_descriptor_edge_bin_m_;
-  descriptor_config.triangle_descriptor_quad_feature_bin_m =
-    triangle_descriptor_quad_feature_bin_m_;
-  backend_->core.configure(descriptor_config);
+  backend_->core.configure(makeDescriptorConfig(config_));
 
   initializePubSub();
 
@@ -1297,7 +179,7 @@ void GraphBasedSlamComponent::Impl::initializePubSub()
         // seeing the previous complete graph until the move-only commit.
         std::lock_guard<std::mutex> ingest_lock(submap_ingest_mtx_);
         lidarslam_msgs::msg::MapArray staged_map = *msg_ptr;
-        if (use_pcd_cache_) {
+        if (config_.use_pcd_cache_) {
           stageMapArrayCloudCache(staged_map);
         }
         graph_state_.replace(std::move(staged_map));
@@ -1309,13 +191,13 @@ void GraphBasedSlamComponent::Impl::initializePubSub()
     node_.create_subscription<lidarslam_msgs::msg::MapArray>(
     "map_array", rclcpp::QoS(rclcpp::KeepLast(1)).reliable(), map_array_callback);
 
-  if (use_odom_input_) {
+  if (config_.use_odom_input_) {
     // Deep queues so a long loop-search callback cannot overflow the
     // subscription histories and drop frames, plus stamp-based pairing so
     // the submap pose/cloud match is a function of the data, not of the
     // executor schedule. Reliability is kept as before (odom reliable,
     // cloud sensor-data/best-effort) for publisher compatibility.
-    const size_t sync_depth = static_cast<size_t>(std::max(odom_cloud_sync_queue_size_, 1));
+    const size_t sync_depth = static_cast<size_t>(std::max(config_.odom_cloud_sync_queue_size_, 1));
     rmw_qos_profile_t odom_qos = rmw_qos_profile_default;
     odom_qos.depth = sync_depth;
     rmw_qos_profile_t cloud_qos = rmw_qos_profile_sensor_data;
@@ -1346,7 +228,7 @@ void GraphBasedSlamComponent::Impl::initializePubSub()
     "modified_path",
     rclcpp::QoS(10));
 
-  if (use_imu_preintegration_) {
+  if (config_.use_imu_preintegration_) {
     auto imu_callback =
       [this](const sensor_msgs::msg::Imu::SharedPtr msg) -> void
       {
@@ -1357,14 +239,14 @@ void GraphBasedSlamComponent::Impl::initializePubSub()
     RCLCPP_INFO(node_.get_logger(), "IMU preintegration enabled, subscribed to /imu");
   }
 
-  if (use_gnss_) {
+  if (config_.use_gnss_) {
     gnss_sub_ = node_.create_subscription<sensor_msgs::msg::NavSatFix>(
-      gnss_topic_, rclcpp::SensorDataQoS(),
+      config_.gnss_topic_, rclcpp::SensorDataQoS(),
       [this](const sensor_msgs::msg::NavSatFix::SharedPtr msg) {receiveNavSatFix(*msg);});
     RCLCPP_INFO(
       node_.get_logger(),
       "GNSS constraints enabled, subscribed to %s",
-      gnss_topic_.c_str());
+      config_.gnss_topic_.c_str());
   }
 
   RCLCPP_INFO(node_.get_logger(), "initialization end");
@@ -1414,7 +296,7 @@ GraphBasedSlamComponent::Impl::makeFilteredLocalSubmapProvider(
              new pcl::PointCloud<pcl::PointXYZI>);
            Eigen::Affine3d reference_affine;
            tf2::fromMsg(map_array_msg.submaps[ref_idx].pose, reference_affine);
-           for (int k = 0; k < search_submap_num_ && (ref_idx - k) >= 0; ++k) {
+           for (int k = 0; k < config_.search_submap_num_ && (ref_idx - k) >= 0; ++k) {
              const int src_idx = ref_idx - k;
              pcl::PointCloud<pcl::PointXYZI>::Ptr cloud =
                loadSubmapCloud(map_array_msg, src_idx);
@@ -1468,18 +350,18 @@ void GraphBasedSlamComponent::Impl::drainEventDrivenLoopSearch()
     // Each search receives an explicit prefix length, avoiding one full
     // MapArray deep-copy per query without exposing future submaps to q.
     for (; query_idx < num_submaps && rclcpp::ok(); ++query_idx) {
-      if (debug_flag_) {
+      if (config_.debug_flag_) {
         RCLCPP_INFO(
           node_.get_logger(), "event-driven loop search, query submap %d of %d", query_idx,
           num_submaps);
       }
       backend_->core.ingestDescriptors(query_idx + 1, build_filtered_local_submap);
-      if (loop_search_schedule::shouldSearch(query_idx, loop_search_query_stride_)) {
+      if (loop_search_schedule::shouldSearch(query_idx, config_.loop_search_query_stride_)) {
         searchLoopForLatest(map_array_msg, loop_edges, query_idx + 1, query_idx);
-      } else if (debug_flag_) {
+      } else if (config_.debug_flag_) {
         RCLCPP_INFO(
           node_.get_logger(), "loop search registration skipped for query submap %d by stride %d",
-          query_idx, loop_search_query_stride_);
+          query_idx, config_.loop_search_query_stride_);
       }
       last_searched_submap_idx_ = query_idx;
     }
@@ -1510,88 +392,7 @@ void GraphBasedSlamComponent::Impl::searchLoopForLatest(
       return loadSubmapCloud(map_array_msg, idx);
     };
 
-  backend_core::LoopSearchConfig search_config;
-  search_config.search_submap_num = search_submap_num_;
-  search_config.prefer_scan_context_candidates = prefer_scan_context_candidates_;
-  search_config.use_3d_bbs_for_scan_context = use_3d_bbs_for_scan_context_;
-  search_config.three_d_bbs_source_submap_num = three_d_bbs_source_submap_num_;
-  search_config.three_d_bbs_target_submap_radius = three_d_bbs_target_submap_radius_;
-  search_config.three_d_bbs_voxel_leaf_size = three_d_bbs_voxel_leaf_size_;
-  search_config.three_d_bbs_min_level_res = three_d_bbs_min_level_res_;
-  search_config.three_d_bbs_max_level = three_d_bbs_max_level_;
-  search_config.three_d_bbs_score_threshold_percentage =
-    three_d_bbs_score_threshold_percentage_;
-  search_config.three_d_bbs_timeout_msec = three_d_bbs_timeout_msec_;
-  search_config.three_d_bbs_num_threads = three_d_bbs_num_threads_;
-  search_config.three_d_bbs_translation_search_margin_m =
-    three_d_bbs_translation_search_margin_m_;
-  search_config.three_d_bbs_roll_pitch_search_deg = three_d_bbs_roll_pitch_search_deg_;
-  search_config.three_d_bbs_yaw_search_deg = three_d_bbs_yaw_search_deg_;
-
-  candidate_aggregator::Config & aggregator_config = search_config.aggregator;
-  aggregator_config.debug = debug_flag_;
-  aggregator_config.max_loop_candidate_count = max_loop_candidate_count_;
-  aggregator_config.distance_loop_closure = distance_loop_closure_;
-  aggregator_config.range_of_searching_loop_closure = range_of_searching_loop_closure_;
-  aggregator_config.scan_context_threshold = scan_context_threshold_;
-  aggregator_config.scan_context_query_stride = std::max(1, scan_context_query_stride_);
-  aggregator_config.scan_context_exclude_recent = std::max(1, scan_context_exclude_recent_);
-  aggregator_config.bev_use_mutual_visibility = bev_use_mutual_visibility_;
-  aggregator_config.bev_mutual_visibility_min_overlap_ratio =
-    bev_mutual_visibility_min_overlap_ratio_;
-  aggregator_config.bev_mutual_visibility_occupancy_eps = bev_mutual_visibility_occupancy_eps_;
-  aggregator_config.bev_descriptor_yaw_bins = bev_descriptor_yaw_bins_;
-  aggregator_config.bev_descriptor_max_euclidean_distance_m =
-    bev_descriptor_max_euclidean_distance_m_;
-  aggregator_config.bev_descriptor_threshold = bev_descriptor_threshold_;
-  aggregator_config.bev_descriptor_sequence_window = bev_descriptor_sequence_window_;
-  aggregator_config.bev_descriptor_sequence_threshold = bev_descriptor_sequence_threshold_;
-  aggregator_config.bev_descriptor_pose_consistency_threshold_m =
-    bev_descriptor_pose_consistency_threshold_m_;
-  aggregator_config.bev_descriptor_rerank_weight_m = bev_descriptor_rerank_weight_m_;
-  aggregator_config.solid_descriptor_max_euclidean_distance_m =
-    solid_descriptor_max_euclidean_distance_m_;
-  aggregator_config.solid_descriptor_min_similarity = solid_descriptor_min_similarity_;
-  aggregator_config.solid_descriptor_sequence_window = solid_descriptor_sequence_window_;
-  aggregator_config.solid_descriptor_sequence_min_similarity =
-    solid_descriptor_sequence_min_similarity_;
-  aggregator_config.solid_descriptor_pose_consistency_threshold_m =
-    solid_descriptor_pose_consistency_threshold_m_;
-  aggregator_config.triangle_descriptor_exclude_recent = triangle_descriptor_exclude_recent_;
-  aggregator_config.triangle_descriptor_edge_bin_m = triangle_descriptor_edge_bin_m_;
-  aggregator_config.triangle_descriptor_quad_feature_bin_m =
-    triangle_descriptor_quad_feature_bin_m_;
-  aggregator_config.triangle_descriptor_inlier_translation_m =
-    triangle_descriptor_inlier_translation_m_;
-  aggregator_config.triangle_descriptor_inlier_rotation_deg =
-    triangle_descriptor_inlier_rotation_deg_;
-  aggregator_config.triangle_descriptor_min_inliers = triangle_descriptor_min_inliers_;
-  aggregator_config.triangle_descriptor_min_inlier_ratio = triangle_descriptor_min_inlier_ratio_;
-  aggregator_config.triangle_descriptor_max_pairs = triangle_descriptor_max_pairs_;
-  aggregator_config.triangle_descriptor_min_4th_point_agreements =
-    triangle_descriptor_min_4th_point_agreements_;
-  aggregator_config.triangle_descriptor_fourth_point_max_distance_m =
-    triangle_descriptor_fourth_point_max_distance_m_;
-  aggregator_config.triangle_descriptor_refine_se3_with_all_inliers =
-    triangle_descriptor_refine_se3_with_all_inliers_;
-  aggregator_config.triangle_descriptor_min_votes = triangle_descriptor_min_votes_;
-  aggregator_config.triangle_descriptor_skip_ransac = triangle_descriptor_skip_ransac_;
-  aggregator_config.triangle_verify_with_bev = triangle_verify_with_bev_;
-  aggregator_config.triangle_verify_bev_max_distance = triangle_verify_bev_max_distance_;
-
-  loop_verifier::GateConfig & gate_config = search_config.gates;
-  gate_config.generic_score_threshold = threshold_loop_closure_score_;
-  gate_config.scan_context_score_threshold = scan_context_loop_closure_score_threshold_;
-  gate_config.max_translation_m = loop_max_translation_delta_;
-  gate_config.max_rotation_deg = loop_max_rotation_delta_deg_;
-  gate_config.min_overlap_ratio = loop_min_overlap_ratio_;
-  gate_config.min_overlap_ratio_large_correction =
-    loop_min_overlap_ratio_large_correction_;
-  gate_config.overlap_large_correction_translation_m =
-    loop_overlap_large_correction_translation_m_;
-  gate_config.overlap_max_distance_m = loop_overlap_max_distance_m_;
-  gate_config.max_translation_descriptor_m = loop_max_translation_delta_descriptor_;
-  gate_config.max_rotation_descriptor_deg = loop_max_rotation_delta_deg_descriptor_;
+  const backend_core::LoopSearchConfig search_config = makeLoopSearchConfig(config_);
 
   const backend_core::LoopSearchOutput search_output = backend_->core.searchLoopForSubmap(
     submaps,
@@ -1629,7 +430,7 @@ void GraphBasedSlamComponent::Impl::searchLoopForLatest(
   query_prefix.cloud_coordinate = map_array_msg.cloud_coordinate;
   query_prefix.submaps.assign(
     map_array_msg.submaps.begin(), map_array_msg.submaps.begin() + num_submaps);
-  doPoseAdjustment(std::move(query_prefix), loop_edges, use_save_map_in_loop_);
+  doPoseAdjustment(std::move(query_prefix), loop_edges, config_.use_save_map_in_loop_);
 }
 
 void GraphBasedSlamComponent::Impl::doPoseAdjustment(
@@ -1653,7 +454,7 @@ void GraphBasedSlamComponent::Impl::doPoseAdjustment(
 
   /* IMU rotation constraints (pre-pass over the IMU buffer) */
   std::vector<pose_graph::ImuRotationConstraint> imu_constraints;
-  if (use_imu_preintegration_ && submaps_size > 1) {
+  if (config_.use_imu_preintegration_ && submaps_size > 1) {
     std::lock_guard<std::mutex> imu_lock(imu_mtx_);
     for (int i = 1; i < submaps_size; i++) {
       double t0 = rclcpp::Time(map_array_msg.submaps[i - 1].header.stamp).seconds();
@@ -1674,7 +475,7 @@ void GraphBasedSlamComponent::Impl::doPoseAdjustment(
       imu_constraint.measurement.translation() = odom_relative.translation();
       imu_constraints.push_back(imu_constraint);
     }
-    if (debug_flag_) {
+    if (config_.debug_flag_) {
       RCLCPP_INFO(
         node_.get_logger(), "Added %zu IMU rotation constraint edges", imu_constraints.size());
     }
@@ -1694,7 +495,7 @@ void GraphBasedSlamComponent::Impl::doPoseAdjustment(
 
   /* GNSS anchors (pre-pass: nearest-measurement match over the buffer) */
   std::vector<pose_graph::GnssConstraint> gnss_constraints;
-  if (use_gnss_ && gnss_origin_set_) {
+  if (config_.use_gnss_ && gnss_origin_set_) {
     std::lock_guard<std::mutex> gnss_lock(gnss_mtx_);
     int gnss_rtk_like_edges_added = 0;
 
@@ -1724,7 +525,7 @@ void GraphBasedSlamComponent::Impl::doPoseAdjustment(
         gnss_rtk_like_edges_added++;
       }
     }
-    if (debug_flag_) {
+    if (config_.debug_flag_) {
       RCLCPP_INFO(
         node_.get_logger(),
         "Added %zu GNSS position constraint edges (%d RTK-like by covariance)",
@@ -1738,7 +539,7 @@ void GraphBasedSlamComponent::Impl::doPoseAdjustment(
   // so the anchors govern the global pose — without this the anchors shear
   // the map (docs/research/gnss-constraint-first-validation.md).
   bool fix_first_vertex = true;
-  if (gnss_align_yaw_ && !gnss_constraints.empty()) {
+  if (config_.gnss_align_yaw_ && !gnss_constraints.empty()) {
     std::vector<Eigen::Vector2d> odom_xy;
     std::vector<Eigen::Vector2d> enu_xy;
     odom_xy.reserve(gnss_constraints.size());
@@ -1749,7 +550,8 @@ void GraphBasedSlamComponent::Impl::doPoseAdjustment(
       enu_xy.emplace_back(gnss_constraint.position.x(), gnss_constraint.position.y());
     }
     const auto alignment = gnss_alignment::estimatePlanarAlignment(
-      odom_xy, enu_xy, gnss_yaw_alignment_min_anchors_, gnss_yaw_alignment_min_baseline_m_);
+      odom_xy, enu_xy, config_.gnss_yaw_alignment_min_anchors_,
+        config_.gnss_yaw_alignment_min_baseline_m_);
     if (alignment.valid) {
       Eigen::Isometry3d enu_from_odom = Eigen::Isometry3d::Identity();
       enu_from_odom.linear() =
@@ -1765,7 +567,7 @@ void GraphBasedSlamComponent::Impl::doPoseAdjustment(
         "GNSS yaw alignment applied: yaw=%.2f deg, baseline=%.1f m, rms=%.2f m; "
         "vertex-0 gauge released, graph moves to the ENU frame",
         alignment.yaw_rad * 180.0 / M_PI, alignment.baseline_m, alignment.rms_residual_m);
-    } else if (debug_flag_) {
+    } else if (config_.debug_flag_) {
       RCLCPP_INFO(
         node_.get_logger(),
         "GNSS yaw alignment not applied (pairs=%zu, baseline=%.1f m); keeping the "
@@ -1774,61 +576,41 @@ void GraphBasedSlamComponent::Impl::doPoseAdjustment(
     }
   }
 
-  pose_graph::AdjacentEdgeConfig adjacent_cfg;
-  adjacent_cfg.num_adjacent_pose_constraints = num_adjacent_pose_cnstraints_;
-  adjacent_cfg.split_trans_rot = adjacent_edge_info_auto_scale_split_trans_rot_;
-  adjacent_cfg.info_weight = adjacent_edge_info_weight_;
-  adjacent_cfg.info_weight_trans = adjacent_edge_info_weight_trans_;
-  adjacent_cfg.info_weight_rot = adjacent_edge_info_weight_rot_;
+  const PoseGraphConfigBundle pose_graph_config = makePoseGraphConfig(
+    config_, adjacent_edge_info_weight_, adjacent_edge_info_weight_trans_,
+    adjacent_edge_info_weight_rot_);
 
-  pose_graph::LoopEdgeConfig loop_cfg;
-  loop_cfg.info_weight = loop_edge_info_weight_;
-  loop_cfg.robust_kernel_type = loop_edge_robust_kernel_type_;
-  loop_cfg.robust_kernel_delta = loop_edge_robust_kernel_delta_;
-
-  pose_graph::ImuEdgeConfig imu_cfg;
-  imu_cfg.info_roll_pitch = imu_rotation_info_roll_pitch_;
-  imu_cfg.info_yaw = imu_rotation_info_yaw_;
-
-  pose_graph::Chi2Collection chi2_collection = pose_graph::Chi2Collection::NONE;
-  if (adjacent_edge_info_auto_scale_) {
-    chi2_collection = adjacent_edge_info_auto_scale_split_trans_rot_ ?
-      pose_graph::Chi2Collection::SPLIT : pose_graph::Chi2Collection::UNIFIED;
-  }
-
-  std::string pose_graph_save_path = save_pose_graph_path_;
-  const std::string bundle_pose_graph_path = map_save_dir_ + "/pose_graph.g2o";
+  std::string pose_graph_save_path = config_.save_pose_graph_path_;
+  const std::string bundle_pose_graph_path = config_.map_save_dir_ + "/pose_graph.g2o";
   if (do_save_map) {
-    std::filesystem::create_directories(map_save_dir_);
+    std::filesystem::create_directories(config_.map_save_dir_);
     pose_graph_save_path = bundle_pose_graph_path;
   }
   const pose_graph::OptimizationResult opt_result = pose_graph::optimizePoseGraph(
     submap_nodes, loop_constraints, imu_constraints, gnss_constraints,
-    adjacent_cfg, loop_cfg, imu_cfg, chi2_collection,
+    pose_graph_config.adjacent, pose_graph_config.loop, pose_graph_config.imu,
+    pose_graph_config.chi2_collection,
     fix_first_vertex, /*iterations=*/ 10, pose_graph_save_path);
 
-  if (do_save_map && !save_pose_graph_path_.empty() &&
-    std::filesystem::path(save_pose_graph_path_).lexically_normal() !=
+  if (do_save_map && !config_.save_pose_graph_path_.empty() &&
+    std::filesystem::path(config_.save_pose_graph_path_).lexically_normal() !=
     std::filesystem::path(bundle_pose_graph_path).lexically_normal())
   {
     std::error_code copy_error;
     std::filesystem::copy_file(
-      bundle_pose_graph_path, save_pose_graph_path_,
+      bundle_pose_graph_path, config_.save_pose_graph_path_,
       std::filesystem::copy_options::overwrite_existing, copy_error);
     if (copy_error) {
       RCLCPP_WARN(
         node_.get_logger(), "failed to copy pose graph to configured path %s: %s",
-        save_pose_graph_path_.c_str(), copy_error.message().c_str());
+        config_.save_pose_graph_path_.c_str(), copy_error.message().c_str());
     }
   }
 
-  if (adjacent_edge_info_auto_scale_ && submaps_size > 1) {
-    graphslam::detail::AutoScaleConfig cfg;
-    cfg.ema_alpha = adjacent_edge_info_auto_scale_ema_alpha_;
-    cfg.min_scale = adjacent_edge_info_auto_scale_min_;
-    cfg.max_scale = adjacent_edge_info_auto_scale_max_;
+  if (config_.adjacent_edge_info_auto_scale_ && submaps_size > 1) {
+    graphslam::detail::AutoScaleConfig cfg = pose_graph_config.auto_scale;
 
-    if (adjacent_edge_info_auto_scale_split_trans_rot_) {
+    if (config_.adjacent_edge_info_auto_scale_split_trans_rot_) {
       // Level 2: split the post-opt residuals into translation / rotation
       // blocks and rescale w_trans and w_rot independently (the chi2
       // vectors come back from optimizePoseGraph in edge order).
@@ -1837,12 +619,12 @@ void GraphBasedSlamComponent::Impl::doPoseAdjustment(
       const double median_chi2_rot =
         graphslam::detail::medianChi2(opt_result.adjacent_rot_chi2);
 
-      cfg.target_nis = adjacent_edge_info_auto_scale_target_nis_trans_;
+      cfg.target_nis = config_.adjacent_edge_info_auto_scale_target_nis_trans_;
       const double prev_w_trans = adjacent_edge_info_weight_trans_;
       adjacent_edge_info_weight_trans_ =
         graphslam::detail::nextScale(prev_w_trans, median_chi2_trans, cfg);
 
-      cfg.target_nis = adjacent_edge_info_auto_scale_target_nis_rot_;
+      cfg.target_nis = config_.adjacent_edge_info_auto_scale_target_nis_rot_;
       const double prev_w_rot = adjacent_edge_info_weight_rot_;
       adjacent_edge_info_weight_rot_ =
         graphslam::detail::nextScale(prev_w_rot, median_chi2_rot, cfg);
@@ -1851,15 +633,15 @@ void GraphBasedSlamComponent::Impl::doPoseAdjustment(
         node_.get_logger(),
         "[auto_scale_split] trans median_chi2=%.3f target=%.3f w_trans=%.3f -> %.3f | "
         "rot median_chi2=%.3f target=%.3f w_rot=%.3f -> %.3f (n=%zu)",
-        median_chi2_trans, adjacent_edge_info_auto_scale_target_nis_trans_,
+        median_chi2_trans, config_.adjacent_edge_info_auto_scale_target_nis_trans_,
         prev_w_trans, adjacent_edge_info_weight_trans_,
-        median_chi2_rot, adjacent_edge_info_auto_scale_target_nis_rot_,
+        median_chi2_rot, config_.adjacent_edge_info_auto_scale_target_nis_rot_,
         prev_w_rot, adjacent_edge_info_weight_rot_,
         opt_result.adjacent_trans_chi2.size());
     } else {
       const double median_chi2 = graphslam::detail::medianChi2(opt_result.adjacent_chi2);
 
-      cfg.target_nis = adjacent_edge_info_auto_scale_target_nis_;
+      cfg.target_nis = config_.adjacent_edge_info_auto_scale_target_nis_;
       const double prev_weight = adjacent_edge_info_weight_;
       adjacent_edge_info_weight_ =
         graphslam::detail::nextScale(prev_weight, median_chi2, cfg);
@@ -1880,7 +662,7 @@ void GraphBasedSlamComponent::Impl::doPoseAdjustment(
   path.header.frame_id = "map";
   pcl::PointCloud<pcl::PointXYZI>::Ptr map_ptr(new pcl::PointCloud<pcl::PointXYZI>());
   std::vector<TimedSubmapCloud> dynamic_filter_submaps;
-  if (do_save_map && use_dynamic_object_filter_) {
+  if (do_save_map && config_.use_dynamic_object_filter_) {
     dynamic_filter_submaps.reserve(submaps_size);
   }
   for (int i = 0; i < submaps_size; i++) {
@@ -1899,7 +681,7 @@ void GraphBasedSlamComponent::Impl::doPoseAdjustment(
     sensor_msgs::msg::PointCloud2::SharedPtr cloud_msg_ptr(new sensor_msgs::msg::PointCloud2);
     pcl::toROSMsg(*transformed_cloud_ptr, *cloud_msg_ptr);
     *map_ptr += *transformed_cloud_ptr;
-    if (do_save_map && use_dynamic_object_filter_) {
+    if (do_save_map && config_.use_dynamic_object_filter_) {
       dynamic_filter_submaps.push_back(
         TimedSubmapCloud{
           i,
@@ -1930,14 +712,10 @@ void GraphBasedSlamComponent::Impl::doPoseAdjustment(
   modified_map_pub_->publish(*map_msg_ptr);
   if (do_save_map) {
     pcl::PointCloud<pcl::PointXYZI>::Ptr map_to_save = map_ptr;
-    if (use_dynamic_object_filter_) {
-      DynamicObjectFilterConfig filter_config;
-      filter_config.voxel_size = dynamic_object_filter_voxel_size_;
-      filter_config.min_observations = dynamic_object_filter_min_observations_;
-      filter_config.temporal_window = dynamic_object_filter_temporal_window_;
-      filter_config.max_range_from_sensor_m = dynamic_object_filter_max_range_from_sensor_m_;
+    if (config_.use_dynamic_object_filter_) {
       const auto filter_result =
-        buildDynamicObjectFilteredMap(dynamic_filter_submaps, filter_config);
+        buildDynamicObjectFilteredMap(dynamic_filter_submaps,
+          makeDynamicObjectFilterConfig(config_));
       if (!filter_result.cloud->empty()) {
         map_to_save = filter_result.cloud;
       }
@@ -1977,22 +755,13 @@ void GraphBasedSlamComponent::Impl::receiveNavSatFix(const sensor_msgs::msg::Nav
   }
 
   Eigen::Vector3d enu = geodeticToEnu(msg.latitude, msg.longitude, msg.altitude);
-  detail::GnssWeightingConfig weighting_config;
-  weighting_config.base_info_weight = gnss_info_weight_;
-  weighting_config.vertical_weight_scale = 0.1;
-  weighting_config.use_covariance_weighting = gnss_use_covariance_weighting_;
-  weighting_config.covariance_min_variance_m2 = gnss_covariance_min_variance_m2_;
-  weighting_config.covariance_max_variance_m2 = gnss_covariance_max_variance_m2_;
-  weighting_config.rtk_fix_max_horizontal_stddev_m = gnss_rtk_fix_max_horizontal_stddev_m_;
-  weighting_config.rtk_fix_weight_scale = gnss_rtk_fix_weight_scale_;
-  weighting_config.non_rtk_weight_scale = gnss_non_rtk_weight_scale_;
   const detail::GnssConstraintWeights gnss_weights =
-    detail::computeGnssConstraintWeights(msg, weighting_config);
+    detail::computeGnssConstraintWeights(msg, makeGnssWeightingConfig(config_));
   const double receive_time_sec = node_.get_clock()->now().seconds();
   const double header_time_sec = rclcpp::Time(msg.header.stamp).seconds();
   const detail::GnssTimestampResolution stamp_resolution =
     detail::resolveGnssMeasurementStamp(
-    header_time_sec, receive_time_sec, gnss_header_stamp_max_skew_sec_);
+    header_time_sec, receive_time_sec, config_.gnss_header_stamp_max_skew_sec_);
   GnssEnu g;
   g.stamp = stamp_resolution.stamp_sec;
   g.x = enu.x();
@@ -2006,17 +775,17 @@ void GraphBasedSlamComponent::Impl::receiveNavSatFix(const sensor_msgs::msg::Nav
   g.horizontal_stddev_m = gnss_weights.horizontal_stddev_m;
   gnss_buffer_.push_back(g);
 
-  if (debug_flag_ && stamp_resolution.used_fallback) {
+  if (config_.debug_flag_ && stamp_resolution.used_fallback) {
     RCLCPP_WARN_THROTTLE(
       node_.get_logger(),
       *node_.get_clock(),
       5000,
       "GNSS header stamp %.3f s differs from receive time %.3f s by more than "
       "%.3f s; using receive time",
-      header_time_sec, receive_time_sec, gnss_header_stamp_max_skew_sec_);
+      header_time_sec, receive_time_sec, config_.gnss_header_stamp_max_skew_sec_);
   }
 
-  if (debug_flag_ && gnss_weights.covariance_valid) {
+  if (config_.debug_flag_ && gnss_weights.covariance_valid) {
     RCLCPP_INFO_THROTTLE(
       node_.get_logger(),
       *node_.get_clock(),
@@ -2064,7 +833,7 @@ void GraphBasedSlamComponent::Impl::tryInitializeGnssOrigin(double lat, double l
   RCLCPP_INFO(
     node_.get_logger(),
     "GNSS origin set from %d consistent fixes: lat=%.8f, lon=%.8f, alt=%.2f",
-    gnss_origin_min_samples_, gnss_origin_lat_, gnss_origin_lon_, gnss_origin_alt_);
+    config_.gnss_origin_min_samples_, gnss_origin_lat_, gnss_origin_lon_, gnss_origin_alt_);
 }
 
 Eigen::Vector3d GraphBasedSlamComponent::Impl::geodeticToEnu(
@@ -2141,7 +910,7 @@ void GraphBasedSlamComponent::Impl::receiveSyncedOdomCloud(
   if (!std::isfinite(pos.x()) || !std::isfinite(pos.y()) || !std::isfinite(pos.z())) {
     return;
   }
-  if (debug_flag_ && !first_synced_input_logged_) {
+  if (config_.debug_flag_ && !first_synced_input_logged_) {
     first_synced_input_logged_ = true;
     RCLCPP_INFO(
       node_.get_logger(), "First synced odom+cloud pair: (%.2f, %.2f, %.2f), %zu bytes", pos.x(),
@@ -2157,7 +926,7 @@ void GraphBasedSlamComponent::Impl::recordScanDegeneracy(const nav_msgs::msg::Od
   // the two diagnostics outputs was requested, so the default path stays
   // byte-for-byte identical in behavior and cost.
   const bool csv_enabled = degeneracy_csv_ofs_.is_open();
-  if (!csv_enabled && !save_degeneracy_report_) {
+  if (!csv_enabled && !config_.save_degeneracy_report_) {
     return;
   }
 
@@ -2169,14 +938,14 @@ void GraphBasedSlamComponent::Impl::recordScanDegeneracy(const nav_msgs::msg::Od
   if (csv_enabled) {
     degeneracy_csv_ofs_ << degeneracy::degeneracyDiagnosticsCsvRowLine(stamp_sec, result) << "\n";
   }
-  if (save_degeneracy_report_) {
+  if (config_.save_degeneracy_report_) {
     degeneracy_accumulator_.add(stamp_sec, result);
   }
 }
 
 void GraphBasedSlamComponent::Impl::writeDegeneracyReport()
 {
-  if (!save_degeneracy_report_) {
+  if (!config_.save_degeneracy_report_) {
     return;
   }
   // Best-effort, same as the other map-bundle artifacts
@@ -2187,7 +956,7 @@ void GraphBasedSlamComponent::Impl::writeDegeneracyReport()
     std::lock_guard<std::mutex> lock(degeneracy_mtx_);
     summary = degeneracy_accumulator_.summary();
   }
-  const std::string report_path = map_save_dir_ + "/degeneracy_report.yaml";
+  const std::string report_path = config_.map_save_dir_ + "/degeneracy_report.yaml";
   std::ofstream report(report_path);
   if (!report.is_open()) {
     RCLCPP_WARN(node_.get_logger(), "failed to write degeneracy report: %s", report_path.c_str());
@@ -2212,7 +981,7 @@ void GraphBasedSlamComponent::Impl::tryCreateSubmap(
 
   // Check distance threshold (semantics pinned by test_submap_creation.cpp)
   const submap_creation::Decision decision = submap_creation::evaluate(
-    pos, last_submap_position_valid_, last_submap_position_, submap_distance_threshold_);
+    pos, last_submap_position_valid_, last_submap_position_, config_.submap_distance_threshold_);
   if (!decision.create) {return;}
   accumulated_distance_ += decision.distance;
   last_submap_position_ = pos;
@@ -2228,7 +997,7 @@ void GraphBasedSlamComponent::Impl::tryCreateSubmap(
   submap.cloud.header.frame_id = odom_msg.child_frame_id;
 
   const int submap_idx = static_cast<int>(graph_state_.submapCount());
-  if (use_pcd_cache_) {
+  if (config_.use_pcd_cache_) {
     pcl::PointCloud<pcl::PointXYZI>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZI>);
     pcl::fromROSMsg(submap.cloud, *cloud);
     if (saveSubmapToPCD(submap_idx, cloud)) {
@@ -2281,7 +1050,7 @@ bool GraphBasedSlamComponent::Impl::saveSubmapToPCDUnlocked(
   int idx,
   const pcl::PointCloud<pcl::PointXYZI>::Ptr & cloud)
 {
-  std::string path = map_saver::submapCachePath(pcd_cache_dir_, idx);
+  std::string path = map_saver::submapCachePath(config_.pcd_cache_dir_, idx);
   if (pcl::io::savePCDFileBinaryCompressed(path, *cloud) == 0) {
     return true;
   }
@@ -2293,7 +1062,7 @@ pcl::PointCloud<pcl::PointXYZI>::Ptr GraphBasedSlamComponent::Impl::loadSubmapFr
 {
   std::lock_guard<std::mutex> cache_lock(pcd_cache_mtx_);
   auto cloud = std::make_shared<pcl::PointCloud<pcl::PointXYZI>>();
-  std::string path = map_saver::submapCachePath(pcd_cache_dir_, idx);
+  std::string path = map_saver::submapCachePath(config_.pcd_cache_dir_, idx);
   if (pcl::io::loadPCDFile(path, *cloud) == -1) {
     RCLCPP_WARN(node_.get_logger(), "Failed to load PCD: %s", path.c_str());
   }
@@ -2305,7 +1074,7 @@ pcl::PointCloud<pcl::PointXYZI>::Ptr GraphBasedSlamComponent::Impl::loadSubmapCl
   int idx)
 {
   pcl::PointCloud<pcl::PointXYZI>::Ptr cloud;
-  if (use_pcd_cache_) {
+  if (config_.use_pcd_cache_) {
     cloud = loadSubmapFromPCD(idx);
     if (!cloud->empty()) {
       return cloud;
@@ -2323,9 +1092,9 @@ void GraphBasedSlamComponent::Impl::writeMapBundleArtifacts(
   const LoopEdges & loop_edges,
   const std::vector<Eigen::Isometry3d> & optimized_poses)
 {
-  std::filesystem::create_directories(map_save_dir_);
+  std::filesystem::create_directories(config_.map_save_dir_);
 
-  const std::string trajectory_path = map_save_dir_ + "/trajectory_optimized.tum";
+  const std::string trajectory_path = config_.map_save_dir_ + "/trajectory_optimized.tum";
   std::ofstream trajectory(trajectory_path);
   if (!trajectory.is_open()) {
     RCLCPP_WARN(
@@ -2348,7 +1117,7 @@ void GraphBasedSlamComponent::Impl::writeMapBundleArtifacts(
     }
   }
 
-  const std::string loop_edges_path = map_save_dir_ + "/loop_edges.csv";
+  const std::string loop_edges_path = config_.map_save_dir_ + "/loop_edges.csv";
   std::ofstream loop_csv(loop_edges_path);
   if (!loop_csv.is_open()) {
     RCLCPP_WARN(node_.get_logger(), "failed to write loop edges: %s", loop_edges_path.c_str());
@@ -2376,19 +1145,19 @@ void GraphBasedSlamComponent::Impl::writeMapBundleArtifacts(
   manifest.frame_id = map_array_msg.header.frame_id.empty() ? "map" : map_array_msg.header.frame_id;
   manifest.submap_count = optimized_poses.size();
   manifest.loop_edge_count = loop_edges.size();
-  manifest.map_leaf_size = map_leaf_size_;
-  manifest.grid_size_x = map_grid_size_x_;
-  manifest.grid_size_y = map_grid_size_y_;
-  manifest.dynamic_object_filter = use_dynamic_object_filter_;
-  manifest.planar_map_filter = use_planar_map_filter_;
-  manifest.planar_map_filter_voxel_size = planar_map_filter_voxel_size_;
-  manifest.planar_map_filter_min_neighbors = planar_map_filter_min_neighbors_;
+  manifest.map_leaf_size = config_.map_leaf_size_;
+  manifest.grid_size_x = config_.map_grid_size_x_;
+  manifest.grid_size_y = config_.map_grid_size_y_;
+  manifest.dynamic_object_filter = config_.use_dynamic_object_filter_;
+  manifest.planar_map_filter = config_.use_planar_map_filter_;
+  manifest.planar_map_filter_voxel_size = config_.planar_map_filter_voxel_size_;
+  manifest.planar_map_filter_min_neighbors = config_.planar_map_filter_min_neighbors_;
   manifest.planar_map_filter_max_small_eigenvalue_ratio =
-    planar_map_filter_max_small_eigenvalue_ratio_;
+    config_.planar_map_filter_max_small_eigenvalue_ratio_;
   manifest.planar_map_filter_min_middle_eigenvalue_ratio =
-    planar_map_filter_min_middle_eigenvalue_ratio_;
-  manifest.planar_map_filter_min_retained_ratio = planar_map_filter_min_retained_ratio_;
-  const std::string manifest_path = map_save_dir_ + "/map_bundle.yaml";
+    config_.planar_map_filter_min_middle_eigenvalue_ratio_;
+  manifest.planar_map_filter_min_retained_ratio = config_.planar_map_filter_min_retained_ratio_;
+  const std::string manifest_path = config_.map_save_dir_ + "/map_bundle.yaml";
   std::ofstream manifest_file(manifest_path);
   if (!manifest_file.is_open()) {
     RCLCPP_WARN(
@@ -2411,7 +1180,7 @@ void GraphBasedSlamComponent::Impl::saveGridDividedMap(
   }
 
   // Create output directory (clean existing PCD files to prevent orphans)
-  std::string out_dir = map_save_dir_ + "/pointcloud_map";
+  std::string out_dir = config_.map_save_dir_ + "/pointcloud_map";
   if (std::filesystem::exists(out_dir)) {
     for (auto & entry : std::filesystem::directory_iterator(out_dir)) {
       if (entry.path().extension() == ".pcd" || entry.path().extension() == ".yaml") {
@@ -2425,26 +1194,20 @@ void GraphBasedSlamComponent::Impl::saveGridDividedMap(
   pcl::PointCloud<pcl::PointXYZI>::Ptr downsampled(new pcl::PointCloud<pcl::PointXYZI>);
   pcl::VoxelGrid<pcl::PointXYZI> vg;
   vg.setInputCloud(map);
-  vg.setLeafSize(map_leaf_size_, map_leaf_size_, map_leaf_size_);
+  vg.setLeafSize(config_.map_leaf_size_, config_.map_leaf_size_, config_.map_leaf_size_);
   vg.filter(*downsampled);
 
-  std::cout << map_saver::downsampleLogLine(map->size(), downsampled->size(), map_leaf_size_)
+  std::cout << map_saver::downsampleLogLine(map->size(), downsampled->size(),
+      config_.map_leaf_size_)
             << std::endl;
 
   // Apply map-quality refinement to the same leaf-sized point set that is
   // exported and evaluated. Filtering before this VoxelGrid changes local
   // covariance according to raw submap sampling density and does not match
   // the saved-map contract.
-  if (use_planar_map_filter_) {
-    PlanarMapFilterConfig filter_config;
-    filter_config.voxel_size = planar_map_filter_voxel_size_;
-    filter_config.min_neighbors = planar_map_filter_min_neighbors_;
-    filter_config.max_small_eigenvalue_ratio =
-      planar_map_filter_max_small_eigenvalue_ratio_;
-    filter_config.min_middle_eigenvalue_ratio =
-      planar_map_filter_min_middle_eigenvalue_ratio_;
-    filter_config.min_retained_ratio = planar_map_filter_min_retained_ratio_;
-    const auto filter_result = buildPlanarMapFilteredMap(downsampled, filter_config);
+  if (config_.use_planar_map_filter_) {
+    const auto filter_result =
+      buildPlanarMapFilteredMap(downsampled, makePlanarMapFilterConfig(config_));
     downsampled = filter_result.cloud;
     RCLCPP_INFO(
       node_.get_logger(),
@@ -2464,9 +1227,7 @@ void GraphBasedSlamComponent::Impl::saveGridDividedMap(
   pcl::PointXYZI min_pt, max_pt;
   pcl::getMinMax3D(*downsampled, min_pt, max_pt);
 
-  map_saver::GridConfig grid_config;
-  grid_config.grid_size_x = map_grid_size_x_;
-  grid_config.grid_size_y = map_grid_size_y_;
+  const map_saver::GridConfig grid_config = makeGridConfig(config_);
   const map_saver::GridBounds grid_bounds =
     map_saver::computeGridBounds(min_pt.x, min_pt.y, max_pt.x, max_pt.y, grid_config);
 
@@ -2498,14 +1259,14 @@ void GraphBasedSlamComponent::Impl::saveGridDividedMap(
   meta.close();
 
   // Also save the full map as a single PCD for convenience
-  pcl::io::savePCDFileBinaryCompressed(map_save_dir_ + "/map.pcd", *downsampled);
+  pcl::io::savePCDFileBinaryCompressed(config_.map_save_dir_ + "/map.pcd", *downsampled);
 
   std::cout << map_saver::savedMapLogLine(saved, grid_config, out_dir) << std::endl;
   std::cout << "Total points: " << downsampled->size() << std::endl;
   std::cout << "Metadata: " << out_dir << "/pointcloud_map_metadata.yaml" << std::endl;
 
   // Always emit map_projector_info.yaml so Autoware can load pointcloud-only maps.
-  std::string proj_file = map_save_dir_ + "/map_projector_info.yaml";
+  std::string proj_file = config_.map_save_dir_ + "/map_projector_info.yaml";
   std::ofstream proj(proj_file);
   proj << map_saver::projectorInfoYaml(gnss_origin_set_, gnss_origin_lat_, gnss_origin_lon_);
   std::cout << map_saver::projectorInfoLogLine(gnss_origin_set_, proj_file) << std::endl;

--- a/graph_based_slam/src/graph_based_slam_component_impl.hpp
+++ b/graph_based_slam/src/graph_based_slam_component_impl.hpp
@@ -31,6 +31,7 @@
 #define GRAPH_BASED_SLAM_COMPONENT_IMPL_HPP_
 
 #include "graph_based_slam/graph_based_slam_component.h"
+#include "graph_slam_config.hpp"
 
 #include <Eigen/Core>  // NOLINT(build/include_order)
 #include <Eigen/Geometry>  // NOLINT(build/include_order)
@@ -81,6 +82,7 @@ private:
   struct BackendWorkspace;
 
   GraphBasedSlamComponent & node_;
+  const GraphSlamConfig config_;
   rclcpp::Clock clock_;
   tf2_ros::Buffer tfbuffer_;
   tf2_ros::TransformListener listener_;
@@ -98,6 +100,12 @@ private:
     // never blocks GraphStateStore snapshots during that I/O.
   std::mutex submap_ingest_mtx_;
   GraphStateStore graph_state_;
+
+  // Adaptive optimizer state is intentionally separate from the immutable
+  // startup intent represented by GraphSlamConfig.
+  double adjacent_edge_info_weight_ {1000.0};
+  double adjacent_edge_info_weight_trans_ {1000.0};
+  double adjacent_edge_info_weight_rot_ {1000.0};
 
   rclcpp::Subscription<lidarslam_msgs::msg::MapArray>::SharedPtr map_array_sub_;
   rclcpp::Publisher<lidarslam_msgs::msg::MapArray>::SharedPtr modified_map_array_pub_;
@@ -146,202 +154,15 @@ private:
     bool do_save_map);
   void publishMapAndPose();
 
-    // loop search parameter
-  double threshold_loop_closure_score_;
-  double scan_context_loop_closure_score_threshold_ {-1.0};
-  double distance_loop_closure_;
-  double range_of_searching_loop_closure_;
-  int search_submap_num_;
-  int loop_search_query_stride_ {1};
-  int max_loop_candidate_count_ {3};
-  int loop_edge_dedup_index_window_ {8};
-  double loop_max_translation_delta_ {15.0};
-  double loop_max_rotation_delta_deg_ {45.0};
-  double loop_min_overlap_ratio_ {0.0};
-  double loop_min_overlap_ratio_large_correction_ {0.0};
-  double loop_overlap_large_correction_translation_m_ {0.0};
-  double loop_overlap_max_distance_m_ {0.5};
-    // Per-source overrides for descriptor-based candidates (TRIANGLE,
-    // SCAN_CONTEXT, BEV, SOLID). When positive, replace the generic caps
-    // above for those sources only — DISTANCE keeps the strict default.
-    // -1.0 = disabled / fall back to the generic cap.
-  double loop_max_translation_delta_descriptor_ {-1.0};
-  double loop_max_rotation_delta_deg_descriptor_ {-1.0};
   int last_searched_submap_idx_ {-1};
     // Event-driven loop search (the only scheduling semantics since v0.7
     // Phase 0): loop search runs once per submap arrival in arrival order,
     // each query seeing exactly the map state up to itself. The legacy
     // wall-clock timer path and the retired deterministic_loop_scheduling
     // parameter (v0.4 D1) are gone.
-
-    // pose graph optimization parameter
-  int num_adjacent_pose_cnstraints_;
-  bool use_save_map_in_loop_ {true};
-  double adjacent_edge_info_weight_ {1000.0};
-  double loop_edge_info_weight_ {100.0};
-  double loop_edge_robust_kernel_delta_ {1.0};
-  std::string loop_edge_robust_kernel_type_ {"huber"};
-
-    // Auto-scaling for adjacent_edge_info_weight (Level 1: NIS median tracking).
-    // When enabled, the post-optimisation chi-squared of adjacent edges is
-    // monitored and adjacent_edge_info_weight_ is mixed toward
-    // current * target_nis / median_chi2 via EMA, clamped to [min, max].
-  bool adjacent_edge_info_auto_scale_ {false};
-  double adjacent_edge_info_auto_scale_target_nis_ {6.0};
-  double adjacent_edge_info_auto_scale_ema_alpha_ {0.3};
-  double adjacent_edge_info_auto_scale_min_ {1.0};
-  double adjacent_edge_info_auto_scale_max_ {1.0e6};
-    // Level 2: split the adjacent edge Information matrix into translation /
-    // rotation blocks (block-diag with weights w_trans, w_rot on I_3 each) so
-    // the auto-scaler can balance translation residuals and rotation residuals
-    // independently. When split mode is off the legacy single-scalar shape is
-    // used. Targets default to 3.0 (3 DoF per block, vs 6 for the unified
-    // mode); the EMA / min / max defaults are shared with Level 1.
-  bool adjacent_edge_info_auto_scale_split_trans_rot_ {false};
-  double adjacent_edge_info_weight_trans_ {-1.0};
-  double adjacent_edge_info_weight_rot_ {-1.0};
-  double adjacent_edge_info_auto_scale_target_nis_trans_ {3.0};
-  double adjacent_edge_info_auto_scale_target_nis_rot_ {3.0};
-
   int previous_submaps_num_ {0};
 
-  bool debug_flag_ {false};
-
-    // Scan Context loop detection
-  bool use_scan_context_ {false};
-  double scan_context_threshold_ {0.3};
-  int scan_context_query_stride_ {1};
-  int scan_context_exclude_recent_ {50};
-  bool prefer_scan_context_candidates_ {false};
-  bool use_bev_descriptor_ {false};
-  double bev_descriptor_threshold_ {0.20};
-  double bev_descriptor_grid_size_m_ {80.0};
-  int bev_descriptor_grid_cells_ {40};
-  int bev_descriptor_yaw_bins_ {24};
-  int bev_descriptor_sequence_window_ {0};
-  double bev_descriptor_sequence_threshold_ {-1.0};
-  double bev_descriptor_pose_consistency_threshold_m_ {-1.0};
-  double bev_descriptor_max_euclidean_distance_m_ {-1.0};
-  double bev_descriptor_rerank_weight_m_ {100.0};
-    // FOV-aware (mutual-visibility) distance for the BEV descriptor. Default
-    // off so the cosine-distance baseline stays unchanged on 360° LiDAR.
-  bool bev_use_mutual_visibility_ {false};
-  double bev_mutual_visibility_min_overlap_ratio_ {0.05};
-  double bev_mutual_visibility_occupancy_eps_ {0.5};
-    // Triangle (STD/BTC-style) descriptor place-recognition path. Built on the
-    // BSD-2 primitives in graph_based_slam/triangle_descriptor*. Default off
-    // so the existing default workflow stays unchanged.
-  bool use_triangle_descriptor_ {false};
-    // Tuned 2026-05-18 on NTU VIRAL tnp_01 ablation v4. The earlier loose
-    // defaults (60 cells, 0.3 m salience, 80 keypoints, 1.0 m edge bin)
-    // produced false-positive vote buckets where one stale submap collected
-    // every triangle match; this triggered randomly-rotating SE(3) outputs
-    // that NDT could not refine. The tighter values below caused triangle
-    // to vote across distinct submap ids (32 / 40 / 17 / 9) and produced
-    // the first triangle-sourced accepted loop closure (32 <-> 95, 0.49 m
-    // / 1.06 deg correction).
-  double triangle_descriptor_grid_size_m_ {60.0};
-  int triangle_descriptor_grid_cells_ {100};
-  int triangle_descriptor_max_keypoints_ {40};
-  double triangle_descriptor_min_salience_m_ {0.8};
-  double triangle_descriptor_min_edge_m_ {2.0};
-  double triangle_descriptor_max_edge_m_ {50.0};
-  int triangle_descriptor_max_triangles_ {3000};
-  double triangle_descriptor_edge_bin_m_ {0.5};
-    // Quad-hash 4th-point feature bin (m). 0 = disabled (legacy 3-edge hash).
-    // When > 0, the bucket key also includes the quantized distance from the
-    // triangle centroid to the nearest non-vertex keypoint, which makes the
-    // hash 4-dim and rejects wrong-but-agreeing triangle pairs in repeated
-    // geometry (corridor / parking-row / parallel column rows).
-  double triangle_descriptor_quad_feature_bin_m_ {0.0};
-    // Keypoint extractor mode. "bev_max_height" is the original outdoor-only
-    // extractor; "edge_3d" enables PCA-edgeness keypoints that survive in
-    // narrow-FOV / indoor scenes (MID-360, Newer College math_hard) where
-    // BEV max-height keypoint repeatability collapses.
-  std::string triangle_descriptor_keypoint_mode_ {"bev_max_height"};
-  double triangle_descriptor_edge_voxel_size_m_ {0.4};
-  double triangle_descriptor_edge_neighbor_radius_m_ {1.0};
-  int triangle_descriptor_edge_min_neighbors_ {6};
-  double triangle_descriptor_edge_min_edgeness_ {0.5};
-  double triangle_descriptor_edge_nms_radius_m_ {2.0};
-    // 5-inlier floor would have killed the only accepted loop in v4 (id=32
-    // emitted with 4 inliers), so settle on 4 as the compromise between
-    // recall and noise. Votes can stay loose because the tighter keypoint
-    // / hash params suppress most false buckets on their own.
-  int triangle_descriptor_min_votes_ {6};
-  int triangle_descriptor_min_inliers_ {4};
-    // Companion to min_inliers expressed as inliers / eval_n. Zero disables.
-    // Lets the operator combine a low absolute count with a meaningful
-    // relative-density floor (e.g. 4 inliers / max_pairs 64 = 6% vs the
-    // same 4 inliers / max_pairs 20 = 20%).
-  double triangle_descriptor_min_inlier_ratio_ {0.0};
-    // Cap on triangle pairs evaluated inside the RANSAC consensus check.
-    // Lower numbers make min_inlier_ratio more informative; default 64 keeps
-    // the previous behaviour.
-  int triangle_descriptor_max_pairs_ {64};
-    // 4-point consensus: after the 3-point RANSAC picks a winning SE(3),
-    // optionally project every query keypoint by that transform and require
-    // this many to fall within `fourth_point_max_distance_m` of some
-    // database keypoint in the chosen submap. Three points uniquely
-    // determine SE(3), so even a strong 3-point consensus can be fooled by
-    // repeated structure; the 4-point gate adds an independent constraint.
-    // Default 0 disables the gate.
-  int triangle_descriptor_min_4th_point_agreements_ {0};
-  double triangle_descriptor_fourth_point_max_distance_m_ {2.0};
-    // After the 3-point RANSAC picks the winning SE(3), re-estimate it by
-    // pooling the 3 * N_inliers point correspondences and running a single
-    // N-point Umeyama least-squares. Reduces translation noise by √N versus
-    // keeping the single 3-point hypothesis.
-  bool triangle_descriptor_refine_se3_with_all_inliers_ {false};
-    // Diagnostic-only: when true, run accumulateVotes (and submap_id selection)
-    // but skip the RANSAC findLoopCandidate inner loop. Used to isolate
-    // "executor scheduling cost of enabling triangle pipeline" from
-    // "RANSAC compute cost" when investigating APE drift on tuned configs.
-    // Default false (production).
-  bool triangle_descriptor_skip_ransac_ {false};
-  double triangle_descriptor_inlier_translation_m_ {2.0};
-  double triangle_descriptor_inlier_rotation_deg_ {5.0};
-  int triangle_descriptor_exclude_recent_ {4};
-    // Cross-verification: when both use_triangle_descriptor and
-    // use_bev_descriptor are true, gate the triangle candidate by also
-    // requiring the BEV mutual-visibility distance to clear an upper bound.
-    // Helps filter false positives caused by repeated geometry (corridors,
-    // facades) at the cost of triangle-only recall.
-  bool triangle_verify_with_bev_ {false};
-  double triangle_verify_bev_max_distance_ {0.30};
-  bool use_solid_descriptor_ {false};
-  double solid_descriptor_min_similarity_ {0.70};
-  int solid_descriptor_sequence_window_ {0};
-  double solid_descriptor_sequence_min_similarity_ {-1.0};
-  double solid_descriptor_pose_consistency_threshold_m_ {-1.0};
-  double solid_descriptor_max_euclidean_distance_m_ {-1.0};
-  bool use_3d_bbs_for_scan_context_ {false};
-  double three_d_bbs_min_level_res_ {1.0};
-  int three_d_bbs_max_level_ {3};
-  double three_d_bbs_score_threshold_percentage_ {0.25};
-  int three_d_bbs_timeout_msec_ {50};
-  int three_d_bbs_num_threads_ {0};
-  double three_d_bbs_voxel_leaf_size_ {1.0};
-  int three_d_bbs_source_submap_num_ {2};
-  int three_d_bbs_target_submap_radius_ {1};
-  double three_d_bbs_translation_search_margin_m_ {15.0};
-  double three_d_bbs_roll_pitch_search_deg_ {10.0};
-  double three_d_bbs_yaw_search_deg_ {180.0};
-  bool use_dynamic_object_filter_ {false};
-  double dynamic_object_filter_voxel_size_ {0.3};
-  int dynamic_object_filter_min_observations_ {2};
-  int dynamic_object_filter_temporal_window_ {5};
-  double dynamic_object_filter_max_range_from_sensor_m_ {30.0};
-  bool use_planar_map_filter_ {false};
-  double planar_map_filter_voxel_size_ {0.1};
-  int planar_map_filter_min_neighbors_ {3};
-  double planar_map_filter_max_small_eigenvalue_ratio_ {0.24};
-  double planar_map_filter_min_middle_eigenvalue_ratio_ {0.0};
-  double planar_map_filter_min_retained_ratio_ {0.90};
-
-    // PCD disk cache for memory-efficient submap storage
-  std::string pcd_cache_dir_;
-  bool use_pcd_cache_ {false};
+  // PCD disk cache for memory-efficient submap storage.
   std::mutex pcd_cache_mtx_;
   void stageMapArrayCloudCache(lidarslam_msgs::msg::MapArray & map_array_msg);
   bool saveSubmapToPCD(
@@ -355,11 +176,6 @@ private:
     const lidarslam_msgs::msg::MapArray & map_array_msg, int idx);
 
     // Autoware-compatible grid-divided PCD map output
-  std::string map_save_dir_ {"."};
-  std::string save_pose_graph_path_ {"pose_graph.g2o"};
-  double map_grid_size_x_ {20.0};
-  double map_grid_size_y_ {20.0};
-  double map_leaf_size_ {0.2};
   void saveGridDividedMap(
     const pcl::PointCloud<pcl::PointXYZI>::Ptr & map);
   void writeMapBundleArtifacts(
@@ -371,9 +187,6 @@ private:
     // streams are stamp-synchronized (message_filters ApproximateTime) so
     // the submap pose/cloud pairing no longer depends on executor timing
     // (v0.6 Phase 1; see docs/research/determinism-variance-attribution.md).
-  bool use_odom_input_ {false};
-  double submap_distance_threshold_ {1.5};
-  int odom_cloud_sync_queue_size_ {100};
   std::shared_ptr<message_filters::Subscriber<nav_msgs::msg::Odometry>> odom_sync_sub_;
   std::shared_ptr<message_filters::Subscriber<
       sensor_msgs::msg::PointCloud2>> cloud_sync_sub_;
@@ -401,8 +214,6 @@ private:
     // the map bundle at /map_save time (best-effort, like the other bundle
     // artifacts). Both default off: default behavior (and determinism) is
     // unchanged, and nothing here feeds back into any pose or edge weight.
-  std::string degeneracy_diagnostics_csv_path_;
-  bool save_degeneracy_report_ {false};
   std::mutex degeneracy_mtx_;
   std::ofstream degeneracy_csv_ofs_;
   degeneracy::DegeneracyReportAccumulator degeneracy_accumulator_;
@@ -410,21 +221,6 @@ private:
   void writeDegeneracyReport();
 
     // GNSS constraints for georeferenced mapping
-  bool use_gnss_ {false};
-  bool gnss_align_yaw_ {true};
-  int gnss_yaw_alignment_min_anchors_ {10};
-  double gnss_yaw_alignment_min_baseline_m_ {5.0};
-  std::string gnss_topic_ {"/gnss/fix"};
-  double gnss_info_weight_ {1.0};
-  bool gnss_use_covariance_weighting_ {true};
-  double gnss_covariance_min_variance_m2_ {0.01};
-  double gnss_covariance_max_variance_m2_ {25.0};
-  double gnss_rtk_fix_max_horizontal_stddev_m_ {0.3};
-  double gnss_rtk_fix_weight_scale_ {3.0};
-  double gnss_non_rtk_weight_scale_ {1.0};
-  double gnss_header_stamp_max_skew_sec_ {30.0};
-  int gnss_origin_min_samples_ {3};
-  double gnss_origin_consistency_threshold_m_ {20.0};
   rclcpp::Subscription<sensor_msgs::msg::NavSatFix>::SharedPtr gnss_sub_;
   struct GnssEnu
   {
@@ -452,9 +248,6 @@ private:
   Eigen::Vector3d geodeticToEnu(double lat, double lon, double alt) const;
 
     // IMU preintegration
-  bool use_imu_preintegration_ {false};
-  double imu_rotation_info_roll_pitch_ {100.0};
-  double imu_rotation_info_yaw_ {10.0};
   rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr imu_sub_;
   struct StampedImu
   {

--- a/graph_based_slam/src/graph_slam_composition.cpp
+++ b/graph_based_slam/src/graph_slam_composition.cpp
@@ -1,0 +1,222 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following disclaimer
+//    in the documentation and/or other materials provided with the
+//    distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "graph_slam_composition.hpp"
+
+#include <algorithm>
+
+namespace graphslam
+{
+
+backend_core::DescriptorConfig makeDescriptorConfig(const GraphSlamConfig & config)
+{
+  backend_core::DescriptorConfig result;
+  result.use_scan_context = config.use_scan_context_;
+  result.use_bev_descriptor = config.use_bev_descriptor_;
+  result.use_solid_descriptor = config.use_solid_descriptor_;
+  result.use_triangle_descriptor = config.use_triangle_descriptor_;
+  result.bev_descriptor_grid_size_m = config.bev_descriptor_grid_size_m_;
+  result.bev_descriptor_grid_cells = config.bev_descriptor_grid_cells_;
+  result.bev_descriptor_yaw_bins = config.bev_descriptor_yaw_bins_;
+  result.triangle_descriptor_keypoint_mode = config.triangle_descriptor_keypoint_mode_;
+  result.triangle_descriptor_grid_size_m = config.triangle_descriptor_grid_size_m_;
+  result.triangle_descriptor_grid_cells = config.triangle_descriptor_grid_cells_;
+  result.triangle_descriptor_min_salience_m = config.triangle_descriptor_min_salience_m_;
+  result.triangle_descriptor_max_keypoints = config.triangle_descriptor_max_keypoints_;
+  result.triangle_descriptor_edge_voxel_size_m = config.triangle_descriptor_edge_voxel_size_m_;
+  result.triangle_descriptor_edge_neighbor_radius_m =
+    config.triangle_descriptor_edge_neighbor_radius_m_;
+  result.triangle_descriptor_edge_min_neighbors = config.triangle_descriptor_edge_min_neighbors_;
+  result.triangle_descriptor_edge_min_edgeness = config.triangle_descriptor_edge_min_edgeness_;
+  result.triangle_descriptor_edge_nms_radius_m = config.triangle_descriptor_edge_nms_radius_m_;
+  result.triangle_descriptor_min_edge_m = config.triangle_descriptor_min_edge_m_;
+  result.triangle_descriptor_max_edge_m = config.triangle_descriptor_max_edge_m_;
+  result.triangle_descriptor_max_triangles = config.triangle_descriptor_max_triangles_;
+  result.triangle_descriptor_edge_bin_m = config.triangle_descriptor_edge_bin_m_;
+  result.triangle_descriptor_quad_feature_bin_m = config.triangle_descriptor_quad_feature_bin_m_;
+  return result;
+}
+
+backend_core::LoopSearchConfig makeLoopSearchConfig(const GraphSlamConfig & config)
+{
+  backend_core::LoopSearchConfig result;
+  result.search_submap_num = config.search_submap_num_;
+  result.prefer_scan_context_candidates = config.prefer_scan_context_candidates_;
+  result.use_3d_bbs_for_scan_context = config.use_3d_bbs_for_scan_context_;
+  result.three_d_bbs_source_submap_num = config.three_d_bbs_source_submap_num_;
+  result.three_d_bbs_target_submap_radius = config.three_d_bbs_target_submap_radius_;
+  result.three_d_bbs_voxel_leaf_size = config.three_d_bbs_voxel_leaf_size_;
+  result.three_d_bbs_min_level_res = config.three_d_bbs_min_level_res_;
+  result.three_d_bbs_max_level = config.three_d_bbs_max_level_;
+  result.three_d_bbs_score_threshold_percentage =
+    config.three_d_bbs_score_threshold_percentage_;
+  result.three_d_bbs_timeout_msec = config.three_d_bbs_timeout_msec_;
+  result.three_d_bbs_num_threads = config.three_d_bbs_num_threads_;
+  result.three_d_bbs_translation_search_margin_m =
+    config.three_d_bbs_translation_search_margin_m_;
+  result.three_d_bbs_roll_pitch_search_deg = config.three_d_bbs_roll_pitch_search_deg_;
+  result.three_d_bbs_yaw_search_deg = config.three_d_bbs_yaw_search_deg_;
+
+  candidate_aggregator::Config & aggregator = result.aggregator;
+  aggregator.debug = config.debug_flag_;
+  aggregator.max_loop_candidate_count = config.max_loop_candidate_count_;
+  aggregator.distance_loop_closure = config.distance_loop_closure_;
+  aggregator.range_of_searching_loop_closure = config.range_of_searching_loop_closure_;
+  aggregator.scan_context_threshold = config.scan_context_threshold_;
+  aggregator.scan_context_query_stride = std::max(1, config.scan_context_query_stride_);
+  aggregator.scan_context_exclude_recent = std::max(1, config.scan_context_exclude_recent_);
+  aggregator.bev_use_mutual_visibility = config.bev_use_mutual_visibility_;
+  aggregator.bev_mutual_visibility_min_overlap_ratio =
+    config.bev_mutual_visibility_min_overlap_ratio_;
+  aggregator.bev_mutual_visibility_occupancy_eps = config.bev_mutual_visibility_occupancy_eps_;
+  aggregator.bev_descriptor_yaw_bins = config.bev_descriptor_yaw_bins_;
+  aggregator.bev_descriptor_max_euclidean_distance_m =
+    config.bev_descriptor_max_euclidean_distance_m_;
+  aggregator.bev_descriptor_threshold = config.bev_descriptor_threshold_;
+  aggregator.bev_descriptor_sequence_window = config.bev_descriptor_sequence_window_;
+  aggregator.bev_descriptor_sequence_threshold = config.bev_descriptor_sequence_threshold_;
+  aggregator.bev_descriptor_pose_consistency_threshold_m =
+    config.bev_descriptor_pose_consistency_threshold_m_;
+  aggregator.bev_descriptor_rerank_weight_m = config.bev_descriptor_rerank_weight_m_;
+  aggregator.solid_descriptor_max_euclidean_distance_m =
+    config.solid_descriptor_max_euclidean_distance_m_;
+  aggregator.solid_descriptor_min_similarity = config.solid_descriptor_min_similarity_;
+  aggregator.solid_descriptor_sequence_window = config.solid_descriptor_sequence_window_;
+  aggregator.solid_descriptor_sequence_min_similarity =
+    config.solid_descriptor_sequence_min_similarity_;
+  aggregator.solid_descriptor_pose_consistency_threshold_m =
+    config.solid_descriptor_pose_consistency_threshold_m_;
+  aggregator.triangle_descriptor_exclude_recent = config.triangle_descriptor_exclude_recent_;
+  aggregator.triangle_descriptor_edge_bin_m = config.triangle_descriptor_edge_bin_m_;
+  aggregator.triangle_descriptor_quad_feature_bin_m =
+    config.triangle_descriptor_quad_feature_bin_m_;
+  aggregator.triangle_descriptor_inlier_translation_m =
+    config.triangle_descriptor_inlier_translation_m_;
+  aggregator.triangle_descriptor_inlier_rotation_deg =
+    config.triangle_descriptor_inlier_rotation_deg_;
+  aggregator.triangle_descriptor_min_inliers = config.triangle_descriptor_min_inliers_;
+  aggregator.triangle_descriptor_min_inlier_ratio = config.triangle_descriptor_min_inlier_ratio_;
+  aggregator.triangle_descriptor_max_pairs = config.triangle_descriptor_max_pairs_;
+  aggregator.triangle_descriptor_min_4th_point_agreements =
+    config.triangle_descriptor_min_4th_point_agreements_;
+  aggregator.triangle_descriptor_fourth_point_max_distance_m =
+    config.triangle_descriptor_fourth_point_max_distance_m_;
+  aggregator.triangle_descriptor_refine_se3_with_all_inliers =
+    config.triangle_descriptor_refine_se3_with_all_inliers_;
+  aggregator.triangle_descriptor_min_votes = config.triangle_descriptor_min_votes_;
+  aggregator.triangle_descriptor_skip_ransac = config.triangle_descriptor_skip_ransac_;
+  aggregator.triangle_verify_with_bev = config.triangle_verify_with_bev_;
+  aggregator.triangle_verify_bev_max_distance = config.triangle_verify_bev_max_distance_;
+
+  loop_verifier::GateConfig & gates = result.gates;
+  gates.generic_score_threshold = config.threshold_loop_closure_score_;
+  gates.scan_context_score_threshold = config.scan_context_loop_closure_score_threshold_;
+  gates.max_translation_m = config.loop_max_translation_delta_;
+  gates.max_rotation_deg = config.loop_max_rotation_delta_deg_;
+  gates.min_overlap_ratio = config.loop_min_overlap_ratio_;
+  gates.min_overlap_ratio_large_correction = config.loop_min_overlap_ratio_large_correction_;
+  gates.overlap_large_correction_translation_m =
+    config.loop_overlap_large_correction_translation_m_;
+  gates.overlap_max_distance_m = config.loop_overlap_max_distance_m_;
+  gates.max_translation_descriptor_m = config.loop_max_translation_delta_descriptor_;
+  gates.max_rotation_descriptor_deg = config.loop_max_rotation_delta_deg_descriptor_;
+  return result;
+}
+
+PoseGraphConfigBundle makePoseGraphConfig(
+  const GraphSlamConfig & config,
+  double adjacent_weight,
+  double adjacent_weight_trans,
+  double adjacent_weight_rot)
+{
+  PoseGraphConfigBundle result;
+  result.adjacent.num_adjacent_pose_constraints = config.num_adjacent_pose_cnstraints_;
+  result.adjacent.split_trans_rot = config.adjacent_edge_info_auto_scale_split_trans_rot_;
+  result.adjacent.info_weight = adjacent_weight;
+  result.adjacent.info_weight_trans = adjacent_weight_trans;
+  result.adjacent.info_weight_rot = adjacent_weight_rot;
+  result.loop.info_weight = config.loop_edge_info_weight_;
+  result.loop.robust_kernel_type = config.loop_edge_robust_kernel_type_;
+  result.loop.robust_kernel_delta = config.loop_edge_robust_kernel_delta_;
+  result.imu.info_roll_pitch = config.imu_rotation_info_roll_pitch_;
+  result.imu.info_yaw = config.imu_rotation_info_yaw_;
+  if (config.adjacent_edge_info_auto_scale_) {
+    result.chi2_collection = config.adjacent_edge_info_auto_scale_split_trans_rot_ ?
+      pose_graph::Chi2Collection::SPLIT : pose_graph::Chi2Collection::UNIFIED;
+  }
+  result.auto_scale.ema_alpha = config.adjacent_edge_info_auto_scale_ema_alpha_;
+  result.auto_scale.min_scale = config.adjacent_edge_info_auto_scale_min_;
+  result.auto_scale.max_scale = config.adjacent_edge_info_auto_scale_max_;
+  return result;
+}
+
+DynamicObjectFilterConfig makeDynamicObjectFilterConfig(const GraphSlamConfig & config)
+{
+  DynamicObjectFilterConfig result;
+  result.voxel_size = config.dynamic_object_filter_voxel_size_;
+  result.min_observations = config.dynamic_object_filter_min_observations_;
+  result.temporal_window = config.dynamic_object_filter_temporal_window_;
+  result.max_range_from_sensor_m = config.dynamic_object_filter_max_range_from_sensor_m_;
+  return result;
+}
+
+PlanarMapFilterConfig makePlanarMapFilterConfig(const GraphSlamConfig & config)
+{
+  PlanarMapFilterConfig result;
+  result.voxel_size = config.planar_map_filter_voxel_size_;
+  result.min_neighbors = config.planar_map_filter_min_neighbors_;
+  result.max_small_eigenvalue_ratio = config.planar_map_filter_max_small_eigenvalue_ratio_;
+  result.min_middle_eigenvalue_ratio = config.planar_map_filter_min_middle_eigenvalue_ratio_;
+  result.min_retained_ratio = config.planar_map_filter_min_retained_ratio_;
+  return result;
+}
+
+map_saver::GridConfig makeGridConfig(const GraphSlamConfig & config)
+{
+  map_saver::GridConfig result;
+  result.grid_size_x = config.map_grid_size_x_;
+  result.grid_size_y = config.map_grid_size_y_;
+  return result;
+}
+
+detail::GnssWeightingConfig makeGnssWeightingConfig(const GraphSlamConfig & config)
+{
+  detail::GnssWeightingConfig result;
+  result.base_info_weight = config.gnss_info_weight_;
+  result.vertical_weight_scale = 0.1;
+  result.use_covariance_weighting = config.gnss_use_covariance_weighting_;
+  result.covariance_min_variance_m2 = config.gnss_covariance_min_variance_m2_;
+  result.covariance_max_variance_m2 = config.gnss_covariance_max_variance_m2_;
+  result.rtk_fix_max_horizontal_stddev_m = config.gnss_rtk_fix_max_horizontal_stddev_m_;
+  result.rtk_fix_weight_scale = config.gnss_rtk_fix_weight_scale_;
+  result.non_rtk_weight_scale = config.gnss_non_rtk_weight_scale_;
+  return result;
+}
+
+}  // namespace graphslam

--- a/graph_based_slam/src/graph_slam_composition.hpp
+++ b/graph_based_slam/src/graph_slam_composition.hpp
@@ -1,0 +1,70 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following disclaimer
+//    in the documentation and/or other materials provided with the
+//    distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef GRAPH_SLAM_COMPOSITION_HPP_
+#define GRAPH_SLAM_COMPOSITION_HPP_
+
+#include "graph_slam_config.hpp"
+
+#include "graph_based_slam/backend_core.hpp"
+#include "graph_based_slam/adjacent_edge_auto_scale.hpp"
+#include "graph_based_slam/dynamic_object_filter.hpp"
+#include "graph_based_slam/gnss_weighting.hpp"
+#include "graph_based_slam/map_saver.hpp"
+#include "graph_based_slam/planar_map_filter.hpp"
+#include "graph_based_slam/pose_graph_optimization.hpp"
+
+namespace graphslam
+{
+
+backend_core::DescriptorConfig makeDescriptorConfig(const GraphSlamConfig & config);
+backend_core::LoopSearchConfig makeLoopSearchConfig(const GraphSlamConfig & config);
+
+struct PoseGraphConfigBundle
+{
+  pose_graph::AdjacentEdgeConfig adjacent;
+  pose_graph::LoopEdgeConfig loop;
+  pose_graph::ImuEdgeConfig imu;
+  pose_graph::Chi2Collection chi2_collection {pose_graph::Chi2Collection::NONE};
+  detail::AutoScaleConfig auto_scale;
+};
+
+PoseGraphConfigBundle makePoseGraphConfig(
+  const GraphSlamConfig & config,
+  double adjacent_weight,
+  double adjacent_weight_trans,
+  double adjacent_weight_rot);
+DynamicObjectFilterConfig makeDynamicObjectFilterConfig(const GraphSlamConfig & config);
+PlanarMapFilterConfig makePlanarMapFilterConfig(const GraphSlamConfig & config);
+map_saver::GridConfig makeGridConfig(const GraphSlamConfig & config);
+detail::GnssWeightingConfig makeGnssWeightingConfig(const GraphSlamConfig & config);
+
+}  // namespace graphslam
+
+#endif  // GRAPH_SLAM_COMPOSITION_HPP_

--- a/graph_based_slam/src/graph_slam_config.cpp
+++ b/graph_based_slam/src/graph_slam_config.cpp
@@ -1,0 +1,523 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following disclaimer
+//    in the documentation and/or other materials provided with the
+//    distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "graph_slam_config.hpp"
+
+#include <cmath>
+#include <algorithm>
+#include <string>
+#include <vector>
+
+namespace graphslam
+{
+namespace
+{
+
+template<typename T>
+void loadParameter(rclcpp::Node & node, const char * name, T & value)
+{
+  value = node.declare_parameter<T>(name, value);
+}
+
+}  // namespace
+
+GraphSlamConfig loadGraphSlamConfig(rclcpp::Node & node)
+{
+  GraphSlamConfig config;
+#define LOAD(member, name) loadParameter(node, name, config.member)
+  LOAD(registration_method, "registration_method");
+  LOAD(voxel_leaf_size, "voxel_leaf_size");
+  LOAD(ndt_resolution, "ndt_resolution");
+  LOAD(ndt_num_threads, "ndt_num_threads");
+  LOAD(threshold_loop_closure_score_, "threshold_loop_closure_score");
+  LOAD(scan_context_loop_closure_score_threshold_, "scan_context_loop_closure_score_threshold");
+  LOAD(distance_loop_closure_, "distance_loop_closure");
+  LOAD(range_of_searching_loop_closure_, "range_of_searching_loop_closure");
+  LOAD(search_submap_num_, "search_submap_num");
+  LOAD(loop_search_query_stride_, "loop_search_query_stride");
+  LOAD(max_loop_candidate_count_, "max_loop_candidate_count");
+  LOAD(loop_edge_dedup_index_window_, "loop_edge_dedup_index_window");
+  LOAD(loop_max_translation_delta_, "loop_max_translation_delta");
+  LOAD(loop_max_rotation_delta_deg_, "loop_max_rotation_delta_deg");
+  LOAD(loop_min_overlap_ratio_, "loop_min_overlap_ratio");
+  LOAD(loop_min_overlap_ratio_large_correction_, "loop_min_overlap_ratio_large_correction");
+  LOAD(
+    loop_overlap_large_correction_translation_m_,
+    "loop_overlap_large_correction_translation_m");
+  LOAD(loop_overlap_max_distance_m_, "loop_overlap_max_distance_m");
+  LOAD(loop_max_translation_delta_descriptor_, "loop_max_translation_delta_descriptor");
+  LOAD(loop_max_rotation_delta_deg_descriptor_, "loop_max_rotation_delta_deg_descriptor");
+  LOAD(num_adjacent_pose_cnstraints_, "num_adjacent_pose_cnstraints");
+  LOAD(use_save_map_in_loop_, "use_save_map_in_loop");
+  LOAD(debug_flag_, "debug_flag");
+  LOAD(adjacent_edge_info_weight_, "adjacent_edge_info_weight");
+  LOAD(adjacent_edge_info_auto_scale_, "adjacent_edge_info_auto_scale");
+  LOAD(adjacent_edge_info_auto_scale_target_nis_, "adjacent_edge_info_auto_scale_target_nis");
+  LOAD(adjacent_edge_info_auto_scale_ema_alpha_, "adjacent_edge_info_auto_scale_ema_alpha");
+  LOAD(adjacent_edge_info_auto_scale_min_, "adjacent_edge_info_auto_scale_min");
+  LOAD(adjacent_edge_info_auto_scale_max_, "adjacent_edge_info_auto_scale_max");
+  LOAD(
+    adjacent_edge_info_auto_scale_split_trans_rot_,
+    "adjacent_edge_info_auto_scale_split_trans_rot");
+  LOAD(adjacent_edge_info_weight_trans_, "adjacent_edge_info_weight_trans");
+  LOAD(adjacent_edge_info_weight_rot_, "adjacent_edge_info_weight_rot");
+  LOAD(
+    adjacent_edge_info_auto_scale_target_nis_trans_,
+    "adjacent_edge_info_auto_scale_target_nis_trans");
+  LOAD(
+    adjacent_edge_info_auto_scale_target_nis_rot_,
+    "adjacent_edge_info_auto_scale_target_nis_rot");
+  LOAD(loop_edge_info_weight_, "loop_edge_info_weight");
+  LOAD(loop_edge_robust_kernel_delta_, "loop_edge_robust_kernel_delta");
+  LOAD(loop_edge_robust_kernel_type_, "loop_edge_robust_kernel_type");
+  LOAD(use_scan_context_, "use_scan_context");
+  LOAD(use_bev_descriptor_, "use_bev_descriptor");
+  LOAD(use_solid_descriptor_, "use_solid_descriptor");
+  LOAD(use_triangle_descriptor_, "use_triangle_descriptor");
+  LOAD(triangle_descriptor_grid_size_m_, "triangle_descriptor_grid_size_m");
+  LOAD(triangle_descriptor_grid_cells_, "triangle_descriptor_grid_cells");
+  LOAD(triangle_descriptor_max_keypoints_, "triangle_descriptor_max_keypoints");
+  LOAD(triangle_descriptor_min_salience_m_, "triangle_descriptor_min_salience_m");
+  LOAD(triangle_descriptor_min_edge_m_, "triangle_descriptor_min_edge_m");
+  LOAD(triangle_descriptor_max_edge_m_, "triangle_descriptor_max_edge_m");
+  LOAD(triangle_descriptor_max_triangles_, "triangle_descriptor_max_triangles");
+  LOAD(triangle_descriptor_edge_bin_m_, "triangle_descriptor_edge_bin_m");
+  LOAD(triangle_descriptor_quad_feature_bin_m_, "triangle_descriptor_quad_feature_bin_m");
+  LOAD(triangle_descriptor_keypoint_mode_, "triangle_descriptor_keypoint_mode");
+  LOAD(triangle_descriptor_edge_voxel_size_m_, "triangle_descriptor_edge_voxel_size_m");
+  LOAD(
+    triangle_descriptor_edge_neighbor_radius_m_,
+    "triangle_descriptor_edge_neighbor_radius_m");
+  LOAD(triangle_descriptor_edge_min_neighbors_, "triangle_descriptor_edge_min_neighbors");
+  LOAD(triangle_descriptor_edge_min_edgeness_, "triangle_descriptor_edge_min_edgeness");
+  LOAD(triangle_descriptor_edge_nms_radius_m_, "triangle_descriptor_edge_nms_radius_m");
+  LOAD(triangle_descriptor_min_votes_, "triangle_descriptor_min_votes");
+  LOAD(triangle_descriptor_min_inliers_, "triangle_descriptor_min_inliers");
+  LOAD(triangle_descriptor_min_inlier_ratio_, "triangle_descriptor_min_inlier_ratio");
+  LOAD(triangle_descriptor_max_pairs_, "triangle_descriptor_max_pairs");
+  LOAD(
+    triangle_descriptor_min_4th_point_agreements_,
+    "triangle_descriptor_min_4th_point_agreements");
+  LOAD(
+    triangle_descriptor_fourth_point_max_distance_m_,
+    "triangle_descriptor_fourth_point_max_distance_m");
+  LOAD(
+    triangle_descriptor_refine_se3_with_all_inliers_,
+    "triangle_descriptor_refine_se3_with_all_inliers");
+  LOAD(triangle_descriptor_skip_ransac_, "triangle_descriptor_skip_ransac");
+  LOAD(
+    triangle_descriptor_inlier_translation_m_,
+    "triangle_descriptor_inlier_translation_m");
+  LOAD(triangle_descriptor_inlier_rotation_deg_, "triangle_descriptor_inlier_rotation_deg");
+  LOAD(triangle_descriptor_exclude_recent_, "triangle_descriptor_exclude_recent");
+  LOAD(triangle_verify_with_bev_, "triangle_verify_with_bev");
+  LOAD(triangle_verify_bev_max_distance_, "triangle_verify_bev_max_distance");
+  LOAD(use_pcd_cache_, "use_pcd_cache");
+  LOAD(pcd_cache_dir_, "pcd_cache_dir");
+  LOAD(scan_context_threshold_, "scan_context_threshold");
+  LOAD(scan_context_query_stride_, "scan_context_query_stride");
+  LOAD(scan_context_exclude_recent_, "scan_context_exclude_recent");
+  LOAD(bev_descriptor_threshold_, "bev_descriptor_threshold");
+  LOAD(bev_descriptor_grid_size_m_, "bev_descriptor_grid_size_m");
+  LOAD(bev_descriptor_grid_cells_, "bev_descriptor_grid_cells");
+  LOAD(bev_descriptor_yaw_bins_, "bev_descriptor_yaw_bins");
+  LOAD(bev_descriptor_sequence_window_, "bev_descriptor_sequence_window");
+  LOAD(bev_descriptor_sequence_threshold_, "bev_descriptor_sequence_threshold");
+  LOAD(
+    bev_descriptor_pose_consistency_threshold_m_,
+    "bev_descriptor_pose_consistency_threshold_m");
+  LOAD(bev_descriptor_max_euclidean_distance_m_, "bev_descriptor_max_euclidean_distance_m");
+  LOAD(bev_descriptor_rerank_weight_m_, "bev_descriptor_rerank_weight_m");
+  LOAD(bev_use_mutual_visibility_, "bev_use_mutual_visibility");
+  LOAD(
+    bev_mutual_visibility_min_overlap_ratio_,
+    "bev_mutual_visibility_min_overlap_ratio");
+  LOAD(bev_mutual_visibility_occupancy_eps_, "bev_mutual_visibility_occupancy_eps");
+  LOAD(solid_descriptor_min_similarity_, "solid_descriptor_min_similarity");
+  LOAD(solid_descriptor_sequence_window_, "solid_descriptor_sequence_window");
+  LOAD(solid_descriptor_sequence_min_similarity_, "solid_descriptor_sequence_min_similarity");
+  LOAD(
+    solid_descriptor_pose_consistency_threshold_m_,
+    "solid_descriptor_pose_consistency_threshold_m");
+  LOAD(solid_descriptor_max_euclidean_distance_m_, "solid_descriptor_max_euclidean_distance_m");
+  LOAD(prefer_scan_context_candidates_, "prefer_scan_context_candidates");
+  LOAD(use_3d_bbs_for_scan_context_, "use_3d_bbs_for_scan_context");
+  LOAD(three_d_bbs_min_level_res_, "three_d_bbs_min_level_res");
+  LOAD(three_d_bbs_max_level_, "three_d_bbs_max_level");
+  LOAD(three_d_bbs_score_threshold_percentage_, "three_d_bbs_score_threshold_percentage");
+  LOAD(three_d_bbs_timeout_msec_, "three_d_bbs_timeout_msec");
+  LOAD(three_d_bbs_num_threads_, "three_d_bbs_num_threads");
+  LOAD(three_d_bbs_voxel_leaf_size_, "three_d_bbs_voxel_leaf_size");
+  LOAD(three_d_bbs_source_submap_num_, "three_d_bbs_source_submap_num");
+  LOAD(three_d_bbs_target_submap_radius_, "three_d_bbs_target_submap_radius");
+  LOAD(
+    three_d_bbs_translation_search_margin_m_,
+    "three_d_bbs_translation_search_margin_m");
+  LOAD(three_d_bbs_roll_pitch_search_deg_, "three_d_bbs_roll_pitch_search_deg");
+  LOAD(three_d_bbs_yaw_search_deg_, "three_d_bbs_yaw_search_deg");
+  LOAD(use_dynamic_object_filter_, "use_dynamic_object_filter");
+  LOAD(dynamic_object_filter_voxel_size_, "dynamic_object_filter_voxel_size");
+  LOAD(dynamic_object_filter_min_observations_, "dynamic_object_filter_min_observations");
+  LOAD(dynamic_object_filter_temporal_window_, "dynamic_object_filter_temporal_window");
+  LOAD(
+    dynamic_object_filter_max_range_from_sensor_m_,
+    "dynamic_object_filter_max_range_from_sensor_m");
+  LOAD(use_planar_map_filter_, "use_planar_map_filter");
+  LOAD(planar_map_filter_voxel_size_, "planar_map_filter_voxel_size");
+  LOAD(planar_map_filter_min_neighbors_, "planar_map_filter_min_neighbors");
+  LOAD(
+    planar_map_filter_max_small_eigenvalue_ratio_,
+    "planar_map_filter_max_small_eigenvalue_ratio");
+  LOAD(
+    planar_map_filter_min_middle_eigenvalue_ratio_,
+    "planar_map_filter_min_middle_eigenvalue_ratio");
+  LOAD(planar_map_filter_min_retained_ratio_, "planar_map_filter_min_retained_ratio");
+  LOAD(map_save_dir_, "map_save_dir");
+  LOAD(save_pose_graph_path_, "save_pose_graph_path");
+  LOAD(map_grid_size_x_, "map_grid_size_x");
+  LOAD(map_grid_size_y_, "map_grid_size_y");
+  LOAD(map_leaf_size_, "map_leaf_size");
+  LOAD(use_gnss_, "use_gnss");
+  LOAD(gnss_topic_, "gnss_topic");
+  LOAD(gnss_info_weight_, "gnss_info_weight");
+  LOAD(gnss_use_covariance_weighting_, "gnss_use_covariance_weighting");
+  LOAD(gnss_covariance_min_variance_m2_, "gnss_covariance_min_variance_m2");
+  LOAD(gnss_covariance_max_variance_m2_, "gnss_covariance_max_variance_m2");
+  LOAD(
+    gnss_rtk_fix_max_horizontal_stddev_m_,
+    "gnss_rtk_fix_max_horizontal_stddev_m");
+  LOAD(gnss_rtk_fix_weight_scale_, "gnss_rtk_fix_weight_scale");
+  LOAD(gnss_non_rtk_weight_scale_, "gnss_non_rtk_weight_scale");
+  LOAD(gnss_header_stamp_max_skew_sec_, "gnss_header_stamp_max_skew_sec");
+  LOAD(gnss_align_yaw_, "gnss_align_yaw");
+  LOAD(gnss_yaw_alignment_min_anchors_, "gnss_yaw_alignment_min_anchors");
+  LOAD(gnss_yaw_alignment_min_baseline_m_, "gnss_yaw_alignment_min_baseline_m");
+  LOAD(gnss_origin_min_samples_, "gnss_origin_min_samples");
+  LOAD(gnss_origin_consistency_threshold_m_, "gnss_origin_consistency_threshold_m");
+  LOAD(use_imu_preintegration_, "use_imu_preintegration");
+  LOAD(imu_rotation_info_roll_pitch_, "imu_rotation_info_roll_pitch");
+  LOAD(imu_rotation_info_yaw_, "imu_rotation_info_yaw");
+  LOAD(use_odom_input_, "use_odom_input");
+  LOAD(submap_distance_threshold_, "submap_distance_threshold");
+  LOAD(odom_cloud_sync_queue_size_, "odom_cloud_sync_queue_size");
+  LOAD(degeneracy_diagnostics_csv_path_, "degeneracy_diagnostics_csv_path");
+  LOAD(save_degeneracy_report_, "save_degeneracy_report");
+#undef LOAD
+  return config;
+}
+
+ConfigNormalization normalizeGraphSlamConfig(GraphSlamConfig & config)
+{
+  ConfigNormalization result;
+  const auto warn = [&result](const char * name, const char * action) {
+      result.warnings.emplace_back(std::string(name) + " " + action);
+    };
+  const auto atLeastOne = [&warn](int & value, const char * name) {
+      if (value < 1) {
+        warn(name, "must be >= 1; clamped to 1");
+        value = 1;
+      }
+    };
+  const auto positiveOr = [&warn](double & value, double fallback, const char * name) {
+      if (value <= 0.0) {
+        warn(name, "must be positive; reset to its safe default");
+        value = fallback;
+      }
+    };
+  const auto unitInterval = [&warn](double & value, double fallback, const char * name) {
+      if (value < 0.0 || value > 1.0) {
+        warn(name, "must be in [0, 1]; reset to its safe default");
+        value = fallback;
+      }
+    };
+
+  positiveOr(config.adjacent_edge_info_weight_, 1000.0, "adjacent_edge_info_weight");
+  if (config.adjacent_edge_info_weight_trans_ <= 0.0) {
+    config.adjacent_edge_info_weight_trans_ = config.adjacent_edge_info_weight_;
+  }
+  if (config.adjacent_edge_info_weight_rot_ <= 0.0) {
+    config.adjacent_edge_info_weight_rot_ = config.adjacent_edge_info_weight_;
+  }
+  positiveOr(
+    config.adjacent_edge_info_auto_scale_target_nis_trans_, 3.0,
+    "adjacent_edge_info_auto_scale_target_nis_trans");
+  positiveOr(
+    config.adjacent_edge_info_auto_scale_target_nis_rot_, 3.0,
+    "adjacent_edge_info_auto_scale_target_nis_rot");
+
+  atLeastOne(config.gnss_origin_min_samples_, "gnss_origin_min_samples");
+  positiveOr(
+    config.gnss_origin_consistency_threshold_m_, 20.0,
+    "gnss_origin_consistency_threshold_m");
+  positiveOr(
+    config.gnss_covariance_min_variance_m2_, 0.01,
+    "gnss_covariance_min_variance_m2");
+  if (config.gnss_covariance_max_variance_m2_ < config.gnss_covariance_min_variance_m2_) {
+    warn("gnss_covariance_max_variance_m2", "must be >= minimum; raised to minimum");
+    config.gnss_covariance_max_variance_m2_ = config.gnss_covariance_min_variance_m2_;
+  }
+  positiveOr(
+    config.gnss_rtk_fix_max_horizontal_stddev_m_, 0.3,
+    "gnss_rtk_fix_max_horizontal_stddev_m");
+  positiveOr(config.gnss_rtk_fix_weight_scale_, 3.0, "gnss_rtk_fix_weight_scale");
+  positiveOr(config.gnss_non_rtk_weight_scale_, 1.0, "gnss_non_rtk_weight_scale");
+  positiveOr(config.gnss_header_stamp_max_skew_sec_, 30.0, "gnss_header_stamp_max_skew_sec");
+
+  atLeastOne(config.search_submap_num_, "search_submap_num");
+  atLeastOne(config.loop_search_query_stride_, "loop_search_query_stride");
+  atLeastOne(config.max_loop_candidate_count_, "max_loop_candidate_count");
+  if (config.loop_edge_dedup_index_window_ < 0) {
+    warn("loop_edge_dedup_index_window", "must be >= 0; clamped to 0");
+    config.loop_edge_dedup_index_window_ = 0;
+  }
+  positiveOr(config.loop_max_translation_delta_, 15.0, "loop_max_translation_delta");
+  positiveOr(config.loop_max_rotation_delta_deg_, 45.0, "loop_max_rotation_delta_deg");
+  unitInterval(config.loop_min_overlap_ratio_, 0.0, "loop_min_overlap_ratio");
+  unitInterval(
+    config.loop_min_overlap_ratio_large_correction_, 0.0,
+    "loop_min_overlap_ratio_large_correction");
+  if (config.loop_overlap_large_correction_translation_m_ < 0.0) {
+    warn(
+      "loop_overlap_large_correction_translation_m",
+      "must be non-negative; reset to disabled");
+    config.loop_overlap_large_correction_translation_m_ = 0.0;
+  }
+  positiveOr(config.loop_overlap_max_distance_m_, 0.5, "loop_overlap_max_distance_m");
+  if (config.loop_max_translation_delta_descriptor_ <= 0.0 &&
+    config.loop_max_translation_delta_descriptor_ != -1.0)
+  {
+    warn("loop_max_translation_delta_descriptor", "must be positive or -1; reset to -1");
+    config.loop_max_translation_delta_descriptor_ = -1.0;
+  }
+  if (config.loop_max_rotation_delta_deg_descriptor_ <= 0.0 &&
+    config.loop_max_rotation_delta_deg_descriptor_ != -1.0)
+  {
+    warn("loop_max_rotation_delta_deg_descriptor", "must be positive or -1; reset to -1");
+    config.loop_max_rotation_delta_deg_descriptor_ = -1.0;
+  }
+  atLeastOne(config.num_adjacent_pose_cnstraints_, "num_adjacent_pose_cnstraints");
+  positiveOr(config.loop_edge_info_weight_, 100.0, "loop_edge_info_weight");
+  positiveOr(config.loop_edge_robust_kernel_delta_, 1.0, "loop_edge_robust_kernel_delta");
+
+  positiveOr(config.bev_descriptor_threshold_, 0.20, "bev_descriptor_threshold");
+  positiveOr(config.bev_descriptor_grid_size_m_, 80.0, "bev_descriptor_grid_size_m");
+  if (config.bev_descriptor_grid_cells_ < 8) {
+    warn("bev_descriptor_grid_cells", "must be >= 8; clamped to 8");
+    config.bev_descriptor_grid_cells_ = 8;
+  }
+  atLeastOne(config.bev_descriptor_yaw_bins_, "bev_descriptor_yaw_bins");
+  if (config.bev_descriptor_sequence_window_ < 0) {
+    warn("bev_descriptor_sequence_window", "must be >= 0; clamped to 0");
+    config.bev_descriptor_sequence_window_ = 0;
+  }
+  if (config.bev_descriptor_sequence_threshold_ <= 0.0) {
+    config.bev_descriptor_sequence_threshold_ = config.bev_descriptor_threshold_;
+  }
+  if (config.bev_descriptor_rerank_weight_m_ < 0.0) {
+    warn("bev_descriptor_rerank_weight_m", "must be >= 0; clamped to 0");
+    config.bev_descriptor_rerank_weight_m_ = 0.0;
+  }
+  if (config.bev_descriptor_pose_consistency_threshold_m_ == 0.0) {
+    warn("bev_descriptor_pose_consistency_threshold_m", "cannot be zero; reset to disabled");
+    config.bev_descriptor_pose_consistency_threshold_m_ = -1.0;
+  }
+
+  if (config.triangle_descriptor_keypoint_mode_ != "bev_max_height" &&
+    config.triangle_descriptor_keypoint_mode_ != "edge_3d")
+  {
+    warn("triangle_descriptor_keypoint_mode", "is unknown; reset to bev_max_height");
+    config.triangle_descriptor_keypoint_mode_ = "bev_max_height";
+  }
+  config.triangle_descriptor_edge_voxel_size_m_ =
+    std::max(0.0, config.triangle_descriptor_edge_voxel_size_m_);
+  config.triangle_descriptor_edge_neighbor_radius_m_ =
+    std::max(0.05, config.triangle_descriptor_edge_neighbor_radius_m_);
+  config.triangle_descriptor_edge_min_neighbors_ =
+    std::max(4, config.triangle_descriptor_edge_min_neighbors_);
+  config.triangle_descriptor_edge_min_edgeness_ =
+    std::max(0.0, std::min(1.0, config.triangle_descriptor_edge_min_edgeness_));
+  config.triangle_descriptor_edge_nms_radius_m_ =
+    std::max(0.0, config.triangle_descriptor_edge_nms_radius_m_);
+  positiveOr(config.triangle_descriptor_grid_size_m_, 60.0, "triangle_descriptor_grid_size_m");
+  if (config.triangle_descriptor_grid_cells_ < 8) {
+    warn("triangle_descriptor_grid_cells", "must be >= 8; clamped to 8");
+    config.triangle_descriptor_grid_cells_ = 8;
+  }
+  if (config.triangle_descriptor_max_keypoints_ < 4) {
+    warn("triangle_descriptor_max_keypoints", "must be >= 4; clamped to 4");
+    config.triangle_descriptor_max_keypoints_ = 4;
+  }
+  positiveOr(config.triangle_descriptor_min_edge_m_, 2.0, "triangle_descriptor_min_edge_m");
+  if (config.triangle_descriptor_max_edge_m_ <= config.triangle_descriptor_min_edge_m_) {
+    warn("triangle_descriptor_max_edge_m", "must exceed minimum; reset to minimum x 5");
+    config.triangle_descriptor_max_edge_m_ = config.triangle_descriptor_min_edge_m_ * 5.0;
+  }
+  config.triangle_descriptor_max_triangles_ =
+    std::max(100, config.triangle_descriptor_max_triangles_);
+  positiveOr(config.triangle_descriptor_edge_bin_m_, 1.0, "triangle_descriptor_edge_bin_m");
+  if (config.triangle_descriptor_quad_feature_bin_m_ < 0.0) {
+    warn("triangle_descriptor_quad_feature_bin_m", "must be >= 0; reset to disabled");
+    config.triangle_descriptor_quad_feature_bin_m_ = 0.0;
+  }
+  config.triangle_descriptor_min_votes_ = std::max(1, config.triangle_descriptor_min_votes_);
+  config.triangle_descriptor_min_inliers_ = std::max(1, config.triangle_descriptor_min_inliers_);
+  config.triangle_descriptor_min_inlier_ratio_ =
+    std::max(0.0, std::min(1.0, config.triangle_descriptor_min_inlier_ratio_));
+  if (config.triangle_descriptor_max_pairs_ < 3) {
+    warn("triangle_descriptor_max_pairs", "must be >= 3; clamped to 3");
+    config.triangle_descriptor_max_pairs_ = 3;
+  }
+  config.triangle_descriptor_min_4th_point_agreements_ =
+    std::max(0, config.triangle_descriptor_min_4th_point_agreements_);
+  positiveOr(
+    config.triangle_descriptor_fourth_point_max_distance_m_, 2.0,
+    "triangle_descriptor_fourth_point_max_distance_m");
+  positiveOr(
+    config.triangle_descriptor_inlier_translation_m_, 2.0,
+    "triangle_descriptor_inlier_translation_m");
+  positiveOr(
+    config.triangle_descriptor_inlier_rotation_deg_, 5.0,
+    "triangle_descriptor_inlier_rotation_deg");
+  config.triangle_descriptor_exclude_recent_ =
+    std::max(0, config.triangle_descriptor_exclude_recent_);
+  positiveOr(config.triangle_verify_bev_max_distance_, 0.30, "triangle_verify_bev_max_distance");
+
+  if (config.solid_descriptor_min_similarity_ <= -1.0 ||
+    config.solid_descriptor_min_similarity_ > 1.0)
+  {
+    warn("solid_descriptor_min_similarity", "must be in (-1, 1]; reset to 0.70");
+    config.solid_descriptor_min_similarity_ = 0.70;
+  }
+  if (config.solid_descriptor_sequence_window_ < 0) {
+    warn("solid_descriptor_sequence_window", "must be >= 0; clamped to 0");
+    config.solid_descriptor_sequence_window_ = 0;
+  }
+  if (config.solid_descriptor_sequence_min_similarity_ <= -1.0 ||
+    config.solid_descriptor_sequence_min_similarity_ > 1.0)
+  {
+    config.solid_descriptor_sequence_min_similarity_ = config.solid_descriptor_min_similarity_;
+  }
+  if (config.solid_descriptor_pose_consistency_threshold_m_ == 0.0) {
+    warn("solid_descriptor_pose_consistency_threshold_m", "cannot be zero; reset to disabled");
+    config.solid_descriptor_pose_consistency_threshold_m_ = -1.0;
+  }
+
+  positiveOr(config.three_d_bbs_min_level_res_, 1.0, "three_d_bbs_min_level_res");
+  atLeastOne(config.three_d_bbs_max_level_, "three_d_bbs_max_level");
+  positiveOr(
+    config.three_d_bbs_score_threshold_percentage_, 0.25,
+    "three_d_bbs_score_threshold_percentage");
+  positiveOr(config.three_d_bbs_voxel_leaf_size_, 1.0, "three_d_bbs_voxel_leaf_size");
+  atLeastOne(config.three_d_bbs_source_submap_num_, "three_d_bbs_source_submap_num");
+  if (config.three_d_bbs_target_submap_radius_ < 0) {
+    warn("three_d_bbs_target_submap_radius", "must be >= 0; clamped to 0");
+    config.three_d_bbs_target_submap_radius_ = 0;
+  }
+  positiveOr(
+    config.three_d_bbs_translation_search_margin_m_, 15.0,
+    "three_d_bbs_translation_search_margin_m");
+  positiveOr(
+    config.three_d_bbs_roll_pitch_search_deg_, 10.0,
+    "three_d_bbs_roll_pitch_search_deg");
+  positiveOr(config.three_d_bbs_yaw_search_deg_, 180.0, "three_d_bbs_yaw_search_deg");
+
+  positiveOr(
+    config.dynamic_object_filter_voxel_size_, 0.3,
+    "dynamic_object_filter_voxel_size");
+  atLeastOne(
+    config.dynamic_object_filter_min_observations_,
+    "dynamic_object_filter_min_observations");
+  if (config.dynamic_object_filter_temporal_window_ < 0) {
+    warn("dynamic_object_filter_temporal_window", "must be >= 0; clamped to 0");
+    config.dynamic_object_filter_temporal_window_ = 0;
+  }
+  positiveOr(
+    config.dynamic_object_filter_max_range_from_sensor_m_, 30.0,
+    "dynamic_object_filter_max_range_from_sensor_m");
+  positiveOr(config.planar_map_filter_voxel_size_, 0.1, "planar_map_filter_voxel_size");
+  if (config.planar_map_filter_min_neighbors_ < 3) {
+    warn("planar_map_filter_min_neighbors", "must be >= 3; clamped to 3");
+    config.planar_map_filter_min_neighbors_ = 3;
+  }
+  config.planar_map_filter_max_small_eigenvalue_ratio_ =
+    std::max(0.0, std::min(1.0, config.planar_map_filter_max_small_eigenvalue_ratio_));
+  config.planar_map_filter_min_middle_eigenvalue_ratio_ =
+    std::max(0.0, std::min(1.0, config.planar_map_filter_min_middle_eigenvalue_ratio_));
+  config.planar_map_filter_min_retained_ratio_ =
+    std::max(0.0, std::min(1.0, config.planar_map_filter_min_retained_ratio_));
+  return result;
+}
+
+std::vector<std::string> validateGraphSlamConfig(const GraphSlamConfig & config)
+{
+  std::vector<std::string> errors;
+  const auto positive = [&errors](double value, const char * name) {
+      if (!std::isfinite(value) || value <= 0.0) {
+        errors.emplace_back(std::string(name) + " must be finite and > 0");
+      }
+    };
+
+  positive(config.voxel_leaf_size, "voxel_leaf_size");
+  positive(config.ndt_resolution, "ndt_resolution");
+  positive(config.map_grid_size_x_, "map_grid_size_x");
+  positive(config.map_grid_size_y_, "map_grid_size_y");
+  positive(config.map_leaf_size_, "map_leaf_size");
+  if (config.odom_cloud_sync_queue_size_ < 1) {
+    errors.emplace_back("odom_cloud_sync_queue_size must be >= 1");
+  }
+  if (config.use_pcd_cache_ && config.pcd_cache_dir_.empty()) {
+    errors.emplace_back("pcd_cache_dir must not be empty when use_pcd_cache is true");
+  }
+  return errors;
+}
+
+void logGraphSlamConfig(const GraphSlamConfig & config, const rclcpp::Logger & logger)
+{
+  RCLCPP_INFO(
+    logger,
+    "graph SLAM config: registration=%s voxel=%.3f ndt_resolution=%.3f ndt_threads=%d",
+    config.registration_method.c_str(), config.voxel_leaf_size, config.ndt_resolution,
+    config.ndt_num_threads);
+  RCLCPP_INFO(
+    logger,
+    "graph SLAM config: loop(search_submaps=%d stride=%d candidates=%d dedup_window=%d) "
+    "descriptors(scan_context=%s bev=%s solid=%s triangle=%s)",
+    config.search_submap_num_, config.loop_search_query_stride_, config.max_loop_candidate_count_,
+    config.loop_edge_dedup_index_window_, config.use_scan_context_ ? "on" : "off",
+    config.use_bev_descriptor_ ? "on" : "off", config.use_solid_descriptor_ ? "on" : "off",
+    config.use_triangle_descriptor_ ? "on" : "off");
+  RCLCPP_INFO(
+    logger,
+    "graph SLAM config: inputs(odom=%s gnss=%s imu=%s) storage(pcd_cache=%s map_dir=%s)",
+    config.use_odom_input_ ? "on" : "off", config.use_gnss_ ? "on" : "off",
+    config.use_imu_preintegration_ ? "on" : "off", config.use_pcd_cache_ ? "on" : "off",
+    config.map_save_dir_.c_str());
+}
+
+}  // namespace graphslam

--- a/graph_based_slam/src/graph_slam_config.hpp
+++ b/graph_based_slam/src/graph_slam_config.hpp
@@ -1,0 +1,214 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following disclaimer
+//    in the documentation and/or other materials provided with the
+//    distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef GRAPH_SLAM_CONFIG_HPP_
+#define GRAPH_SLAM_CONFIG_HPP_
+
+#include <string>
+#include <vector>
+
+#include <rclcpp/rclcpp.hpp>
+
+namespace graphslam
+{
+
+// Complete, typed snapshot of the ROS parameter surface. This source-private
+// type keeps parameter declaration/loading out of the component lifecycle and
+// separates the normalized startup snapshot from live graph and sensor state.
+struct GraphSlamConfig
+{
+  // Registration and loop search.
+  std::string registration_method {"NDT"};
+  double voxel_leaf_size {0.2};
+  double ndt_resolution {5.0};
+  int ndt_num_threads {0};
+  double threshold_loop_closure_score_ {1.0};
+  double scan_context_loop_closure_score_threshold_ {-1.0};
+  double distance_loop_closure_ {20.0};
+  double range_of_searching_loop_closure_ {20.0};
+  int search_submap_num_ {3};
+  int loop_search_query_stride_ {1};
+  int max_loop_candidate_count_ {3};
+  int loop_edge_dedup_index_window_ {8};
+  double loop_max_translation_delta_ {15.0};
+  double loop_max_rotation_delta_deg_ {45.0};
+  double loop_min_overlap_ratio_ {0.0};
+  double loop_min_overlap_ratio_large_correction_ {0.0};
+  double loop_overlap_large_correction_translation_m_ {0.0};
+  double loop_overlap_max_distance_m_ {0.5};
+  double loop_max_translation_delta_descriptor_ {-1.0};
+  double loop_max_rotation_delta_deg_descriptor_ {-1.0};
+
+  // Pose graph optimization.
+  int num_adjacent_pose_cnstraints_ {5};
+  bool use_save_map_in_loop_ {true};
+  bool debug_flag_ {false};
+  double adjacent_edge_info_weight_ {1000.0};
+  bool adjacent_edge_info_auto_scale_ {false};
+  double adjacent_edge_info_auto_scale_target_nis_ {6.0};
+  double adjacent_edge_info_auto_scale_ema_alpha_ {0.3};
+  double adjacent_edge_info_auto_scale_min_ {1.0};
+  double adjacent_edge_info_auto_scale_max_ {1.0e6};
+  bool adjacent_edge_info_auto_scale_split_trans_rot_ {false};
+  double adjacent_edge_info_weight_trans_ {-1.0};
+  double adjacent_edge_info_weight_rot_ {-1.0};
+  double adjacent_edge_info_auto_scale_target_nis_trans_ {3.0};
+  double adjacent_edge_info_auto_scale_target_nis_rot_ {3.0};
+  double loop_edge_info_weight_ {100.0};
+  double loop_edge_robust_kernel_delta_ {1.0};
+  std::string loop_edge_robust_kernel_type_ {"huber"};
+
+  // Place recognition and verification.
+  bool use_scan_context_ {false};
+  bool use_bev_descriptor_ {false};
+  bool use_solid_descriptor_ {false};
+  bool use_triangle_descriptor_ {false};
+  double triangle_descriptor_grid_size_m_ {60.0};
+  int triangle_descriptor_grid_cells_ {100};
+  int triangle_descriptor_max_keypoints_ {40};
+  double triangle_descriptor_min_salience_m_ {0.8};
+  double triangle_descriptor_min_edge_m_ {2.0};
+  double triangle_descriptor_max_edge_m_ {50.0};
+  int triangle_descriptor_max_triangles_ {3000};
+  double triangle_descriptor_edge_bin_m_ {0.5};
+  double triangle_descriptor_quad_feature_bin_m_ {0.0};
+  std::string triangle_descriptor_keypoint_mode_ {"bev_max_height"};
+  double triangle_descriptor_edge_voxel_size_m_ {0.4};
+  double triangle_descriptor_edge_neighbor_radius_m_ {1.0};
+  int triangle_descriptor_edge_min_neighbors_ {6};
+  double triangle_descriptor_edge_min_edgeness_ {0.5};
+  double triangle_descriptor_edge_nms_radius_m_ {2.0};
+  int triangle_descriptor_min_votes_ {6};
+  int triangle_descriptor_min_inliers_ {4};
+  double triangle_descriptor_min_inlier_ratio_ {0.0};
+  int triangle_descriptor_max_pairs_ {64};
+  int triangle_descriptor_min_4th_point_agreements_ {0};
+  double triangle_descriptor_fourth_point_max_distance_m_ {2.0};
+  bool triangle_descriptor_refine_se3_with_all_inliers_ {false};
+  bool triangle_descriptor_skip_ransac_ {false};
+  double triangle_descriptor_inlier_translation_m_ {2.0};
+  double triangle_descriptor_inlier_rotation_deg_ {5.0};
+  int triangle_descriptor_exclude_recent_ {4};
+  bool triangle_verify_with_bev_ {false};
+  double triangle_verify_bev_max_distance_ {0.30};
+  double scan_context_threshold_ {0.3};
+  int scan_context_query_stride_ {1};
+  int scan_context_exclude_recent_ {50};
+  double bev_descriptor_threshold_ {0.20};
+  double bev_descriptor_grid_size_m_ {80.0};
+  int bev_descriptor_grid_cells_ {40};
+  int bev_descriptor_yaw_bins_ {24};
+  int bev_descriptor_sequence_window_ {0};
+  double bev_descriptor_sequence_threshold_ {-1.0};
+  double bev_descriptor_pose_consistency_threshold_m_ {-1.0};
+  double bev_descriptor_max_euclidean_distance_m_ {-1.0};
+  double bev_descriptor_rerank_weight_m_ {100.0};
+  bool bev_use_mutual_visibility_ {false};
+  double bev_mutual_visibility_min_overlap_ratio_ {0.05};
+  double bev_mutual_visibility_occupancy_eps_ {0.5};
+  double solid_descriptor_min_similarity_ {0.70};
+  int solid_descriptor_sequence_window_ {0};
+  double solid_descriptor_sequence_min_similarity_ {-1.0};
+  double solid_descriptor_pose_consistency_threshold_m_ {-1.0};
+  double solid_descriptor_max_euclidean_distance_m_ {-1.0};
+  bool prefer_scan_context_candidates_ {false};
+  bool use_3d_bbs_for_scan_context_ {false};
+  double three_d_bbs_min_level_res_ {1.0};
+  int three_d_bbs_max_level_ {3};
+  double three_d_bbs_score_threshold_percentage_ {0.25};
+  int three_d_bbs_timeout_msec_ {50};
+  int three_d_bbs_num_threads_ {0};
+  double three_d_bbs_voxel_leaf_size_ {1.0};
+  int three_d_bbs_source_submap_num_ {2};
+  int three_d_bbs_target_submap_radius_ {1};
+  double three_d_bbs_translation_search_margin_m_ {15.0};
+  double three_d_bbs_roll_pitch_search_deg_ {10.0};
+  double three_d_bbs_yaw_search_deg_ {180.0};
+
+  // Map filtering, storage and export.
+  bool use_dynamic_object_filter_ {false};
+  double dynamic_object_filter_voxel_size_ {0.3};
+  int dynamic_object_filter_min_observations_ {2};
+  int dynamic_object_filter_temporal_window_ {5};
+  double dynamic_object_filter_max_range_from_sensor_m_ {30.0};
+  bool use_planar_map_filter_ {false};
+  double planar_map_filter_voxel_size_ {0.1};
+  int planar_map_filter_min_neighbors_ {3};
+  double planar_map_filter_max_small_eigenvalue_ratio_ {0.24};
+  double planar_map_filter_min_middle_eigenvalue_ratio_ {0.0};
+  double planar_map_filter_min_retained_ratio_ {0.90};
+  bool use_pcd_cache_ {false};
+  std::string pcd_cache_dir_ {"/tmp/graph_slam_pcd_cache"};
+  std::string map_save_dir_ {"."};
+  std::string save_pose_graph_path_ {"pose_graph.g2o"};
+  double map_grid_size_x_ {20.0};
+  double map_grid_size_y_ {20.0};
+  double map_leaf_size_ {0.2};
+
+  // Optional absolute and inertial constraints.
+  bool use_gnss_ {false};
+  std::string gnss_topic_ {"/gnss/fix"};
+  double gnss_info_weight_ {1.0};
+  bool gnss_use_covariance_weighting_ {true};
+  double gnss_covariance_min_variance_m2_ {0.01};
+  double gnss_covariance_max_variance_m2_ {25.0};
+  double gnss_rtk_fix_max_horizontal_stddev_m_ {0.3};
+  double gnss_rtk_fix_weight_scale_ {3.0};
+  double gnss_non_rtk_weight_scale_ {1.0};
+  double gnss_header_stamp_max_skew_sec_ {30.0};
+  bool gnss_align_yaw_ {true};
+  int gnss_yaw_alignment_min_anchors_ {10};
+  double gnss_yaw_alignment_min_baseline_m_ {5.0};
+  int gnss_origin_min_samples_ {3};
+  double gnss_origin_consistency_threshold_m_ {20.0};
+  bool use_imu_preintegration_ {false};
+  double imu_rotation_info_roll_pitch_ {100.0};
+  double imu_rotation_info_yaw_ {10.0};
+
+  // Direct odometry input and diagnostics.
+  bool use_odom_input_ {false};
+  double submap_distance_threshold_ {1.5};
+  int odom_cloud_sync_queue_size_ {100};
+  std::string degeneracy_diagnostics_csv_path_;
+  bool save_degeneracy_report_ {false};
+};
+
+struct ConfigNormalization
+{
+  std::vector<std::string> warnings;
+};
+
+GraphSlamConfig loadGraphSlamConfig(rclcpp::Node & node);
+ConfigNormalization normalizeGraphSlamConfig(GraphSlamConfig & config);
+std::vector<std::string> validateGraphSlamConfig(const GraphSlamConfig & config);
+void logGraphSlamConfig(const GraphSlamConfig & config, const rclcpp::Logger & logger);
+
+}  // namespace graphslam
+
+#endif  // GRAPH_SLAM_CONFIG_HPP_

--- a/graph_based_slam/test/test_graph_slam_composition.cpp
+++ b/graph_based_slam/test/test_graph_slam_composition.cpp
@@ -1,0 +1,87 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following disclaimer
+//    in the documentation and/or other materials provided with the
+//    distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include "graph_slam_composition.hpp"
+
+TEST(GraphSlamComposition, BuildsDescriptorAndLoopSearchBoundaries)
+{
+  graphslam::GraphSlamConfig config;
+  config.use_triangle_descriptor_ = true;
+  config.triangle_descriptor_max_keypoints_ = 73;
+  config.search_submap_num_ = 9;
+  config.max_loop_candidate_count_ = 7;
+  config.scan_context_query_stride_ = 0;
+  config.loop_max_translation_delta_ = 12.5;
+
+  const auto descriptor = graphslam::makeDescriptorConfig(config);
+  const auto loop_search = graphslam::makeLoopSearchConfig(config);
+
+  EXPECT_TRUE(descriptor.use_triangle_descriptor);
+  EXPECT_EQ(descriptor.triangle_descriptor_max_keypoints, 73);
+  EXPECT_EQ(loop_search.search_submap_num, 9);
+  EXPECT_EQ(loop_search.aggregator.max_loop_candidate_count, 7);
+  EXPECT_EQ(loop_search.aggregator.scan_context_query_stride, 1);
+  EXPECT_DOUBLE_EQ(loop_search.gates.max_translation_m, 12.5);
+}
+
+TEST(GraphSlamComposition, KeepsAdaptiveStateOutsideStartupConfig)
+{
+  graphslam::GraphSlamConfig config;
+  config.num_adjacent_pose_cnstraints_ = 8;
+  config.adjacent_edge_info_auto_scale_ = true;
+  config.adjacent_edge_info_auto_scale_split_trans_rot_ = true;
+  config.adjacent_edge_info_auto_scale_ema_alpha_ = 0.42;
+  config.loop_edge_robust_kernel_type_ = "cauchy";
+
+  const auto result = graphslam::makePoseGraphConfig(config, 11.0, 22.0, 33.0);
+
+  EXPECT_EQ(result.adjacent.num_adjacent_pose_constraints, 8);
+  EXPECT_DOUBLE_EQ(result.adjacent.info_weight, 11.0);
+  EXPECT_DOUBLE_EQ(result.adjacent.info_weight_trans, 22.0);
+  EXPECT_DOUBLE_EQ(result.adjacent.info_weight_rot, 33.0);
+  EXPECT_EQ(result.loop.robust_kernel_type, "cauchy");
+  EXPECT_EQ(result.chi2_collection, graphslam::pose_graph::Chi2Collection::SPLIT);
+  EXPECT_DOUBLE_EQ(result.auto_scale.ema_alpha, 0.42);
+}
+
+TEST(GraphSlamComposition, BuildsIoAndSensorPolicies)
+{
+  graphslam::GraphSlamConfig config;
+  config.dynamic_object_filter_min_observations_ = 6;
+  config.planar_map_filter_min_retained_ratio_ = 0.81;
+  config.map_grid_size_x_ = 31.0;
+  config.gnss_rtk_fix_weight_scale_ = 4.5;
+
+  EXPECT_EQ(graphslam::makeDynamicObjectFilterConfig(config).min_observations, 6);
+  EXPECT_DOUBLE_EQ(graphslam::makePlanarMapFilterConfig(config).min_retained_ratio, 0.81);
+  EXPECT_DOUBLE_EQ(graphslam::makeGridConfig(config).grid_size_x, 31.0);
+  EXPECT_DOUBLE_EQ(graphslam::makeGnssWeightingConfig(config).rtk_fix_weight_scale, 4.5);
+}

--- a/graph_based_slam/test/test_graph_slam_config.cpp
+++ b/graph_based_slam/test/test_graph_slam_config.cpp
@@ -1,0 +1,151 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following disclaimer
+//    in the documentation and/or other materials provided with the
+//    distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include "graph_slam_config.hpp"
+
+namespace
+{
+
+class GraphSlamConfigTest : public ::testing::Test
+{
+protected:
+  static void SetUpTestSuite()
+  {
+    if (!rclcpp::ok()) {
+      int argc = 0;
+      rclcpp::init(argc, nullptr);
+    }
+  }
+
+  static void TearDownTestSuite()
+  {
+    rclcpp::shutdown();
+  }
+};
+
+TEST_F(GraphSlamConfigTest, DefaultsAreValid)
+{
+  const graphslam::GraphSlamConfig config;
+  EXPECT_TRUE(graphslam::validateGraphSlamConfig(config).empty());
+}
+
+TEST_F(GraphSlamConfigTest, LoaderAppliesRosOverridesAndDeclaresCompleteSurface)
+{
+  rclcpp::NodeOptions options;
+  options.parameter_overrides({
+      rclcpp::Parameter("registration_method", "GICP"),
+      rclcpp::Parameter("voxel_leaf_size", 0.4),
+      rclcpp::Parameter("use_gnss", true),
+      rclcpp::Parameter("gnss_topic", "/fix/filtered"),
+  });
+  auto node = std::make_shared<rclcpp::Node>("graph_slam_config_test", options);
+  const auto parameters_before_load = node->list_parameters({}, 0).names.size();
+
+  const auto config = graphslam::loadGraphSlamConfig(*node);
+
+  EXPECT_EQ(config.registration_method, "GICP");
+  EXPECT_DOUBLE_EQ(config.voxel_leaf_size, 0.4);
+  EXPECT_TRUE(config.use_gnss_);
+  EXPECT_EQ(config.gnss_topic_, "/fix/filtered");
+  EXPECT_TRUE(node->has_parameter("triangle_descriptor_keypoint_mode"));
+  EXPECT_TRUE(node->has_parameter("degeneracy_diagnostics_csv_path"));
+  EXPECT_EQ(node->list_parameters({}, 0).names.size() - parameters_before_load, 143U);
+}
+
+TEST_F(GraphSlamConfigTest, ValidationReportsIndependentConfigurationErrors)
+{
+  graphslam::GraphSlamConfig config;
+  config.voxel_leaf_size = 0.0;
+  config.map_grid_size_x_ = -1.0;
+  config.odom_cloud_sync_queue_size_ = 0;
+  config.use_pcd_cache_ = true;
+  config.pcd_cache_dir_.clear();
+
+  const auto errors = graphslam::validateGraphSlamConfig(config);
+
+  EXPECT_EQ(errors.size(), 4U);
+  EXPECT_NE(
+    std::find(errors.begin(), errors.end(), "voxel_leaf_size must be finite and > 0"),
+    errors.end());
+  EXPECT_NE(
+    std::find(errors.begin(), errors.end(),
+      "pcd_cache_dir must not be empty when use_pcd_cache is true"),
+    errors.end());
+}
+
+TEST_F(GraphSlamConfigTest, NormalizationRepairsDependentAndBoundedValues)
+{
+  graphslam::GraphSlamConfig config;
+  config.adjacent_edge_info_weight_ = -2.0;
+  config.adjacent_edge_info_weight_trans_ = -1.0;
+  config.adjacent_edge_info_weight_rot_ = -1.0;
+  config.gnss_covariance_min_variance_m2_ = 2.0;
+  config.gnss_covariance_max_variance_m2_ = 1.0;
+  config.loop_min_overlap_ratio_ = 2.0;
+  config.triangle_descriptor_keypoint_mode_ = "unknown";
+  config.planar_map_filter_min_retained_ratio_ = 1.5;
+
+  const auto result = graphslam::normalizeGraphSlamConfig(config);
+
+  EXPECT_FALSE(result.warnings.empty());
+  EXPECT_DOUBLE_EQ(config.adjacent_edge_info_weight_, 1000.0);
+  EXPECT_DOUBLE_EQ(config.adjacent_edge_info_weight_trans_, 1000.0);
+  EXPECT_DOUBLE_EQ(config.adjacent_edge_info_weight_rot_, 1000.0);
+  EXPECT_DOUBLE_EQ(config.gnss_covariance_max_variance_m2_, 2.0);
+  EXPECT_DOUBLE_EQ(config.loop_min_overlap_ratio_, 0.0);
+  EXPECT_EQ(config.triangle_descriptor_keypoint_mode_, "bev_max_height");
+  EXPECT_DOUBLE_EQ(config.planar_map_filter_min_retained_ratio_, 1.0);
+}
+
+TEST_F(GraphSlamConfigTest, NormalizationIsIdempotent)
+{
+  graphslam::GraphSlamConfig config;
+  config.search_submap_num_ = 0;
+  config.bev_descriptor_sequence_threshold_ = -1.0;
+
+  graphslam::normalizeGraphSlamConfig(config);
+  const graphslam::GraphSlamConfig once = config;
+  const auto second = graphslam::normalizeGraphSlamConfig(config);
+
+  EXPECT_TRUE(second.warnings.empty());
+  EXPECT_EQ(config.search_submap_num_, once.search_submap_num_);
+  EXPECT_DOUBLE_EQ(
+    config.bev_descriptor_sequence_threshold_, once.bev_descriptor_sequence_threshold_);
+}
+
+}  // namespace

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ nav:
   - Autoware Foxglove: autoware-foxglove.md
   - Operator Workflows: workflows.md
   - Degeneracy Resilience Guide: degeneracy-guide.md
+  - Graph SLAM Architecture: graph-slam-architecture.md
   - 3DGS Photoreal Map: 3dgs-map-tutorial.md
   - 3DGS Map Viewer: 3dgs-viewer.md
   - Benchmarking And Release Gate: benchmarking.md


### PR DESCRIPTION
## Summary

Milestone 1 of the Graph SLAM ROS-shell / deterministic-engine redesign.

- centralize all 143 ROS parameters in a typed, source-private `GraphSlamConfig`
- split loading, normalization, validation, and logging into explicit startup phases
- freeze the validated configuration snapshot before runtime initialization
- keep adaptive edge weights and other live values outside configuration
- add pure composition builders for descriptor, loop-search, pose-graph, filtering, grid, and GNSS backend DTOs
- shrink the component implementation from 2,517 to 1,278 lines and replace the former ~864-line constructor with a short composition flow
- document the five-milestone target architecture and dependency direction
- repair existing documentation links that prevented the strict docs gate from completing

## Why

The ROS component previously combined parameter declaration, compatibility normalization, validation, backend DTO construction, runtime state mutation, filesystem effects, and ROS wiring in one constructor. This made configuration mapping difficult to test, encouraged startup intent to be mutated during execution, and left no clean composition root for the planned unified `GraphSlamApplication`.

This PR establishes that boundary without changing parameter names, defaults, topics, services, or backend algorithms.

## Impact

Backend configuration mapping can now be tested without constructing the ROS component. The immutable startup snapshot and pure builders give the next milestone a stable seam for routing both online callbacks and offline replay through one application layer.

## Validation

- `colcon build --packages-select graph_based_slam --symlink-install --cmake-args -DBUILD_TESTING=ON`
- config/composition unit tests: 2/2 passed
- Graph SLAM package suite: 155/155 CTest targets passed; 2,207 assertions, 0 failures
- default workflow: 4 packages; 2,421 tests, 0 errors, 0 failures, 117 skipped
- node startup smoke: passed
- `python3 -m mkdocs build --strict`: passed
- `ament_uncrustify` and `git diff --check`: passed
- synthetic release-readiness passing fixture: passed
- threshold guard failing fixture: rejected with expected exit code 2

## Follow-up milestones

1. Unified `GraphSlamApplication`
2. Backend engine ownership
3. External I/O ports
4. Architecture hardening and enforced online/offline byte-identical parity
