### PR TITLE
Unify Graph SLAM application workflow

### DIFF
--- a/docs/graph-slam-architecture.md
+++ b/docs/graph-slam-architecture.md
@@ -52,9 +52,17 @@ they are not configuration work.
 
 ### 2. Unified application
 
-- introduce `GraphSlamApplication` as the only mapping workflow entry point;
-- route online callbacks and offline replay through the same commands;
-- move orchestration and state transitions out of the ROS component.
+`GraphSlamApplication` is now the ordered, ROS-free mapping workflow entry
+point. Both the live component and deterministic bag replay submit the same
+ordered submap prefixes through `processSubmaps()`. The application owns the
+query cursor, stride scheduling, accepted/deduplicated loop-edge set, and the
+pose-graph optimization command. This makes callback batching observationally
+equivalent to submitting one submap at a time.
+
+The adapters still convert ROS messages, load clouds, emit logs, and publish or
+write results. Registration, voxel filtering, descriptor storage, and 3D-BBS
+objects are injected into the application during this milestone so their
+ownership can move as one coherent unit in milestone 3.
 
 ### 3. Backend engine ownership
 

--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -119,6 +119,22 @@ set_target_properties(graph_slam_config PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_include_directories(graph_slam_config PRIVATE src)
 ament_target_dependencies(graph_slam_config rclcpp)
 
+add_library(graph_slam_application STATIC
+  src/graph_slam_application.cpp
+)
+set_target_properties(graph_slam_application PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_include_directories(
+  graph_slam_application PUBLIC include ${EIGEN3_INCLUDE_DIR} ${PCL_INCLUDE_DIRS}
+)
+target_link_libraries(
+  graph_slam_application
+  ${PCL_LIBRARIES}
+  g2o::core
+  g2o::types_slam3d
+  g2o::solver_eigen
+  g2o::stuff
+)
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   find_package(ament_cmake_gtest REQUIRED)
@@ -292,6 +308,23 @@ if(BUILD_TESTING)
     ament_target_dependencies(test_backend_core ndt_omp_ros2)
     target_link_libraries(
       test_backend_core ${PCL_LIBRARIES} graph_based_slam_3d_bbs_vendor
+    )
+  endif()
+  ament_add_gtest(
+    test_graph_slam_application
+    test/test_graph_slam_application.cpp
+    src/three_d_bbs_loop_verifier.cpp
+  )
+  if(TARGET test_graph_slam_application)
+    target_include_directories(
+      test_graph_slam_application PRIVATE include ${EIGEN3_INCLUDE_DIR}
+    )
+    ament_target_dependencies(test_graph_slam_application ndt_omp_ros2)
+    target_link_libraries(
+      test_graph_slam_application
+      graph_slam_application
+      ${PCL_LIBRARIES}
+      graph_based_slam_3d_bbs_vendor
     )
   endif()
   ament_add_gtest(
@@ -1065,6 +1098,7 @@ ament_target_dependencies(graph_based_slam_component
 
 target_link_libraries(graph_based_slam_component
   graph_slam_config
+  graph_slam_application
   g2o::core
   g2o::types_slam3d
   g2o::solver_eigen
@@ -1127,6 +1161,7 @@ ament_target_dependencies(graph_slam_offline_runner
 )
 
 target_link_libraries(graph_slam_offline_runner
+  graph_slam_application
   ${PCL_LIBRARIES}
   g2o::core
   g2o::types_slam3d

--- a/graph_based_slam/include/graph_based_slam/backend_core.hpp
+++ b/graph_based_slam/include/graph_based_slam/backend_core.hpp
@@ -31,9 +31,10 @@
 #define GRAPH_BASED_SLAM__BACKEND_CORE_HPP_
 
 // The ROS-free, clock-free backend state (docs/roadmap/v0.6.md, Phase 2).
-// This first stage owns the four loop-closure descriptor databases and
-// their submap-ingestion logic; the search and optimization orchestration
-// migrate here in later stages. The contract this class builds toward:
+// This engine owns the four loop-closure descriptor databases and their
+// submap-ingestion/search algorithms. GraphSlamApplication owns workflow
+// ordering and accepted graph state; engine resource ownership moves here
+// in the next architecture milestone. The contract this class builds toward:
 // the same ordered submap sequence plus the same config produce the same
 // state, independent of wall-clock timing. The shell supplies clouds via
 // a provider callback, so message-vs-PCD-cache stays its concern.

--- a/graph_based_slam/include/graph_based_slam/graph_slam_application.hpp
+++ b/graph_based_slam/include/graph_based_slam/graph_slam_application.hpp
@@ -1,0 +1,122 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following disclaimer
+//    in the documentation and/or other materials provided with the
+//    distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef GRAPH_BASED_SLAM__GRAPH_SLAM_APPLICATION_HPP_
+#define GRAPH_BASED_SLAM__GRAPH_SLAM_APPLICATION_HPP_
+
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "graph_based_slam/backend_core.hpp"
+#include "graph_based_slam/loop_edge_set.hpp"
+#include "graph_based_slam/pose_graph_optimization.hpp"
+
+namespace graphslam
+{
+
+// The ordered, ROS-free workflow boundary shared by live and replay adapters.
+// Milestone 2 deliberately injects the compute-heavy engine objects; ownership
+// of those resources moves into the backend in Milestone 3.
+struct GraphSlamApplicationConfig
+{
+  backend_core::DescriptorConfig descriptors;
+  backend_core::LoopSearchConfig loop_search;
+  int loop_search_query_stride {1};
+  int loop_edge_dedup_index_window {8};
+};
+
+struct GraphSlamApplicationDependencies
+{
+  backend_core::BackendCore & backend;
+  pcl::Registration<pcl::PointXYZI, pcl::PointXYZI> & registration;
+  pcl::VoxelGrid<pcl::PointXYZI> & voxelgrid;
+  ThreeDBBSLoopVerifier & three_d_bbs_verifier;
+};
+
+struct LoopSearchEvent
+{
+  int query_index {-1};
+  bool registration_searched {false};
+  backend_core::LoopSearchOutput search_output;
+  bool graph_changed {false};
+  std::vector<backend_core::LoopEdgeSet::Edge> loop_edges;
+};
+
+struct PoseGraphRequest
+{
+  std::vector<pose_graph::SubmapNode> submaps;
+  std::vector<backend_core::LoopEdgeSet::Edge> loop_edges;
+  std::vector<pose_graph::ImuRotationConstraint> imu_constraints;
+  std::vector<pose_graph::GnssConstraint> gnss_constraints;
+  pose_graph::AdjacentEdgeConfig adjacent_config;
+  pose_graph::LoopEdgeConfig loop_config;
+  pose_graph::ImuEdgeConfig imu_config;
+  pose_graph::Chi2Collection chi2_collection {pose_graph::Chi2Collection::NONE};
+  bool fix_first_vertex {true};
+  int iterations {10};
+  std::string save_path;
+  std::vector<pose_graph::PlaneRevisitConstraint> plane_constraints;
+};
+
+class GraphSlamApplication
+{
+public:
+  using LocalSubmapProvider = backend_core::BackendCore::LocalSubmapProvider;
+  using LoopEdge = backend_core::LoopEdgeSet::Edge;
+
+  GraphSlamApplication(
+    GraphSlamApplicationConfig config,
+    GraphSlamApplicationDependencies dependencies);
+
+  // Process every not-yet-observed query from the ordered prefix. The same
+  // input prefix produces the same event order regardless of callback/bag
+  // batching. Providers are invoked synchronously and are not retained.
+  std::vector<LoopSearchEvent> processSubmaps(
+    const std::vector<backend_core::SubmapMeta> & ordered_submaps,
+    const LocalSubmapProvider & filtered_local_provider,
+    const LocalSubmapProvider & raw_cloud_provider);
+
+  bool upsertLoopEdge(const LoopEdge & edge);
+  std::vector<LoopEdge> loopEdges() const;
+  int nextQueryIndex() const;
+
+  pose_graph::OptimizationResult optimize(const PoseGraphRequest & request) const;
+
+private:
+  GraphSlamApplicationConfig config_;
+  GraphSlamApplicationDependencies dependencies_;
+  mutable std::mutex mutex_;
+  int next_query_index_ {1};
+  backend_core::LoopEdgeSet loop_edges_;
+};
+
+}  // namespace graphslam
+
+#endif  // GRAPH_BASED_SLAM__GRAPH_SLAM_APPLICATION_HPP_

--- a/graph_based_slam/include/graph_based_slam/graph_state_store.hpp
+++ b/graph_based_slam/include/graph_based_slam/graph_state_store.hpp
@@ -33,32 +33,21 @@
 #include <cstddef>
 #include <mutex>
 #include <utility>
-#include <vector>
 
 #include <lidarslam_msgs/msg/map_array.hpp>
 #include <lidarslam_msgs/msg/sub_map.hpp>
 #include <std_msgs/msg/header.hpp>
 
-#include "graph_based_slam/loop_edge_set.hpp"
-
 namespace graphslam
 {
 
-// The ROS shell's authoritative graph input state. Expensive cloud
+// The ROS shell's authoritative ROS-message input snapshot. Expensive cloud
 // conversion and cache I/O must finish before replace()/append() so readers
 // observe either the previous complete state or the next complete state.
+// Mapping workflow state and accepted loop edges belong to GraphSlamApplication.
 class GraphStateStore
 {
 public:
-  using LoopEdge = backend_core::LoopEdgeSet::Edge;
-  using LoopEdges = std::vector<LoopEdge>;
-
-  void configureLoopEdgeDedupWindow(int window)
-  {
-    std::lock_guard<std::mutex> lock(mutex_);
-    loop_edges_.configure(window);
-  }
-
   void replace(lidarslam_msgs::msg::MapArray map_array)
   {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -83,36 +72,20 @@ public:
     return map_array_.submaps.size();
   }
 
-  bool snapshot(
-    lidarslam_msgs::msg::MapArray & map_array,
-    LoopEdges & loop_edges) const
+  bool snapshot(lidarslam_msgs::msg::MapArray & map_array) const
   {
     std::lock_guard<std::mutex> lock(mutex_);
     if (!initialized_) {
       return false;
     }
     map_array = map_array_;
-    loop_edges = loop_edges_.edges();
     return true;
-  }
-
-  LoopEdges snapshotLoopEdges() const
-  {
-    std::lock_guard<std::mutex> lock(mutex_);
-    return loop_edges_.edges();
-  }
-
-  bool upsertLoopEdge(const LoopEdge & loop_edge)
-  {
-    std::lock_guard<std::mutex> lock(mutex_);
-    return loop_edges_.upsert(loop_edge);
   }
 
 private:
   mutable std::mutex mutex_;
   bool initialized_{false};
   lidarslam_msgs::msg::MapArray map_array_;
-  backend_core::LoopEdgeSet loop_edges_;
 };
 
 }  // namespace graphslam

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -54,8 +54,8 @@
 #include "graph_based_slam/gnss_alignment.hpp"
 #include "graph_based_slam/gnss_geometry.hpp"
 #include "graph_based_slam/gnss_weighting.hpp"
+#include "graph_based_slam/graph_slam_application.hpp"
 #include "graph_based_slam/loop_verifier.hpp"
-#include "graph_based_slam/loop_search_schedule.hpp"
 #include "graph_based_slam/map_saver.hpp"
 #include "graph_based_slam/planar_map_filter.hpp"
 #include "graph_based_slam/pose_graph_optimization.hpp"
@@ -96,6 +96,7 @@ struct GraphBasedSlamComponent::Impl::BackendWorkspace
   boost::shared_ptr<pcl::Registration<pcl::PointXYZI, pcl::PointXYZI>> registration;
   pcl::VoxelGrid<pcl::PointXYZI> voxelgrid;
   ThreeDBBSLoopVerifier three_d_bbs_loop_verifier;
+  std::unique_ptr<GraphSlamApplication> application;
 };
 
 GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & options)
@@ -126,7 +127,6 @@ GraphBasedSlamComponent::Impl::Impl(GraphBasedSlamComponent & node)
   }
   gnss_origin_accumulator_.configure(
     config_.gnss_origin_min_samples_, config_.gnss_origin_consistency_threshold_m_);
-  graph_state_.configureLoopEdgeDedupWindow(config_.loop_edge_dedup_index_window_);
   logGraphSlamConfig(config_, node_.get_logger());
   if (!config_.degeneracy_diagnostics_csv_path_.empty()) {
     degeneracy_csv_ofs_.open(config_.degeneracy_diagnostics_csv_path_);
@@ -150,7 +150,15 @@ GraphBasedSlamComponent::Impl::Impl(GraphBasedSlamComponent & node)
     exit(1);
   }
 
-  backend_->core.configure(makeDescriptorConfig(config_));
+  GraphSlamApplicationConfig application_config;
+  application_config.descriptors = makeDescriptorConfig(config_);
+  application_config.loop_search = makeLoopSearchConfig(config_);
+  application_config.loop_search_query_stride = config_.loop_search_query_stride_;
+  application_config.loop_edge_dedup_index_window = config_.loop_edge_dedup_index_window_;
+  backend_->application.reset(new GraphSlamApplication(
+      application_config,
+      {backend_->core, *backend_->registration, backend_->voxelgrid,
+        backend_->three_d_bbs_loop_verifier}));
 
   initializePubSub();
 
@@ -275,17 +283,11 @@ bool GraphBasedSlamComponent::Impl::snapshotGraphState(
   lidarslam_msgs::msg::MapArray & map_array_msg,
   LoopEdges & loop_edges)
 {
-  return graph_state_.snapshot(map_array_msg, loop_edges);
-}
-
-void GraphBasedSlamComponent::Impl::snapshotLoopEdges(LoopEdges & loop_edges)
-{
-  loop_edges = graph_state_.snapshotLoopEdges();
-}
-
-bool GraphBasedSlamComponent::Impl::upsertLoopEdge(const LoopEdge & loop_edge)
-{
-  return graph_state_.upsertLoopEdge(loop_edge);
+  if (!graph_state_.snapshot(map_array_msg)) {
+    return false;
+  }
+  loop_edges = backend_->application->loopEdges();
+  return true;
 }
 GraphBasedSlamComponent::Impl::LocalSubmapProvider
 GraphBasedSlamComponent::Impl::makeFilteredLocalSubmapProvider(
@@ -339,98 +341,58 @@ void GraphBasedSlamComponent::Impl::drainEventDrivenLoopSearch()
     if (!snapshotGraphState(map_array_msg, loop_edges)) {return;}
     const int num_submaps = static_cast<int>(map_array_msg.submaps.size());
     if (num_submaps < 2) {return;}
-    int query_idx = last_searched_submap_idx_ + 1;
-    if (query_idx < 1) {query_idx = 1;}
-    if (query_idx >= num_submaps) {return;}
+    if (backend_->application->nextQueryIndex() >= num_submaps) {return;}
     if (map_array_msg.cloud_coordinate != map_array_msg.LOCAL) {
       RCLCPP_WARN(node_.get_logger(), "cloud_coordinate should be local, but it's not local.");
     }
-    const auto build_filtered_local_submap = makeFilteredLocalSubmapProvider(map_array_msg);
-    // One immutable snapshot serves the whole currently available batch.
-    // Each search receives an explicit prefix length, avoiding one full
-    // MapArray deep-copy per query without exposing future submaps to q.
-    for (; query_idx < num_submaps && rclcpp::ok(); ++query_idx) {
+    std::vector<backend_core::SubmapMeta> ordered_submaps;
+    ordered_submaps.reserve(map_array_msg.submaps.size());
+    for (const auto & submap : map_array_msg.submaps) {
+      backend_core::SubmapMeta meta;
+      tf2::fromMsg(submap.pose, meta.pose);
+      meta.travel_distance = submap.distance;
+      ordered_submaps.push_back(meta);
+    }
+    const auto filtered_local_provider = makeFilteredLocalSubmapProvider(map_array_msg);
+    const auto raw_cloud_provider =
+      [this, &map_array_msg](int idx) -> pcl::PointCloud<pcl::PointXYZI>::Ptr {
+        return loadSubmapCloud(map_array_msg, idx);
+      };
+    const auto events = backend_->application->processSubmaps(
+      ordered_submaps, filtered_local_provider, raw_cloud_provider);
+    for (const auto & event : events) {
       if (config_.debug_flag_) {
         RCLCPP_INFO(
-          node_.get_logger(), "event-driven loop search, query submap %d of %d", query_idx,
+          node_.get_logger(), "event-driven loop search, query submap %d of %d", event.query_index,
           num_submaps);
       }
-      backend_->core.ingestDescriptors(query_idx + 1, build_filtered_local_submap);
-      if (loop_search_schedule::shouldSearch(query_idx, config_.loop_search_query_stride_)) {
-        searchLoopForLatest(map_array_msg, loop_edges, query_idx + 1, query_idx);
-      } else if (config_.debug_flag_) {
+      for (const auto & line : event.search_output.logs) {
+        if (line.via_logger) {
+          RCLCPP_INFO(node_.get_logger(), "%s", line.text.c_str());
+        } else {
+          std::cout << line.text << std::endl;
+        }
+      }
+      if (!event.registration_searched && config_.debug_flag_) {
         RCLCPP_INFO(
           node_.get_logger(), "loop search registration skipped for query submap %d by stride %d",
-          query_idx, config_.loop_search_query_stride_);
+          event.query_index, config_.loop_search_query_stride_);
       }
-      last_searched_submap_idx_ = query_idx;
+      if (event.search_output.proposal.found && !event.graph_changed) {
+        std::cout << "loop edge skipped as redundant or lower quality" << std::endl;
+      }
+      if (event.graph_changed) {
+        lidarslam_msgs::msg::MapArray query_prefix;
+        query_prefix.header = map_array_msg.header;
+        query_prefix.cloud_coordinate = map_array_msg.cloud_coordinate;
+        query_prefix.submaps.assign(
+          map_array_msg.submaps.begin(),
+          map_array_msg.submaps.begin() + event.query_index + 1);
+        doPoseAdjustment(
+          std::move(query_prefix), event.loop_edges, config_.use_save_map_in_loop_);
+      }
     }
   }
-}
-
-void GraphBasedSlamComponent::Impl::searchLoopForLatest(
-  const lidarslam_msgs::msg::MapArray & map_array_msg,
-  LoopEdges & loop_edges,
-  int num_submaps,
-  int latest_idx)
-{
-  if (num_submaps < 1 || num_submaps > static_cast<int>(map_array_msg.submaps.size())) {
-    return;
-  }
-  std::vector<backend_core::SubmapMeta> submaps;
-  submaps.reserve(num_submaps);
-  for (int i = 0; i < num_submaps; ++i) {
-    const auto & submap = map_array_msg.submaps[i];
-    backend_core::SubmapMeta meta;
-    tf2::fromMsg(submap.pose, meta.pose);
-    meta.travel_distance = submap.distance;
-    submaps.push_back(meta);
-  }
-
-  const auto raw_cloud_provider =
-    [this, &map_array_msg](int idx) -> pcl::PointCloud<pcl::PointXYZI>::Ptr {
-      return loadSubmapCloud(map_array_msg, idx);
-    };
-
-  const backend_core::LoopSearchConfig search_config = makeLoopSearchConfig(config_);
-
-  const backend_core::LoopSearchOutput search_output = backend_->core.searchLoopForSubmap(
-    submaps,
-    latest_idx,
-    search_config,
-    raw_cloud_provider,
-    *backend_->registration,
-    backend_->voxelgrid,
-    backend_->three_d_bbs_loop_verifier);
-
-  for (const auto & line : search_output.logs) {
-    if (line.via_logger) {
-      RCLCPP_INFO(node_.get_logger(), "%s", line.text.c_str());
-    } else {
-      std::cout << line.text << std::endl;
-    }
-  }
-
-  if (!search_output.proposal.found) {
-    return;
-  }
-
-  LoopEdge loop_edge;
-  loop_edge.pair_id = search_output.proposal.pair_id;
-  loop_edge.relative_pose = search_output.proposal.relative_pose;
-  loop_edge.fitness_score = search_output.proposal.fitness_score;
-  const bool graph_changed = upsertLoopEdge(loop_edge);
-  if (!graph_changed) {
-    std::cout << "loop edge skipped as redundant or lower quality" << std::endl;
-    return;
-  }
-  snapshotLoopEdges(loop_edges);
-  lidarslam_msgs::msg::MapArray query_prefix;
-  query_prefix.header = map_array_msg.header;
-  query_prefix.cloud_coordinate = map_array_msg.cloud_coordinate;
-  query_prefix.submaps.assign(
-    map_array_msg.submaps.begin(), map_array_msg.submaps.begin() + num_submaps);
-  doPoseAdjustment(std::move(query_prefix), loop_edges, config_.use_save_map_in_loop_);
 }
 
 void GraphBasedSlamComponent::Impl::doPoseAdjustment(
@@ -479,18 +441,6 @@ void GraphBasedSlamComponent::Impl::doPoseAdjustment(
       RCLCPP_INFO(
         node_.get_logger(), "Added %zu IMU rotation constraint edges", imu_constraints.size());
     }
-  }
-
-  /* loop edges -> plain constraints */
-  std::vector<pose_graph::LoopConstraint> loop_constraints;
-  loop_constraints.reserve(loop_edges.size());
-  for (const auto & loop_edge : loop_edges) {
-    pose_graph::LoopConstraint loop_constraint;
-    loop_constraint.from = loop_edge.pair_id.first;
-    loop_constraint.to = loop_edge.pair_id.second;
-    loop_constraint.relative_pose = loop_edge.relative_pose;
-    loop_constraint.fitness_score = loop_edge.fitness_score;
-    loop_constraints.push_back(loop_constraint);
   }
 
   /* GNSS anchors (pre-pass: nearest-measurement match over the buffer) */
@@ -586,11 +536,19 @@ void GraphBasedSlamComponent::Impl::doPoseAdjustment(
     std::filesystem::create_directories(config_.map_save_dir_);
     pose_graph_save_path = bundle_pose_graph_path;
   }
-  const pose_graph::OptimizationResult opt_result = pose_graph::optimizePoseGraph(
-    submap_nodes, loop_constraints, imu_constraints, gnss_constraints,
-    pose_graph_config.adjacent, pose_graph_config.loop, pose_graph_config.imu,
-    pose_graph_config.chi2_collection,
-    fix_first_vertex, /*iterations=*/ 10, pose_graph_save_path);
+  PoseGraphRequest optimization_request;
+  optimization_request.submaps = submap_nodes;
+  optimization_request.loop_edges = loop_edges;
+  optimization_request.imu_constraints = imu_constraints;
+  optimization_request.gnss_constraints = gnss_constraints;
+  optimization_request.adjacent_config = pose_graph_config.adjacent;
+  optimization_request.loop_config = pose_graph_config.loop;
+  optimization_request.imu_config = pose_graph_config.imu;
+  optimization_request.chi2_collection = pose_graph_config.chi2_collection;
+  optimization_request.fix_first_vertex = fix_first_vertex;
+  optimization_request.save_path = pose_graph_save_path;
+  const pose_graph::OptimizationResult opt_result =
+    backend_->application->optimize(optimization_request);
 
   if (do_save_map && !config_.save_pose_graph_path_.empty() &&
     std::filesystem::path(config_.save_pose_graph_path_).lexically_normal() !=

--- a/graph_based_slam/src/graph_based_slam_component_impl.hpp
+++ b/graph_based_slam/src/graph_based_slam_component_impl.hpp
@@ -68,6 +68,7 @@
 #include "graph_based_slam/degeneracy_report_summary.hpp"
 #include "graph_based_slam/gnss_origin_accumulator.hpp"
 #include "graph_based_slam/graph_state_store.hpp"
+#include "graph_based_slam/loop_edge_set.hpp"
 #include "graph_based_slam/serialized_work_drain.hpp"
 
 namespace graphslam
@@ -113,8 +114,7 @@ private:
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr modified_map_pub_;
   rclcpp::Service<std_srvs::srv::Empty>::SharedPtr map_save_srv_;
 
-  using LoopEdge = GraphStateStore::LoopEdge;
-  using LoopEdges = GraphStateStore::LoopEdges;
+  using LoopEdges = std::vector<backend_core::LoopEdgeSet::Edge>;
   using PointCloud = pcl::PointCloud<pcl::PointXYZI>;
   using PointCloudPtr = PointCloud::Ptr;
   using LocalSubmapProvider = std::function<PointCloudPtr(int)>;
@@ -133,12 +133,6 @@ private:
     // the data, not of how the executor batched arrivals.
   void runEventDrivenLoopSearch();
   void drainEventDrivenLoopSearch();
-    // Per-query loop search body shared by the event-driven drain.
-  void searchLoopForLatest(
-    const lidarslam_msgs::msg::MapArray & map_array_msg,
-    LoopEdges & loop_edges,
-    int num_submaps,
-    int latest_idx);
     // Voxel-filtered local aggregate of a submap and its recent neighbors;
     // the returned provider borrows map_array_msg and must not outlive it.
   LocalSubmapProvider makeFilteredLocalSubmapProvider(
@@ -146,15 +140,12 @@ private:
   bool snapshotGraphState(
     lidarslam_msgs::msg::MapArray & map_array_msg,
     LoopEdges & loop_edges);
-  void snapshotLoopEdges(LoopEdges & loop_edges);
-  bool upsertLoopEdge(const LoopEdge & loop_edge);
   void doPoseAdjustment(
     lidarslam_msgs::msg::MapArray map_array_msg,
     const LoopEdges & loop_edges,
     bool do_save_map);
   void publishMapAndPose();
 
-  int last_searched_submap_idx_ {-1};
     // Event-driven loop search (the only scheduling semantics since v0.7
     // Phase 0): loop search runs once per submap arrival in arrival order,
     // each query seeing exactly the map state up to itself. The legacy

--- a/graph_based_slam/src/graph_slam_application.cpp
+++ b/graph_based_slam/src/graph_slam_application.cpp
@@ -1,0 +1,136 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following disclaimer
+//    in the documentation and/or other materials provided with the
+//    distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "graph_based_slam/graph_slam_application.hpp"
+
+#include <algorithm>
+#include <stdexcept>
+#include <utility>
+
+#include "graph_based_slam/loop_search_schedule.hpp"
+
+namespace graphslam
+{
+
+GraphSlamApplication::GraphSlamApplication(
+  GraphSlamApplicationConfig config,
+  GraphSlamApplicationDependencies dependencies)
+: config_(std::move(config)), dependencies_(dependencies)
+{
+  if (config_.loop_search_query_stride < 1) {
+    throw std::invalid_argument("loop_search_query_stride must be at least 1");
+  }
+  if (config_.loop_edge_dedup_index_window < 0) {
+    throw std::invalid_argument("loop_edge_dedup_index_window must not be negative");
+  }
+  dependencies_.backend.configure(config_.descriptors);
+  loop_edges_.configure(config_.loop_edge_dedup_index_window);
+}
+
+std::vector<LoopSearchEvent> GraphSlamApplication::processSubmaps(
+  const std::vector<backend_core::SubmapMeta> & ordered_submaps,
+  const LocalSubmapProvider & filtered_local_provider,
+  const LocalSubmapProvider & raw_cloud_provider)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  std::vector<LoopSearchEvent> events;
+  const int submap_count = static_cast<int>(ordered_submaps.size());
+  if (next_query_index_ >= submap_count) {
+    return events;
+  }
+
+  events.reserve(static_cast<std::size_t>(submap_count - next_query_index_));
+  for (; next_query_index_ < submap_count; ++next_query_index_) {
+    LoopSearchEvent event;
+    event.query_index = next_query_index_;
+    dependencies_.backend.ingestDescriptors(next_query_index_ + 1, filtered_local_provider);
+    event.registration_searched = loop_search_schedule::shouldSearch(
+      next_query_index_, config_.loop_search_query_stride);
+    if (event.registration_searched) {
+      // Expose only the ordered prefix visible to this query. This makes
+      // batching observationally equivalent to one-submap-at-a-time input.
+      std::vector<backend_core::SubmapMeta> visible(
+        ordered_submaps.begin(), ordered_submaps.begin() + next_query_index_ + 1);
+      event.search_output = dependencies_.backend.searchLoopForSubmap(
+        visible, next_query_index_, config_.loop_search, raw_cloud_provider,
+        dependencies_.registration, dependencies_.voxelgrid,
+        dependencies_.three_d_bbs_verifier);
+      if (event.search_output.proposal.found) {
+        LoopEdge edge;
+        edge.pair_id = event.search_output.proposal.pair_id;
+        edge.relative_pose = event.search_output.proposal.relative_pose;
+        edge.fitness_score = event.search_output.proposal.fitness_score;
+        event.graph_changed = loop_edges_.upsert(edge);
+      }
+    }
+    event.loop_edges = loop_edges_.edges();
+    events.push_back(std::move(event));
+  }
+  return events;
+}
+
+bool GraphSlamApplication::upsertLoopEdge(const LoopEdge & edge)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  return loop_edges_.upsert(edge);
+}
+
+std::vector<GraphSlamApplication::LoopEdge> GraphSlamApplication::loopEdges() const
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  return loop_edges_.edges();
+}
+
+int GraphSlamApplication::nextQueryIndex() const
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  return next_query_index_;
+}
+
+pose_graph::OptimizationResult GraphSlamApplication::optimize(
+  const PoseGraphRequest & request) const
+{
+  std::vector<pose_graph::LoopConstraint> loop_constraints;
+  loop_constraints.reserve(request.loop_edges.size());
+  for (const auto & edge : request.loop_edges) {
+    pose_graph::LoopConstraint constraint;
+    constraint.from = edge.pair_id.first;
+    constraint.to = edge.pair_id.second;
+    constraint.relative_pose = edge.relative_pose;
+    constraint.fitness_score = edge.fitness_score;
+    loop_constraints.push_back(constraint);
+  }
+  return pose_graph::optimizePoseGraph(
+    request.submaps, loop_constraints, request.imu_constraints,
+    request.gnss_constraints, request.adjacent_config, request.loop_config,
+    request.imu_config, request.chi2_collection, request.fix_first_vertex,
+    request.iterations, request.save_path, request.plane_constraints);
+}
+
+}  // namespace graphslam

--- a/graph_based_slam/src/graph_slam_offline_runner.cpp
+++ b/graph_based_slam/src/graph_slam_offline_runner.cpp
@@ -70,8 +70,8 @@
 #include "graph_based_slam/backend_core.hpp"
 #include "graph_based_slam/degeneracy_diagnostics_csv.hpp"
 #include "graph_based_slam/degeneracy_report_summary.hpp"
+#include "graph_based_slam/graph_slam_application.hpp"
 #include "graph_based_slam/map_refiner.hpp"
-#include "graph_based_slam/loop_search_schedule.hpp"
 #include "graph_based_slam/plane_feature_association.hpp"
 #include "graph_based_slam/plane_revisit_constraints.hpp"
 #include "graph_based_slam/pose_graph_optimization.hpp"
@@ -111,7 +111,7 @@ void writeTum(
 void loadFixedLoopEdges(
   const std::string & path,
   std::size_t submap_count,
-  graphslam::backend_core::LoopEdgeSet & edge_set)
+  graphslam::GraphSlamApplication & application)
 {
   std::ifstream input(path);
   if (!input.is_open()) {
@@ -164,7 +164,7 @@ void loadFixedLoopEdges(
       throw std::runtime_error(
               "fixed loop edge index out of range at line " + std::to_string(line_number));
     }
-    if (!edge_set.upsert(edge)) {
+    if (!application.upsertLoopEdge(edge)) {
       throw std::runtime_error(
               "fixed loop edge was invalid or deduplicated at line " +
               std::to_string(line_number));
@@ -566,15 +566,19 @@ int main(int argc, char ** argv)
   graphslam::ThreeDBBSLoopVerifier bbs_verifier;
 
   BackendCore core;
-  core.configure(descriptor_config);
-  graphslam::backend_core::LoopEdgeSet edge_set;
-  edge_set.configure(loop_edge_dedup_index_window < 0 ? 0 : loop_edge_dedup_index_window);
+  graphslam::GraphSlamApplicationConfig application_config;
+  application_config.descriptors = descriptor_config;
+  application_config.loop_search = search_config;
+  application_config.loop_search_query_stride = loop_search_query_stride;
+  application_config.loop_edge_dedup_index_window =
+    loop_edge_dedup_index_window < 0 ? 0 : loop_edge_dedup_index_window;
+  graphslam::GraphSlamApplication application(
+    application_config, {core, *registration, voxelgrid, bbs_verifier});
 
   std::vector<SubmapRecord> records;
   bool last_position_valid = false;
   Eigen::Vector3d last_position = Eigen::Vector3d::Zero();
   double accumulated_distance = 0.0;
-  int next_query_idx = 1;
 
   // The same voxel-filtered local-aggregate semantics as the component's
   // makeFilteredLocalSubmapProvider, over the in-memory record store.
@@ -606,45 +610,27 @@ int main(int argc, char ** argv)
     };
 
   const auto drain_queries = [&]() {
-      const int num_submaps = static_cast<int>(records.size());
       if (!fixed_loop_edges_path.empty()) {
-        next_query_idx = num_submaps;
         return;
       }
-      while (next_query_idx < num_submaps) {
-        const int query_idx = next_query_idx;
-        core.ingestDescriptors(query_idx + 1, filtered_local_provider);
-        if (!graphslam::loop_search_schedule::shouldSearch(
-            query_idx, loop_search_query_stride))
-        {
-          next_query_idx = query_idx + 1;
-          continue;
-        }
-        std::vector<graphslam::backend_core::SubmapMeta> visible;
-        visible.reserve(query_idx + 1);
-        for (int i = 0; i <= query_idx; ++i) {
-          visible.push_back(records[i].meta);
-        }
-        const graphslam::backend_core::LoopSearchOutput output = core.searchLoopForSubmap(
-          visible, query_idx, search_config, raw_cloud_provider, *registration, voxelgrid,
-          bbs_verifier);
-        for (const auto & line : output.logs) {
+      std::vector<graphslam::backend_core::SubmapMeta> ordered_submaps;
+      ordered_submaps.reserve(records.size());
+      for (const auto & record : records) {
+        ordered_submaps.push_back(record.meta);
+      }
+      const auto events = application.processSubmaps(
+        ordered_submaps, filtered_local_provider, raw_cloud_provider);
+      for (const auto & event : events) {
+        for (const auto & line : event.search_output.logs) {
           if (line.via_logger) {
             RCLCPP_INFO(logger, "%s", line.text.c_str());
           } else {
             std::cout << line.text << std::endl;
           }
         }
-        if (output.proposal.found) {
-          graphslam::backend_core::LoopEdgeSet::Edge edge;
-          edge.pair_id = output.proposal.pair_id;
-          edge.relative_pose = output.proposal.relative_pose;
-          edge.fitness_score = output.proposal.fitness_score;
-          if (!edge_set.upsert(edge)) {
-            std::cout << "loop edge skipped as redundant or lower quality" << std::endl;
-          }
+        if (event.search_output.proposal.found && !event.graph_changed) {
+          std::cout << "loop edge skipped as redundant or lower quality" << std::endl;
         }
-        next_query_idx = query_idx + 1;
       }
     };
 
@@ -723,10 +709,10 @@ int main(int argc, char ** argv)
 
   if (!fixed_loop_edges_path.empty()) {
     try {
-      loadFixedLoopEdges(fixed_loop_edges_path, records.size(), edge_set);
+      loadFixedLoopEdges(fixed_loop_edges_path, records.size(), application);
       RCLCPP_INFO(
         logger, "Loaded %zu fixed loop edges from %s; descriptor search was skipped",
-        edge_set.edges().size(), fixed_loop_edges_path.c_str());
+        application.loopEdges().size(), fixed_loop_edges_path.c_str());
     } catch (const std::exception & error) {
       RCLCPP_ERROR(logger, "%s", error.what());
       rclcpp::shutdown();
@@ -738,7 +724,7 @@ int main(int argc, char ** argv)
     logger,
     "Offline run complete: %zu pairs, %zu submaps, %.1f m travelled, %zu loop edges "
     "(%zu odom / %zu cloud messages left unpaired)",
-    paired_count, records.size(), accumulated_distance, edge_set.edges().size(),
+    paired_count, records.size(), accumulated_distance, application.loopEdges().size(),
     pending_odoms.size(), pending_clouds.size());
 
   // --- Final pose-graph optimization from raw odometry poses plus the
@@ -751,16 +737,7 @@ int main(int argc, char ** argv)
     submap_node.pose = Eigen::Isometry3d(record.meta.pose.matrix());
     submap_nodes.push_back(submap_node);
   }
-  std::vector<graphslam::pose_graph::LoopConstraint> loop_constraints;
-  loop_constraints.reserve(edge_set.edges().size());
-  for (const auto & edge : edge_set.edges()) {
-    graphslam::pose_graph::LoopConstraint loop_constraint;
-    loop_constraint.from = edge.pair_id.first;
-    loop_constraint.to = edge.pair_id.second;
-    loop_constraint.relative_pose = edge.relative_pose;
-    loop_constraint.fitness_score = edge.fitness_score;
-    loop_constraints.push_back(loop_constraint);
-  }
+  const auto loop_edges = application.loopEdges();
   graphslam::pose_graph::AdjacentEdgeConfig adjacent_config;
   adjacent_config.num_adjacent_pose_constraints = num_adjacent_pose_constraints;
   adjacent_config.info_weight = adjacent_edge_info_weight;
@@ -843,11 +820,14 @@ int main(int argc, char ** argv)
   std::vector<Eigen::Isometry3d> optimized_poses;
   optimized_poses.reserve(records.size());
   if (!records.empty()) {
-    const graphslam::pose_graph::OptimizationResult result =
-      graphslam::pose_graph::optimizePoseGraph(
-      submap_nodes, loop_constraints, {}, {}, adjacent_config, loop_config, imu_config,
-      graphslam::pose_graph::Chi2Collection::NONE, true, 10, std::string(),
-      plane_revisit_result.constraints);
+    graphslam::PoseGraphRequest request;
+    request.submaps = submap_nodes;
+    request.loop_edges = loop_edges;
+    request.adjacent_config = adjacent_config;
+    request.loop_config = loop_config;
+    request.imu_config = imu_config;
+    request.plane_constraints = plane_revisit_result.constraints;
+    const graphslam::pose_graph::OptimizationResult result = application.optimize(request);
     optimized_poses = result.poses;
     if (use_plane_revisit_constraints) {
       std::ofstream report(output_dir + "/plane_revisit_report.yaml");
@@ -893,7 +873,7 @@ int main(int argc, char ** argv)
     std::ofstream csv(output_dir + "/loop_edges.csv");
     csv << "from,to,fitness,tx,ty,tz,qx,qy,qz,qw\n";
     char line[512];
-    for (const auto & edge : edge_set.edges()) {
+    for (const auto & edge : loop_edges) {
       const Eigen::Vector3d t = edge.relative_pose.translation();
       const Eigen::Quaterniond q(edge.relative_pose.rotation());
       std::snprintf(

--- a/graph_based_slam/test/test_graph_slam_application.cpp
+++ b/graph_based_slam/test/test_graph_slam_application.cpp
@@ -1,0 +1,163 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following disclaimer
+//    in the documentation and/or other materials provided with the
+//    distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+#include <pcl/registration/icp.h>  // NOLINT(build/include_order)
+
+#include "graph_based_slam/graph_slam_application.hpp"
+
+namespace graphslam
+{
+namespace
+{
+
+using Cloud = pcl::PointCloud<pcl::PointXYZI>;
+
+struct Fixture
+{
+  backend_core::BackendCore backend;
+  pcl::IterativeClosestPoint<pcl::PointXYZI, pcl::PointXYZI> registration;
+  pcl::VoxelGrid<pcl::PointXYZI> voxelgrid;
+  ThreeDBBSLoopVerifier verifier;
+
+  std::unique_ptr<GraphSlamApplication> makeApplication(int stride = 1)
+  {
+    GraphSlamApplicationConfig config;
+    config.loop_search_query_stride = stride;
+    return std::unique_ptr<GraphSlamApplication>(new GraphSlamApplication(
+      config, {backend, registration, voxelgrid, verifier}));
+  }
+};
+
+backend_core::BackendCore::CloudPtr emptyCloud(int index)
+{
+  static_cast<void>(index);
+  backend_core::BackendCore::CloudPtr cloud(new Cloud);
+  return cloud;
+}
+
+std::vector<backend_core::SubmapMeta> submaps(int count)
+{
+  std::vector<backend_core::SubmapMeta> result(static_cast<std::size_t>(count));
+  for (int i = 0; i < count; ++i) {
+    result[static_cast<std::size_t>(i)].pose.translation().x() = i * 10.0;
+    result[static_cast<std::size_t>(i)].travel_distance = i * 10.0;
+  }
+  return result;
+}
+
+TEST(GraphSlamApplication, BatchAndIncrementalInputProduceTheSameQueryOrder)
+{
+  Fixture batch_fixture;
+  auto batch = batch_fixture.makeApplication();
+  const auto batch_events = batch->processSubmaps(submaps(5), emptyCloud, emptyCloud);
+
+  Fixture incremental_fixture;
+  auto incremental = incremental_fixture.makeApplication();
+  std::vector<LoopSearchEvent> incremental_events;
+  for (int count = 1; count <= 5; ++count) {
+    const auto events = incremental->processSubmaps(submaps(count), emptyCloud, emptyCloud);
+    incremental_events.insert(incremental_events.end(), events.begin(), events.end());
+  }
+
+  ASSERT_EQ(batch_events.size(), 4U);
+  ASSERT_EQ(incremental_events.size(), batch_events.size());
+  for (std::size_t i = 0; i < batch_events.size(); ++i) {
+    EXPECT_EQ(batch_events[i].query_index, incremental_events[i].query_index);
+    EXPECT_EQ(batch_events[i].registration_searched, incremental_events[i].registration_searched);
+    EXPECT_EQ(batch_events[i].graph_changed, incremental_events[i].graph_changed);
+    EXPECT_EQ(batch_events[i].loop_edges.size(), incremental_events[i].loop_edges.size());
+  }
+  EXPECT_EQ(batch->nextQueryIndex(), 5);
+  EXPECT_EQ(incremental->nextQueryIndex(), 5);
+}
+
+TEST(GraphSlamApplication, StrideSkipsRegistrationButStillAdvancesEveryQuery)
+{
+  Fixture fixture;
+  auto application = fixture.makeApplication(2);
+  const auto events = application->processSubmaps(submaps(6), emptyCloud, emptyCloud);
+
+  ASSERT_EQ(events.size(), 5U);
+  EXPECT_TRUE(events[0].registration_searched);
+  EXPECT_FALSE(events[1].registration_searched);
+  EXPECT_TRUE(events[2].registration_searched);
+  EXPECT_FALSE(events[3].registration_searched);
+  EXPECT_TRUE(events[4].registration_searched);
+  EXPECT_EQ(application->nextQueryIndex(), 6);
+}
+
+TEST(GraphSlamApplication, OwnsTheCanonicalDeduplicatedLoopEdgeSet)
+{
+  Fixture fixture;
+  auto application = fixture.makeApplication();
+  GraphSlamApplication::LoopEdge edge;
+  edge.pair_id = {9, 2};
+  edge.relative_pose.translation().x() = 7.0;
+  edge.fitness_score = 0.3;
+
+  ASSERT_TRUE(application->upsertLoopEdge(edge));
+  const auto edges = application->loopEdges();
+  ASSERT_EQ(edges.size(), 1U);
+  EXPECT_EQ(edges[0].pair_id, std::make_pair(2, 9));
+  EXPECT_DOUBLE_EQ(edges[0].relative_pose.translation().x(), -7.0);
+  EXPECT_DOUBLE_EQ(edges[0].fitness_score, 0.3);
+}
+
+TEST(GraphSlamApplication, OptimizesPlainPoseGraphRequestsThroughTheSharedEntryPoint)
+{
+  Fixture fixture;
+  auto application = fixture.makeApplication();
+  PoseGraphRequest request;
+  request.submaps.resize(1);
+  request.submaps[0].pose.translation().x() = 3.5;
+
+  const auto result = application->optimize(request);
+
+  ASSERT_EQ(result.poses.size(), 1U);
+  EXPECT_DOUBLE_EQ(result.poses[0].translation().x(), 3.5);
+}
+
+TEST(GraphSlamApplication, RejectsInvalidWorkflowConfiguration)
+{
+  Fixture fixture;
+  GraphSlamApplicationConfig config;
+  config.loop_search_query_stride = 0;
+  EXPECT_THROW(
+    GraphSlamApplication(config, {
+        fixture.backend, fixture.registration, fixture.voxelgrid, fixture.verifier}),
+    std::invalid_argument);
+}
+
+}  // namespace
+}  // namespace graphslam

--- a/graph_based_slam/test/test_graph_state_store.cpp
+++ b/graph_based_slam/test/test_graph_state_store.cpp
@@ -40,12 +40,11 @@ TEST(GraphStateStore, IsEmptyUntilTheFirstCompleteStateIsCommitted)
 {
   graphslam::GraphStateStore store;
   lidarslam_msgs::msg::MapArray map_array;
-  graphslam::GraphStateStore::LoopEdges loop_edges;
 
-  EXPECT_FALSE(store.snapshot(map_array, loop_edges));
+  EXPECT_FALSE(store.snapshot(map_array));
 
   store.replace(lidarslam_msgs::msg::MapArray());
-  EXPECT_TRUE(store.snapshot(map_array, loop_edges));
+  EXPECT_TRUE(store.snapshot(map_array));
   EXPECT_TRUE(map_array.submaps.empty());
 }
 
@@ -59,12 +58,11 @@ TEST(GraphStateStore, ReplaceAndSnapshotDoNotAliasCallerOwnedMessages)
   store.replace(std::move(input));
 
   lidarslam_msgs::msg::MapArray first_snapshot;
-  graphslam::GraphStateStore::LoopEdges loop_edges;
-  ASSERT_TRUE(store.snapshot(first_snapshot, loop_edges));
+  ASSERT_TRUE(store.snapshot(first_snapshot));
   first_snapshot.submaps[0].distance = 99.0;
 
   lidarslam_msgs::msg::MapArray second_snapshot;
-  ASSERT_TRUE(store.snapshot(second_snapshot, loop_edges));
+  ASSERT_TRUE(store.snapshot(second_snapshot));
   EXPECT_EQ(second_snapshot.header.frame_id, "map");
   ASSERT_EQ(second_snapshot.submaps.size(), 1U);
   EXPECT_DOUBLE_EQ(second_snapshot.submaps[0].distance, 12.5);
@@ -82,29 +80,11 @@ TEST(GraphStateStore, AppendCommitsMapHeaderAndSubmapTogether)
   EXPECT_EQ(store.append(std::move(submap), header), 1U);
 
   lidarslam_msgs::msg::MapArray snapshot;
-  graphslam::GraphStateStore::LoopEdges loop_edges;
-  ASSERT_TRUE(store.snapshot(snapshot, loop_edges));
+  ASSERT_TRUE(store.snapshot(snapshot));
   EXPECT_EQ(snapshot.header.frame_id, "map");
   EXPECT_EQ(snapshot.header.stamp.sec, 42);
   ASSERT_EQ(snapshot.submaps.size(), 1U);
   EXPECT_DOUBLE_EQ(snapshot.submaps[0].distance, 3.0);
-}
-
-TEST(GraphStateStore, SnapshotKeepsMapAndAcceptedEdgesInOneCriticalSection)
-{
-  graphslam::GraphStateStore store;
-  store.configureLoopEdgeDedupWindow(0);
-  store.replace(lidarslam_msgs::msg::MapArray());
-  graphslam::GraphStateStore::LoopEdge edge;
-  edge.pair_id = {1, 4};
-  edge.fitness_score = 0.2;
-  ASSERT_TRUE(store.upsertLoopEdge(edge));
-
-  lidarslam_msgs::msg::MapArray snapshot;
-  graphslam::GraphStateStore::LoopEdges loop_edges;
-  ASSERT_TRUE(store.snapshot(snapshot, loop_edges));
-  ASSERT_EQ(loop_edges.size(), 1U);
-  EXPECT_EQ(loop_edges[0].pair_id, std::make_pair(1, 4));
 }
 
 TEST(GraphStateStore, ConcurrentAppendAndSnapshotRemainConsistent)
@@ -128,8 +108,7 @@ TEST(GraphStateStore, ConcurrentAppendAndSnapshotRemainConsistent)
 
   while (!writer_done.load()) {
     lidarslam_msgs::msg::MapArray snapshot;
-    graphslam::GraphStateStore::LoopEdges loop_edges;
-    if (!store.snapshot(snapshot, loop_edges)) {
+    if (!store.snapshot(snapshot)) {
       inconsistent_snapshot = true;
       break;
     }


### PR DESCRIPTION
## Summary
- introduce a ROS-free `GraphSlamApplication` as the shared ordered workflow boundary
- route online callbacks and offline replay through the same loop-search and pose-optimization commands
- make the application the canonical owner of query scheduling and accepted loop edges

## Architecture
Registration, voxel filtering, descriptor storage, and 3D-BBS resources remain injected in this milestone; ownership moves in Milestone 3. ROS message conversion, logging, publishing, and filesystem output remain adapter concerns.

This is a stacked PR based on #372. Review the Milestone 1 configuration boundary first.

## Validation
- repository default CI: 4 packages, 2438 tests, 0 errors/failures, 120 skipped
- affected component, offline runner, and application targets build
- Application unit tests, copyright, cpplint, and uncrustify pass
- ROS component startup smoke passes
- `mkdocs build --strict`
- synthetic release-readiness fixture passes and threshold guard rejects the failing fixture with exit 2
