### PR TITLE
Own Graph SLAM engine resources

### DIFF
--- a/docs/graph-slam-architecture.md
+++ b/docs/graph-slam-architecture.md
@@ -66,9 +66,24 @@ ownership can move as one coherent unit in milestone 3.
 
 ### 3. Backend engine ownership
 
-- make the application own graph, registration, optimization, and scheduling;
-- expose immutable result snapshots instead of shared mutable containers;
-- keep ordering and tie-breaking explicit for deterministic output.
+`GraphSlamApplication` is now the aggregate lifetime boundary for the mapping
+engine. It is constructed from plain configuration only. Its private engine
+owns descriptor databases, registration, the shared voxel filter, 3D-BBS,
+query scheduling, and the canonical deduplicated loop graph. Neither the ROS
+component nor the offline runner can construct or retain those resources.
+
+Descriptor aggregation and filtering also moved behind `processSubmaps()`.
+Adapters now supply only ordered submap metadata and a synchronous raw-cloud
+provider; batching therefore cannot select a different filtering path.
+`GraphSlamStateSnapshot` and per-query events return graph state by value.
+Pose-graph requests no longer accept loop edges from callers: optimization
+uses the canonical graph induced by the supplied submap prefix, excluding any
+later accepted edges after a batched drain.
+
+Registration creation and invalid-method handling are identical online and
+offline because they happen in the same constructor. The composition root
+maps the validated ROS snapshot into the complete application configuration;
+the offline adapter builds the same plain DTO from replay parameters.
 
 ### 4. External I/O ports
 

--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -126,6 +126,7 @@ set_target_properties(graph_slam_application PROPERTIES POSITION_INDEPENDENT_COD
 target_include_directories(
   graph_slam_application PUBLIC include ${EIGEN3_INCLUDE_DIR} ${PCL_INCLUDE_DIRS}
 )
+ament_target_dependencies(graph_slam_application ndt_omp_ros2)
 target_link_libraries(
   graph_slam_application
   ${PCL_LIBRARIES}

--- a/graph_based_slam/include/graph_based_slam/backend_core.hpp
+++ b/graph_based_slam/include/graph_based_slam/backend_core.hpp
@@ -32,9 +32,9 @@
 
 // The ROS-free, clock-free backend state (docs/roadmap/v0.6.md, Phase 2).
 // This engine owns the four loop-closure descriptor databases and their
-// submap-ingestion/search algorithms. GraphSlamApplication owns workflow
-// ordering and accepted graph state; engine resource ownership moves here
-// in the next architecture milestone. The contract this class builds toward:
+// submap-ingestion/search algorithms. GraphSlamApplication is the aggregate
+// lifetime boundary: its private engine owns this state together with the
+// registration, filters, verifier, scheduling and accepted graph. The contract:
 // the same ordered submap sequence plus the same config produce the same
 // state, independent of wall-clock timing. The shell supplies clouds via
 // a provider callback, so message-vs-PCD-cache stays its concern.
@@ -263,9 +263,9 @@ inline double registrationOverlapRatio(
   return registrationOverlapMetrics(aligned_source, target, max_distance_m).source_to_target;
 }
 
-// Backend-owned loop-closure state. Single-threaded by contract: the ROS
-// shell enforces this with SerializedWorkDrain and the offline runner owns
-// the core from its bag loop.
+// Backend-owned loop-closure state. Single-threaded by contract: the owning
+// GraphSlamApplication serializes access, while the ROS shell only coalesces
+// notifications from a potentially multi-threaded executor.
 class BackendCore
 {
 public:
@@ -373,8 +373,8 @@ public:
   // (pure aggregator calls over the descriptor databases), registration
   // verification and best-candidate selection. Raw submap clouds come
   // from the provider (message vs PCD cache stays the shell's concern);
-  // the registration / voxel filter / 3D-BBS compute objects are injected
-  // so the shell and the offline runner can own their own instances.
+  // registration / voxel filter / 3D-BBS compute objects are borrowed from
+  // the owning GraphSlamApplication engine for this synchronous operation.
   // Every operator-visible line is returned as a LogLine so the shell
   // emits byte-identical output.
   LoopSearchOutput searchLoopForSubmap(

--- a/graph_based_slam/include/graph_based_slam/graph_slam_application.hpp
+++ b/graph_based_slam/include/graph_based_slam/graph_slam_application.hpp
@@ -30,7 +30,7 @@
 #ifndef GRAPH_BASED_SLAM__GRAPH_SLAM_APPLICATION_HPP_
 #define GRAPH_BASED_SLAM__GRAPH_SLAM_APPLICATION_HPP_
 
-#include <mutex>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -42,22 +42,19 @@ namespace graphslam
 {
 
 // The ordered, ROS-free workflow boundary shared by live and replay adapters.
-// Milestone 2 deliberately injects the compute-heavy engine objects; ownership
-// of those resources moves into the backend in Milestone 3.
+// It is also the lifetime boundary for every stateful mapping-engine resource:
+// descriptor databases, registration, filtering, 3D-BBS, scheduling and the
+// canonical graph. Adapters provide ordered data, never engine objects.
 struct GraphSlamApplicationConfig
 {
   backend_core::DescriptorConfig descriptors;
   backend_core::LoopSearchConfig loop_search;
+  std::string registration_method {"NDT"};
+  double ndt_resolution {3.0};
+  int ndt_num_threads {0};
+  double voxel_leaf_size {0.2};
   int loop_search_query_stride {1};
   int loop_edge_dedup_index_window {8};
-};
-
-struct GraphSlamApplicationDependencies
-{
-  backend_core::BackendCore & backend;
-  pcl::Registration<pcl::PointXYZI, pcl::PointXYZI> & registration;
-  pcl::VoxelGrid<pcl::PointXYZI> & voxelgrid;
-  ThreeDBBSLoopVerifier & three_d_bbs_verifier;
 };
 
 struct LoopSearchEvent
@@ -72,7 +69,6 @@ struct LoopSearchEvent
 struct PoseGraphRequest
 {
   std::vector<pose_graph::SubmapNode> submaps;
-  std::vector<backend_core::LoopEdgeSet::Edge> loop_edges;
   std::vector<pose_graph::ImuRotationConstraint> imu_constraints;
   std::vector<pose_graph::GnssConstraint> gnss_constraints;
   pose_graph::AdjacentEdgeConfig adjacent_config;
@@ -85,36 +81,39 @@ struct PoseGraphRequest
   std::vector<pose_graph::PlaneRevisitConstraint> plane_constraints;
 };
 
+struct GraphSlamStateSnapshot
+{
+  int next_query_index {1};
+  std::vector<backend_core::LoopEdgeSet::Edge> loop_edges;
+};
+
 class GraphSlamApplication
 {
 public:
   using LocalSubmapProvider = backend_core::BackendCore::LocalSubmapProvider;
   using LoopEdge = backend_core::LoopEdgeSet::Edge;
 
-  GraphSlamApplication(
-    GraphSlamApplicationConfig config,
-    GraphSlamApplicationDependencies dependencies);
+  explicit GraphSlamApplication(GraphSlamApplicationConfig config);
+  ~GraphSlamApplication();
+
+  GraphSlamApplication(const GraphSlamApplication &) = delete;
+  GraphSlamApplication & operator=(const GraphSlamApplication &) = delete;
 
   // Process every not-yet-observed query from the ordered prefix. The same
   // input prefix produces the same event order regardless of callback/bag
   // batching. Providers are invoked synchronously and are not retained.
   std::vector<LoopSearchEvent> processSubmaps(
     const std::vector<backend_core::SubmapMeta> & ordered_submaps,
-    const LocalSubmapProvider & filtered_local_provider,
     const LocalSubmapProvider & raw_cloud_provider);
 
   bool upsertLoopEdge(const LoopEdge & edge);
-  std::vector<LoopEdge> loopEdges() const;
-  int nextQueryIndex() const;
+  GraphSlamStateSnapshot stateSnapshot() const;
 
   pose_graph::OptimizationResult optimize(const PoseGraphRequest & request) const;
 
 private:
-  GraphSlamApplicationConfig config_;
-  GraphSlamApplicationDependencies dependencies_;
-  mutable std::mutex mutex_;
-  int next_query_index_ {1};
-  backend_core::LoopEdgeSet loop_edges_;
+  class Engine;
+  std::unique_ptr<Engine> engine_;
 };
 
 }  // namespace graphslam

--- a/graph_based_slam/include/graph_based_slam/loop_edge_set.hpp
+++ b/graph_based_slam/include/graph_based_slam/loop_edge_set.hpp
@@ -44,8 +44,8 @@ namespace backend_core
 {
 
 // Accepted loop edges with the nearby-pair dedup/upsert policy. This
-// container is deliberately synchronization-free; BackendCore owns one in
-// offline mode and GraphStateStore protects one in the ROS shell.
+// container is deliberately synchronization-free; GraphSlamApplication owns
+// the single canonical instance and protects it with its engine mutex.
 class LoopEdgeSet
 {
 public:

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -38,6 +38,7 @@
 #include <stdexcept>
 #include <unordered_map>
 
+#include <pcl/common/common.h>  // NOLINT(build/include_order)
 #include <pcl/io/pcd_io.h>  // NOLINT(build/include_order)
 #include <pcl/filters/voxel_grid.h>  // NOLINT(build/include_order)
 #include <pcl_conversions/pcl_conversions.h>  // NOLINT(build/include_order)
@@ -59,7 +60,6 @@
 #include "graph_based_slam/map_saver.hpp"
 #include "graph_based_slam/planar_map_filter.hpp"
 #include "graph_based_slam/pose_graph_optimization.hpp"
-#include "graph_based_slam/registration_factory.hpp"
 #include "graph_based_slam/submap_creation.hpp"
 #include "g2o/core/robust_kernel_impl.h"
 #define GRAPH_BASED_SLAM_WITH_G2O 1
@@ -92,10 +92,11 @@ GraphSlamConfig loadValidatedGraphSlamConfig(rclcpp::Node & node)
 
 struct GraphBasedSlamComponent::Impl::BackendWorkspace
 {
-  backend_core::BackendCore core;
-  boost::shared_ptr<pcl::Registration<pcl::PointXYZI, pcl::PointXYZI>> registration;
-  pcl::VoxelGrid<pcl::PointXYZI> voxelgrid;
-  ThreeDBBSLoopVerifier three_d_bbs_loop_verifier;
+  explicit BackendWorkspace(GraphSlamApplicationConfig config)
+  : application(new GraphSlamApplication(std::move(config)))
+  {
+  }
+
   std::unique_ptr<GraphSlamApplication> application;
 };
 
@@ -114,7 +115,7 @@ GraphBasedSlamComponent::Impl::Impl(GraphBasedSlamComponent & node)
   tfbuffer_(std::make_shared<rclcpp::Clock>(clock_)),
   listener_(tfbuffer_),
   broadcaster_(&node_),
-  backend_(std::make_unique<BackendWorkspace>())
+  backend_(std::make_unique<BackendWorkspace>(makeGraphSlamApplicationConfig(config_)))
 {
   RCLCPP_INFO(node_.get_logger(), "initialization start");
 
@@ -138,27 +139,6 @@ GraphBasedSlamComponent::Impl::Impl(GraphBasedSlamComponent & node)
         config_.degeneracy_diagnostics_csv_path_.c_str());
     }
   }
-
-  backend_->voxelgrid.setLeafSize(
-    config_.voxel_leaf_size, config_.voxel_leaf_size, config_.voxel_leaf_size);
-
-  backend_->registration =
-    backend_core::makeLoopRegistration(
-    config_.registration_method, config_.ndt_resolution, config_.ndt_num_threads);
-  if (!backend_->registration) {
-    RCLCPP_ERROR(node_.get_logger(), "invalid registration_method");
-    exit(1);
-  }
-
-  GraphSlamApplicationConfig application_config;
-  application_config.descriptors = makeDescriptorConfig(config_);
-  application_config.loop_search = makeLoopSearchConfig(config_);
-  application_config.loop_search_query_stride = config_.loop_search_query_stride_;
-  application_config.loop_edge_dedup_index_window = config_.loop_edge_dedup_index_window_;
-  backend_->application.reset(new GraphSlamApplication(
-      application_config,
-      {backend_->core, *backend_->registration, backend_->voxelgrid,
-        backend_->three_d_bbs_loop_verifier}));
 
   initializePubSub();
 
@@ -286,44 +266,8 @@ bool GraphBasedSlamComponent::Impl::snapshotGraphState(
   if (!graph_state_.snapshot(map_array_msg)) {
     return false;
   }
-  loop_edges = backend_->application->loopEdges();
+  loop_edges = backend_->application->stateSnapshot().loop_edges;
   return true;
-}
-GraphBasedSlamComponent::Impl::LocalSubmapProvider
-GraphBasedSlamComponent::Impl::makeFilteredLocalSubmapProvider(
-  const lidarslam_msgs::msg::MapArray & map_array_msg)
-{
-  return [this, &map_array_msg](int ref_idx) -> pcl::PointCloud<pcl::PointXYZI>::Ptr {
-           pcl::PointCloud<pcl::PointXYZI>::Ptr aggregated_cloud(
-             new pcl::PointCloud<pcl::PointXYZI>);
-           Eigen::Affine3d reference_affine;
-           tf2::fromMsg(map_array_msg.submaps[ref_idx].pose, reference_affine);
-           for (int k = 0; k < config_.search_submap_num_ && (ref_idx - k) >= 0; ++k) {
-             const int src_idx = ref_idx - k;
-             pcl::PointCloud<pcl::PointXYZI>::Ptr cloud =
-               loadSubmapCloud(map_array_msg, src_idx);
-             if (!cloud || cloud->empty()) {
-               continue;
-             }
-             Eigen::Affine3d src_affine;
-             tf2::fromMsg(map_array_msg.submaps[src_idx].pose, src_affine);
-             pcl::PointCloud<pcl::PointXYZI>::Ptr transformed_cloud(
-               new pcl::PointCloud<pcl::PointXYZI>);
-             const Eigen::Matrix4f local_transform =
-               (reference_affine.inverse() * src_affine).matrix().cast<float>();
-             pcl::transformPointCloud(*cloud, *transformed_cloud, local_transform);
-             *aggregated_cloud += *transformed_cloud;
-           }
-
-           pcl::PointCloud<pcl::PointXYZI>::Ptr filtered_cloud(
-             new pcl::PointCloud<pcl::PointXYZI>);
-           if (aggregated_cloud->empty()) {
-             return filtered_cloud;
-           }
-           backend_->voxelgrid.setInputCloud(aggregated_cloud);
-           backend_->voxelgrid.filter(*filtered_cloud);
-           return filtered_cloud;
-         };
 }
 
 void GraphBasedSlamComponent::Impl::runEventDrivenLoopSearch()
@@ -341,7 +285,7 @@ void GraphBasedSlamComponent::Impl::drainEventDrivenLoopSearch()
     if (!snapshotGraphState(map_array_msg, loop_edges)) {return;}
     const int num_submaps = static_cast<int>(map_array_msg.submaps.size());
     if (num_submaps < 2) {return;}
-    if (backend_->application->nextQueryIndex() >= num_submaps) {return;}
+    if (backend_->application->stateSnapshot().next_query_index >= num_submaps) {return;}
     if (map_array_msg.cloud_coordinate != map_array_msg.LOCAL) {
       RCLCPP_WARN(node_.get_logger(), "cloud_coordinate should be local, but it's not local.");
     }
@@ -353,13 +297,12 @@ void GraphBasedSlamComponent::Impl::drainEventDrivenLoopSearch()
       meta.travel_distance = submap.distance;
       ordered_submaps.push_back(meta);
     }
-    const auto filtered_local_provider = makeFilteredLocalSubmapProvider(map_array_msg);
     const auto raw_cloud_provider =
       [this, &map_array_msg](int idx) -> pcl::PointCloud<pcl::PointXYZI>::Ptr {
         return loadSubmapCloud(map_array_msg, idx);
       };
     const auto events = backend_->application->processSubmaps(
-      ordered_submaps, filtered_local_provider, raw_cloud_provider);
+      ordered_submaps, raw_cloud_provider);
     for (const auto & event : events) {
       if (config_.debug_flag_) {
         RCLCPP_INFO(
@@ -538,7 +481,6 @@ void GraphBasedSlamComponent::Impl::doPoseAdjustment(
   }
   PoseGraphRequest optimization_request;
   optimization_request.submaps = submap_nodes;
-  optimization_request.loop_edges = loop_edges;
   optimization_request.imu_constraints = imu_constraints;
   optimization_request.gnss_constraints = gnss_constraints;
   optimization_request.adjacent_config = pose_graph_config.adjacent;

--- a/graph_based_slam/src/graph_based_slam_component_impl.hpp
+++ b/graph_based_slam/src/graph_based_slam_component_impl.hpp
@@ -117,7 +117,6 @@ private:
   using LoopEdges = std::vector<backend_core::LoopEdgeSet::Edge>;
   using PointCloud = pcl::PointCloud<pcl::PointXYZI>;
   using PointCloudPtr = PointCloud::Ptr;
-  using LocalSubmapProvider = std::function<PointCloudPtr(int)>;
   using MapSaveRequestHeader = std::shared_ptr<rmw_request_id_t>;
   using MapSaveRequest = std::shared_ptr<std_srvs::srv::Empty::Request>;
   using MapSaveResponse = std::shared_ptr<std_srvs::srv::Empty::Response>;
@@ -133,10 +132,6 @@ private:
     // the data, not of how the executor batched arrivals.
   void runEventDrivenLoopSearch();
   void drainEventDrivenLoopSearch();
-    // Voxel-filtered local aggregate of a submap and its recent neighbors;
-    // the returned provider borrows map_array_msg and must not outlive it.
-  LocalSubmapProvider makeFilteredLocalSubmapProvider(
-    const lidarslam_msgs::msg::MapArray & map_array_msg);
   bool snapshotGraphState(
     lidarslam_msgs::msg::MapArray & map_array_msg,
     LoopEdges & loop_edges);

--- a/graph_based_slam/src/graph_slam_application.cpp
+++ b/graph_based_slam/src/graph_slam_application.cpp
@@ -30,66 +30,132 @@
 #include "graph_based_slam/graph_slam_application.hpp"
 
 #include <algorithm>
+#include <mutex>
 #include <stdexcept>
 #include <utility>
 
 #include "graph_based_slam/loop_search_schedule.hpp"
+#include "graph_based_slam/registration_factory.hpp"
 
 namespace graphslam
 {
 
-GraphSlamApplication::GraphSlamApplication(
-  GraphSlamApplicationConfig config,
-  GraphSlamApplicationDependencies dependencies)
-: config_(std::move(config)), dependencies_(dependencies)
+class GraphSlamApplication::Engine
 {
-  if (config_.loop_search_query_stride < 1) {
-    throw std::invalid_argument("loop_search_query_stride must be at least 1");
+public:
+  using CloudPtr = backend_core::BackendCore::CloudPtr;
+  using LocalSubmapProvider = backend_core::BackendCore::LocalSubmapProvider;
+
+  explicit Engine(GraphSlamApplicationConfig application_config)
+  : config(std::move(application_config))
+  {
+    if (config.loop_search_query_stride < 1) {
+      throw std::invalid_argument("loop_search_query_stride must be at least 1");
+    }
+    if (config.loop_edge_dedup_index_window < 0) {
+      throw std::invalid_argument("loop_edge_dedup_index_window must not be negative");
+    }
+    if (!(config.voxel_leaf_size > 0.0)) {
+      throw std::invalid_argument("voxel_leaf_size must be positive");
+    }
+    registration = backend_core::makeLoopRegistration(
+      config.registration_method, config.ndt_resolution, config.ndt_num_threads);
+    if (!registration) {
+      throw std::invalid_argument("unknown registration_method: " + config.registration_method);
+    }
+    const float voxel_leaf_size = static_cast<float>(config.voxel_leaf_size);
+    voxelgrid.setLeafSize(voxel_leaf_size, voxel_leaf_size, voxel_leaf_size);
+    backend.configure(config.descriptors);
+    loop_edges.configure(config.loop_edge_dedup_index_window);
   }
-  if (config_.loop_edge_dedup_index_window < 0) {
-    throw std::invalid_argument("loop_edge_dedup_index_window must not be negative");
+
+  CloudPtr filteredLocalSubmap(
+    const std::vector<backend_core::SubmapMeta> & ordered_submaps,
+    const LocalSubmapProvider & raw_cloud_provider,
+    int reference_index)
+  {
+    CloudPtr aggregate(new pcl::PointCloud<pcl::PointXYZI>);
+    const Eigen::Affine3d & reference_pose = ordered_submaps[reference_index].pose;
+    for (int offset = 0;
+      offset < config.loop_search.search_submap_num && reference_index - offset >= 0;
+      ++offset)
+    {
+      const int source_index = reference_index - offset;
+      const CloudPtr source = raw_cloud_provider(source_index);
+      if (!source || source->empty()) {
+        continue;
+      }
+      CloudPtr transformed(new pcl::PointCloud<pcl::PointXYZI>);
+      const Eigen::Matrix4f local_transform =
+        (reference_pose.inverse() * ordered_submaps[source_index].pose).matrix().cast<float>();
+      pcl::transformPointCloud(*source, *transformed, local_transform);
+      *aggregate += *transformed;
+    }
+
+    CloudPtr filtered(new pcl::PointCloud<pcl::PointXYZI>);
+    if (!aggregate->empty()) {
+      voxelgrid.setInputCloud(aggregate);
+      voxelgrid.filter(*filtered);
+    }
+    return filtered;
   }
-  dependencies_.backend.configure(config_.descriptors);
-  loop_edges_.configure(config_.loop_edge_dedup_index_window);
+
+  GraphSlamApplicationConfig config;
+  backend_core::BackendCore backend;
+  boost::shared_ptr<pcl::Registration<pcl::PointXYZI, pcl::PointXYZI>> registration;
+  pcl::VoxelGrid<pcl::PointXYZI> voxelgrid;
+  ThreeDBBSLoopVerifier three_d_bbs_verifier;
+  mutable std::mutex mutex;
+  int next_query_index {1};
+  backend_core::LoopEdgeSet loop_edges;
+};
+
+GraphSlamApplication::GraphSlamApplication(GraphSlamApplicationConfig config)
+: engine_(new Engine(std::move(config)))
+{
 }
+
+GraphSlamApplication::~GraphSlamApplication() = default;
 
 std::vector<LoopSearchEvent> GraphSlamApplication::processSubmaps(
   const std::vector<backend_core::SubmapMeta> & ordered_submaps,
-  const LocalSubmapProvider & filtered_local_provider,
   const LocalSubmapProvider & raw_cloud_provider)
 {
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::lock_guard<std::mutex> lock(engine_->mutex);
   std::vector<LoopSearchEvent> events;
   const int submap_count = static_cast<int>(ordered_submaps.size());
-  if (next_query_index_ >= submap_count) {
+  if (engine_->next_query_index >= submap_count) {
     return events;
   }
 
-  events.reserve(static_cast<std::size_t>(submap_count - next_query_index_));
-  for (; next_query_index_ < submap_count; ++next_query_index_) {
+  const LocalSubmapProvider filtered_local_provider =
+    [this, &ordered_submaps, &raw_cloud_provider](int index) {
+      return engine_->filteredLocalSubmap(ordered_submaps, raw_cloud_provider, index);
+    };
+  events.reserve(static_cast<std::size_t>(submap_count - engine_->next_query_index));
+  for (; engine_->next_query_index < submap_count; ++engine_->next_query_index) {
     LoopSearchEvent event;
-    event.query_index = next_query_index_;
-    dependencies_.backend.ingestDescriptors(next_query_index_ + 1, filtered_local_provider);
+    event.query_index = engine_->next_query_index;
+    engine_->backend.ingestDescriptors(engine_->next_query_index + 1, filtered_local_provider);
     event.registration_searched = loop_search_schedule::shouldSearch(
-      next_query_index_, config_.loop_search_query_stride);
+      engine_->next_query_index, engine_->config.loop_search_query_stride);
     if (event.registration_searched) {
       // Expose only the ordered prefix visible to this query. This makes
       // batching observationally equivalent to one-submap-at-a-time input.
       std::vector<backend_core::SubmapMeta> visible(
-        ordered_submaps.begin(), ordered_submaps.begin() + next_query_index_ + 1);
-      event.search_output = dependencies_.backend.searchLoopForSubmap(
-        visible, next_query_index_, config_.loop_search, raw_cloud_provider,
-        dependencies_.registration, dependencies_.voxelgrid,
-        dependencies_.three_d_bbs_verifier);
+        ordered_submaps.begin(), ordered_submaps.begin() + engine_->next_query_index + 1);
+      event.search_output = engine_->backend.searchLoopForSubmap(
+        visible, engine_->next_query_index, engine_->config.loop_search, raw_cloud_provider,
+        *engine_->registration, engine_->voxelgrid, engine_->three_d_bbs_verifier);
       if (event.search_output.proposal.found) {
         LoopEdge edge;
         edge.pair_id = event.search_output.proposal.pair_id;
         edge.relative_pose = event.search_output.proposal.relative_pose;
         edge.fitness_score = event.search_output.proposal.fitness_score;
-        event.graph_changed = loop_edges_.upsert(edge);
+        event.graph_changed = engine_->loop_edges.upsert(edge);
       }
     }
-    event.loop_edges = loop_edges_.edges();
+    event.loop_edges = engine_->loop_edges.edges();
     events.push_back(std::move(event));
   }
   return events;
@@ -97,28 +163,40 @@ std::vector<LoopSearchEvent> GraphSlamApplication::processSubmaps(
 
 bool GraphSlamApplication::upsertLoopEdge(const LoopEdge & edge)
 {
-  std::lock_guard<std::mutex> lock(mutex_);
-  return loop_edges_.upsert(edge);
+  std::lock_guard<std::mutex> lock(engine_->mutex);
+  return engine_->loop_edges.upsert(edge);
 }
 
-std::vector<GraphSlamApplication::LoopEdge> GraphSlamApplication::loopEdges() const
+GraphSlamStateSnapshot GraphSlamApplication::stateSnapshot() const
 {
-  std::lock_guard<std::mutex> lock(mutex_);
-  return loop_edges_.edges();
-}
-
-int GraphSlamApplication::nextQueryIndex() const
-{
-  std::lock_guard<std::mutex> lock(mutex_);
-  return next_query_index_;
+  std::lock_guard<std::mutex> lock(engine_->mutex);
+  GraphSlamStateSnapshot result;
+  result.next_query_index = engine_->next_query_index;
+  result.loop_edges = engine_->loop_edges.edges();
+  return result;
 }
 
 pose_graph::OptimizationResult GraphSlamApplication::optimize(
   const PoseGraphRequest & request) const
 {
+  std::vector<LoopEdge> graph_edges;
+  {
+    std::lock_guard<std::mutex> lock(engine_->mutex);
+    graph_edges = engine_->loop_edges.edges();
+  }
   std::vector<pose_graph::LoopConstraint> loop_constraints;
-  loop_constraints.reserve(request.loop_edges.size());
-  for (const auto & edge : request.loop_edges) {
+  loop_constraints.reserve(graph_edges.size());
+  for (const auto & edge : graph_edges) {
+    // A query-prefix optimization sees exactly the canonical graph induced
+    // by that prefix, even if a batched processSubmaps() call has already
+    // accepted edges for later queries.
+    if (
+      edge.pair_id.first < 0 || edge.pair_id.second < 0 ||
+      edge.pair_id.first >= static_cast<int>(request.submaps.size()) ||
+      edge.pair_id.second >= static_cast<int>(request.submaps.size()))
+    {
+      continue;
+    }
     pose_graph::LoopConstraint constraint;
     constraint.from = edge.pair_id.first;
     constraint.to = edge.pair_id.second;

--- a/graph_based_slam/src/graph_slam_composition.cpp
+++ b/graph_based_slam/src/graph_slam_composition.cpp
@@ -149,6 +149,20 @@ backend_core::LoopSearchConfig makeLoopSearchConfig(const GraphSlamConfig & conf
   return result;
 }
 
+GraphSlamApplicationConfig makeGraphSlamApplicationConfig(const GraphSlamConfig & config)
+{
+  GraphSlamApplicationConfig result;
+  result.descriptors = makeDescriptorConfig(config);
+  result.loop_search = makeLoopSearchConfig(config);
+  result.registration_method = config.registration_method;
+  result.ndt_resolution = config.ndt_resolution;
+  result.ndt_num_threads = config.ndt_num_threads;
+  result.voxel_leaf_size = config.voxel_leaf_size;
+  result.loop_search_query_stride = config.loop_search_query_stride_;
+  result.loop_edge_dedup_index_window = config.loop_edge_dedup_index_window_;
+  return result;
+}
+
 PoseGraphConfigBundle makePoseGraphConfig(
   const GraphSlamConfig & config,
   double adjacent_weight,

--- a/graph_based_slam/src/graph_slam_composition.hpp
+++ b/graph_based_slam/src/graph_slam_composition.hpp
@@ -36,6 +36,7 @@
 #include "graph_based_slam/adjacent_edge_auto_scale.hpp"
 #include "graph_based_slam/dynamic_object_filter.hpp"
 #include "graph_based_slam/gnss_weighting.hpp"
+#include "graph_based_slam/graph_slam_application.hpp"
 #include "graph_based_slam/map_saver.hpp"
 #include "graph_based_slam/planar_map_filter.hpp"
 #include "graph_based_slam/pose_graph_optimization.hpp"
@@ -45,6 +46,7 @@ namespace graphslam
 
 backend_core::DescriptorConfig makeDescriptorConfig(const GraphSlamConfig & config);
 backend_core::LoopSearchConfig makeLoopSearchConfig(const GraphSlamConfig & config);
+GraphSlamApplicationConfig makeGraphSlamApplicationConfig(const GraphSlamConfig & config);
 
 struct PoseGraphConfigBundle
 {

--- a/graph_based_slam/src/graph_slam_offline_runner.cpp
+++ b/graph_based_slam/src/graph_slam_offline_runner.cpp
@@ -75,9 +75,7 @@
 #include "graph_based_slam/plane_feature_association.hpp"
 #include "graph_based_slam/plane_revisit_constraints.hpp"
 #include "graph_based_slam/pose_graph_optimization.hpp"
-#include "graph_based_slam/registration_factory.hpp"
 #include "graph_based_slam/submap_creation.hpp"
-#include "graph_based_slam/three_d_bbs_loop_verifier.hpp"
 
 namespace
 {
@@ -554,57 +552,23 @@ int main(int argc, char ** argv)
   node->get_parameter_or(
     "loop_edge_robust_kernel_type", loop_edge_robust_kernel_type, std::string("huber"));
 
-  auto registration = graphslam::backend_core::makeLoopRegistration(
-    registration_method, ndt_resolution, ndt_num_threads);
-  if (!registration) {
-    RCLCPP_ERROR(logger, "invalid registration_method");
-    rclcpp::shutdown();
-    return 1;
-  }
-  pcl::VoxelGrid<pcl::PointXYZI> voxelgrid;
-  voxelgrid.setLeafSize(voxel_leaf_size, voxel_leaf_size, voxel_leaf_size);
-  graphslam::ThreeDBBSLoopVerifier bbs_verifier;
-
-  BackendCore core;
   graphslam::GraphSlamApplicationConfig application_config;
   application_config.descriptors = descriptor_config;
   application_config.loop_search = search_config;
+  application_config.registration_method = registration_method;
+  application_config.ndt_resolution = ndt_resolution;
+  application_config.ndt_num_threads = ndt_num_threads;
+  application_config.voxel_leaf_size = voxel_leaf_size;
   application_config.loop_search_query_stride = loop_search_query_stride;
   application_config.loop_edge_dedup_index_window =
     loop_edge_dedup_index_window < 0 ? 0 : loop_edge_dedup_index_window;
-  graphslam::GraphSlamApplication application(
-    application_config, {core, *registration, voxelgrid, bbs_verifier});
+  graphslam::GraphSlamApplication application(application_config);
 
   std::vector<SubmapRecord> records;
   bool last_position_valid = false;
   Eigen::Vector3d last_position = Eigen::Vector3d::Zero();
   double accumulated_distance = 0.0;
 
-  // The same voxel-filtered local-aggregate semantics as the component's
-  // makeFilteredLocalSubmapProvider, over the in-memory record store.
-  const auto filtered_local_provider = [&](int ref_idx) -> CloudPtr {
-      CloudPtr aggregated_cloud(new pcl::PointCloud<pcl::PointXYZI>);
-      const Eigen::Affine3d & reference_affine = records[ref_idx].meta.pose;
-      for (int k = 0; k < search_config.search_submap_num && (ref_idx - k) >= 0; ++k) {
-        const int src_idx = ref_idx - k;
-        const CloudPtr & cloud = records[src_idx].cloud;
-        if (!cloud || cloud->empty()) {
-          continue;
-        }
-        CloudPtr transformed_cloud(new pcl::PointCloud<pcl::PointXYZI>);
-        const Eigen::Matrix4f local_transform =
-          (reference_affine.inverse() * records[src_idx].meta.pose).matrix().cast<float>();
-        pcl::transformPointCloud(*cloud, *transformed_cloud, local_transform);
-        *aggregated_cloud += *transformed_cloud;
-      }
-      CloudPtr filtered_cloud(new pcl::PointCloud<pcl::PointXYZI>);
-      if (aggregated_cloud->empty()) {
-        return filtered_cloud;
-      }
-      voxelgrid.setInputCloud(aggregated_cloud);
-      voxelgrid.filter(*filtered_cloud);
-      return filtered_cloud;
-    };
   const auto raw_cloud_provider = [&](int idx) -> CloudPtr {
       return records[idx].cloud;
     };
@@ -618,8 +582,7 @@ int main(int argc, char ** argv)
       for (const auto & record : records) {
         ordered_submaps.push_back(record.meta);
       }
-      const auto events = application.processSubmaps(
-        ordered_submaps, filtered_local_provider, raw_cloud_provider);
+      const auto events = application.processSubmaps(ordered_submaps, raw_cloud_provider);
       for (const auto & event : events) {
         for (const auto & line : event.search_output.logs) {
           if (line.via_logger) {
@@ -712,7 +675,7 @@ int main(int argc, char ** argv)
       loadFixedLoopEdges(fixed_loop_edges_path, records.size(), application);
       RCLCPP_INFO(
         logger, "Loaded %zu fixed loop edges from %s; descriptor search was skipped",
-        application.loopEdges().size(), fixed_loop_edges_path.c_str());
+        application.stateSnapshot().loop_edges.size(), fixed_loop_edges_path.c_str());
     } catch (const std::exception & error) {
       RCLCPP_ERROR(logger, "%s", error.what());
       rclcpp::shutdown();
@@ -724,7 +687,8 @@ int main(int argc, char ** argv)
     logger,
     "Offline run complete: %zu pairs, %zu submaps, %.1f m travelled, %zu loop edges "
     "(%zu odom / %zu cloud messages left unpaired)",
-    paired_count, records.size(), accumulated_distance, application.loopEdges().size(),
+    paired_count, records.size(), accumulated_distance,
+    application.stateSnapshot().loop_edges.size(),
     pending_odoms.size(), pending_clouds.size());
 
   // --- Final pose-graph optimization from raw odometry poses plus the
@@ -737,7 +701,7 @@ int main(int argc, char ** argv)
     submap_node.pose = Eigen::Isometry3d(record.meta.pose.matrix());
     submap_nodes.push_back(submap_node);
   }
-  const auto loop_edges = application.loopEdges();
+  const auto loop_edges = application.stateSnapshot().loop_edges;
   graphslam::pose_graph::AdjacentEdgeConfig adjacent_config;
   adjacent_config.num_adjacent_pose_constraints = num_adjacent_pose_constraints;
   adjacent_config.info_weight = adjacent_edge_info_weight;
@@ -822,7 +786,6 @@ int main(int argc, char ** argv)
   if (!records.empty()) {
     graphslam::PoseGraphRequest request;
     request.submaps = submap_nodes;
-    request.loop_edges = loop_edges;
     request.adjacent_config = adjacent_config;
     request.loop_config = loop_config;
     request.imu_config = imu_config;

--- a/graph_based_slam/test/test_graph_slam_application.cpp
+++ b/graph_based_slam/test/test_graph_slam_application.cpp
@@ -32,8 +32,6 @@
 #include <memory>
 #include <vector>
 
-#include <pcl/registration/icp.h>  // NOLINT(build/include_order)
-
 #include "graph_based_slam/graph_slam_application.hpp"
 
 namespace graphslam
@@ -45,17 +43,12 @@ using Cloud = pcl::PointCloud<pcl::PointXYZI>;
 
 struct Fixture
 {
-  backend_core::BackendCore backend;
-  pcl::IterativeClosestPoint<pcl::PointXYZI, pcl::PointXYZI> registration;
-  pcl::VoxelGrid<pcl::PointXYZI> voxelgrid;
-  ThreeDBBSLoopVerifier verifier;
-
   std::unique_ptr<GraphSlamApplication> makeApplication(int stride = 1)
   {
     GraphSlamApplicationConfig config;
+    config.registration_method = "GICP";
     config.loop_search_query_stride = stride;
-    return std::unique_ptr<GraphSlamApplication>(new GraphSlamApplication(
-      config, {backend, registration, voxelgrid, verifier}));
+    return std::unique_ptr<GraphSlamApplication>(new GraphSlamApplication(config));
   }
 };
 
@@ -80,13 +73,13 @@ TEST(GraphSlamApplication, BatchAndIncrementalInputProduceTheSameQueryOrder)
 {
   Fixture batch_fixture;
   auto batch = batch_fixture.makeApplication();
-  const auto batch_events = batch->processSubmaps(submaps(5), emptyCloud, emptyCloud);
+  const auto batch_events = batch->processSubmaps(submaps(5), emptyCloud);
 
   Fixture incremental_fixture;
   auto incremental = incremental_fixture.makeApplication();
   std::vector<LoopSearchEvent> incremental_events;
   for (int count = 1; count <= 5; ++count) {
-    const auto events = incremental->processSubmaps(submaps(count), emptyCloud, emptyCloud);
+    const auto events = incremental->processSubmaps(submaps(count), emptyCloud);
     incremental_events.insert(incremental_events.end(), events.begin(), events.end());
   }
 
@@ -98,15 +91,15 @@ TEST(GraphSlamApplication, BatchAndIncrementalInputProduceTheSameQueryOrder)
     EXPECT_EQ(batch_events[i].graph_changed, incremental_events[i].graph_changed);
     EXPECT_EQ(batch_events[i].loop_edges.size(), incremental_events[i].loop_edges.size());
   }
-  EXPECT_EQ(batch->nextQueryIndex(), 5);
-  EXPECT_EQ(incremental->nextQueryIndex(), 5);
+  EXPECT_EQ(batch->stateSnapshot().next_query_index, 5);
+  EXPECT_EQ(incremental->stateSnapshot().next_query_index, 5);
 }
 
 TEST(GraphSlamApplication, StrideSkipsRegistrationButStillAdvancesEveryQuery)
 {
   Fixture fixture;
   auto application = fixture.makeApplication(2);
-  const auto events = application->processSubmaps(submaps(6), emptyCloud, emptyCloud);
+  const auto events = application->processSubmaps(submaps(6), emptyCloud);
 
   ASSERT_EQ(events.size(), 5U);
   EXPECT_TRUE(events[0].registration_searched);
@@ -114,7 +107,32 @@ TEST(GraphSlamApplication, StrideSkipsRegistrationButStillAdvancesEveryQuery)
   EXPECT_TRUE(events[2].registration_searched);
   EXPECT_FALSE(events[3].registration_searched);
   EXPECT_TRUE(events[4].registration_searched);
-  EXPECT_EQ(application->nextQueryIndex(), 6);
+  EXPECT_EQ(application->stateSnapshot().next_query_index, 6);
+}
+
+TEST(GraphSlamApplication, OwnsDeterministicDescriptorAggregationAndFiltering)
+{
+  GraphSlamApplicationConfig config;
+  config.registration_method = "GICP";
+  config.descriptors.use_scan_context = true;
+  config.loop_search.search_submap_num = 3;
+  config.loop_search_query_stride = 100;
+  GraphSlamApplication application(config);
+  std::vector<int> requested_indices;
+  const auto provider = [&requested_indices](int index) {
+      requested_indices.push_back(index);
+      backend_core::BackendCore::CloudPtr cloud(new Cloud);
+      pcl::PointXYZI point;
+      point.x = static_cast<float>(index);
+      cloud->push_back(point);
+      return cloud;
+    };
+
+  const auto events = application.processSubmaps(submaps(3), provider);
+
+  ASSERT_EQ(events.size(), 2U);
+  const std::vector<int> expected {0, 1, 0, 2, 1, 0};
+  EXPECT_EQ(requested_indices, expected);
 }
 
 TEST(GraphSlamApplication, OwnsTheCanonicalDeduplicatedLoopEdgeSet)
@@ -127,7 +145,7 @@ TEST(GraphSlamApplication, OwnsTheCanonicalDeduplicatedLoopEdgeSet)
   edge.fitness_score = 0.3;
 
   ASSERT_TRUE(application->upsertLoopEdge(edge));
-  const auto edges = application->loopEdges();
+  const auto edges = application->stateSnapshot().loop_edges;
   ASSERT_EQ(edges.size(), 1U);
   EXPECT_EQ(edges[0].pair_id, std::make_pair(2, 9));
   EXPECT_DOUBLE_EQ(edges[0].relative_pose.translation().x(), -7.0);
@@ -138,6 +156,10 @@ TEST(GraphSlamApplication, OptimizesPlainPoseGraphRequestsThroughTheSharedEntryP
 {
   Fixture fixture;
   auto application = fixture.makeApplication();
+  GraphSlamApplication::LoopEdge future_edge;
+  future_edge.pair_id = {0, 5};
+  future_edge.fitness_score = 0.1;
+  ASSERT_TRUE(application->upsertLoopEdge(future_edge));
   PoseGraphRequest request;
   request.submaps.resize(1);
   request.submaps[0].pose.translation().x() = 3.5;
@@ -150,13 +172,21 @@ TEST(GraphSlamApplication, OptimizesPlainPoseGraphRequestsThroughTheSharedEntryP
 
 TEST(GraphSlamApplication, RejectsInvalidWorkflowConfiguration)
 {
-  Fixture fixture;
   GraphSlamApplicationConfig config;
+  config.registration_method = "GICP";
   config.loop_search_query_stride = 0;
-  EXPECT_THROW(
-    GraphSlamApplication(config, {
-        fixture.backend, fixture.registration, fixture.voxelgrid, fixture.verifier}),
-    std::invalid_argument);
+  EXPECT_THROW(static_cast<void>(GraphSlamApplication(config)), std::invalid_argument);
+}
+
+TEST(GraphSlamApplication, RejectsInvalidOwnedEngineConfiguration)
+{
+  GraphSlamApplicationConfig config;
+  config.registration_method = "not-a-registration";
+  EXPECT_THROW(static_cast<void>(GraphSlamApplication(config)), std::invalid_argument);
+
+  config.registration_method = "GICP";
+  config.voxel_leaf_size = 0.0;
+  EXPECT_THROW(static_cast<void>(GraphSlamApplication(config)), std::invalid_argument);
 }
 
 }  // namespace

--- a/graph_based_slam/test/test_graph_slam_composition.cpp
+++ b/graph_based_slam/test/test_graph_slam_composition.cpp
@@ -40,9 +40,13 @@ TEST(GraphSlamComposition, BuildsDescriptorAndLoopSearchBoundaries)
   config.max_loop_candidate_count_ = 7;
   config.scan_context_query_stride_ = 0;
   config.loop_max_translation_delta_ = 12.5;
+  config.registration_method = "GICP";
+  config.voxel_leaf_size = 0.35;
+  config.loop_search_query_stride_ = 3;
 
   const auto descriptor = graphslam::makeDescriptorConfig(config);
   const auto loop_search = graphslam::makeLoopSearchConfig(config);
+  const auto application = graphslam::makeGraphSlamApplicationConfig(config);
 
   EXPECT_TRUE(descriptor.use_triangle_descriptor);
   EXPECT_EQ(descriptor.triangle_descriptor_max_keypoints, 73);
@@ -50,6 +54,10 @@ TEST(GraphSlamComposition, BuildsDescriptorAndLoopSearchBoundaries)
   EXPECT_EQ(loop_search.aggregator.max_loop_candidate_count, 7);
   EXPECT_EQ(loop_search.aggregator.scan_context_query_stride, 1);
   EXPECT_DOUBLE_EQ(loop_search.gates.max_translation_m, 12.5);
+  EXPECT_EQ(application.registration_method, "GICP");
+  EXPECT_DOUBLE_EQ(application.voxel_leaf_size, 0.35);
+  EXPECT_EQ(application.loop_search_query_stride, 3);
+  EXPECT_EQ(application.loop_search.search_submap_num, 9);
 }
 
 TEST(GraphSlamComposition, KeepsAdaptiveStateOutsideStartupConfig)


### PR DESCRIPTION
## Summary
- make GraphSlamApplication the aggregate lifetime boundary for BackendCore, registration, voxel filtering, 3D-BBS, scheduling, and canonical graph state
- move descriptor aggregation/filtering behind processSubmaps so online and offline adapters provide only ordered metadata and raw clouds
- optimize from immutable canonical graph snapshots and prevent later batched edges from leaking into prefix optimization

## Architecture
The ROS component and offline runner no longer construct or retain mapping-engine resources. GraphSlamApplication is configured from a plain DTO and returns state by value. Filesystem output, diagnostics, cache/storage, and clock concerns remain adapter responsibilities for Milestone 4.

This is a stacked PR based on #373. Review the Milestone 2 unified application boundary first.

## Validation
- repository default CI: 4 packages, 2440 tests, 0 errors/failures, 120 skipped
- graph_based_slam package: 2226 tests, 0 errors/failures, 119 skipped
- Application ownership/unit tests: 7 passed
- component, offline runner, and application targets build
- ROS component startup smoke passes
- `mkdocs build --strict`
- synthetic release-readiness fixture passes and threshold guard rejects the failing fixture with exit 2
