### PR TITLE
Add Graph SLAM external I/O ports

### DIFF
--- a/docs/graph-slam-architecture.md
+++ b/docs/graph-slam-architecture.md
@@ -87,9 +87,24 @@ the offline adapter builds the same plain DTO from replay parameters.
 
 ### 4. External I/O ports
 
-- define clock, cache/storage, diagnostics, and map-output ports;
-- provide ROS/filesystem adapters outside the backend;
-- use in-memory adapters for deterministic unit and replay tests.
+The outer boundary now exposes explicit clock, submap storage, diagnostics,
+and map-output ports. The live ROS composition root binds those contracts to
+the node clock, ROS logging, PCD storage, and filesystem artifact output. The
+offline runner uses the same filesystem artifact adapter, while unit and
+deterministic replay tests can bind manual-clock and in-memory adapters.
+
+Pose-graph optimization no longer accepts a save path. It serializes the
+canonical g2o graph to bytes in `OptimizationResult`; an outer map-output port
+decides whether and where to persist those bytes. The same boundary owns
+trajectory, loop-edge, bundle-manifest, diagnostic-report, grid metadata, and
+PCD output. Consequently `graph_slam_application` neither links the
+filesystem adapter nor observes a clock, logger, ROS API, or path.
+
+Submap cache access is also a value-snapshot contract. In-memory and PCD
+implementations return independent clouds, so callers cannot mutate storage
+state through an alias. Port validation rejects partial composition, and unit
+tests pin clock control, diagnostic ordering, snapshot isolation, exact byte
+preservation, and append behavior.
 
 ### 5. Architecture hardening
 

--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -136,6 +136,16 @@ target_link_libraries(
   g2o::stuff
 )
 
+add_library(graph_slam_io_adapters STATIC
+  src/filesystem_io_ports.cpp
+)
+set_target_properties(graph_slam_io_adapters PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_compile_features(graph_slam_io_adapters PRIVATE cxx_std_17)
+target_include_directories(
+  graph_slam_io_adapters PUBLIC include PRIVATE src ${PCL_INCLUDE_DIRS}
+)
+target_link_libraries(graph_slam_io_adapters ${PCL_LIBRARIES})
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   find_package(ament_cmake_gtest REQUIRED)
@@ -326,6 +336,19 @@ if(BUILD_TESTING)
       graph_slam_application
       ${PCL_LIBRARIES}
       graph_based_slam_3d_bbs_vendor
+    )
+  endif()
+  ament_add_gtest(
+    test_external_io_ports
+    test/test_external_io_ports.cpp
+  )
+  if(TARGET test_external_io_ports)
+    target_include_directories(
+      test_external_io_ports PRIVATE include src ${PCL_INCLUDE_DIRS}
+    )
+    target_compile_features(test_external_io_ports PRIVATE cxx_std_17)
+    target_link_libraries(
+      test_external_io_ports graph_slam_io_adapters ${PCL_LIBRARIES}
     )
   endif()
   ament_add_gtest(
@@ -1073,6 +1096,7 @@ add_library(graph_based_slam_component SHARED
   src/graph_slam_composition.cpp
   src/three_d_bbs_loop_verifier.cpp
 )
+target_compile_features(graph_based_slam_component PRIVATE cxx_std_17)
 
 target_compile_definitions(graph_based_slam_component PRIVATE "GS_GBS_BUILDING_DLL")
 if(GRAPH_BASED_SLAM_HAVE_3D_BBS)
@@ -1100,6 +1124,7 @@ ament_target_dependencies(graph_based_slam_component
 target_link_libraries(graph_based_slam_component
   graph_slam_config
   graph_slam_application
+  graph_slam_io_adapters
   g2o::core
   g2o::types_slam3d
   g2o::solver_eigen
@@ -1145,6 +1170,7 @@ add_executable(graph_slam_offline_runner
   src/graph_slam_offline_runner.cpp
   src/three_d_bbs_loop_verifier.cpp
 )
+target_compile_features(graph_slam_offline_runner PRIVATE cxx_std_17)
 
 if(GRAPH_BASED_SLAM_HAVE_3D_BBS)
   target_compile_definitions(graph_slam_offline_runner PRIVATE GRAPH_BASED_SLAM_HAVE_3D_BBS)
@@ -1163,6 +1189,7 @@ ament_target_dependencies(graph_slam_offline_runner
 
 target_link_libraries(graph_slam_offline_runner
   graph_slam_application
+  graph_slam_io_adapters
   ${PCL_LIBRARIES}
   g2o::core
   g2o::types_slam3d

--- a/graph_based_slam/include/graph_based_slam/external_io_ports.hpp
+++ b/graph_based_slam/include/graph_based_slam/external_io_ports.hpp
@@ -1,0 +1,309 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following disclaimer
+//    in the documentation and/or other materials provided with the
+//    distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef GRAPH_BASED_SLAM__EXTERNAL_IO_PORTS_HPP_
+#define GRAPH_BASED_SLAM__EXTERNAL_IO_PORTS_HPP_
+
+#include <algorithm>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <pcl/point_cloud.h>  // NOLINT(build/include_order)
+#include <pcl/point_types.h>  // NOLINT(build/include_order)
+
+namespace graphslam
+{
+namespace ports
+{
+
+using PointCloud = pcl::PointCloud<pcl::PointXYZI>;
+using PointCloudPtr = PointCloud::Ptr;
+using PointCloudXyz = pcl::PointCloud<pcl::PointXYZ>;
+
+struct SubmapWrite
+{
+  int index {-1};
+  PointCloudPtr cloud;
+};
+
+enum class DiagnosticLevel
+{
+  DEBUG,
+  INFO,
+  WARNING,
+  ERROR,
+};
+
+struct DiagnosticEvent
+{
+  DiagnosticLevel level {DiagnosticLevel::INFO};
+  std::string code;
+  std::string message;
+};
+
+// Time is injected only where an adapter must resolve missing or invalid
+// source timestamps. Mapping-engine decisions never read this port.
+class ClockPort
+{
+public:
+  virtual ~ClockPort() = default;
+  virtual double nowSeconds() const = 0;
+};
+
+class SubmapStoragePort
+{
+public:
+  virtual ~SubmapStoragePort() = default;
+  virtual bool store(int index, const PointCloud & cloud) = 0;
+  // A batch is one visibility transaction: load() cannot observe a prefix.
+  virtual std::vector<bool> storeBatch(const std::vector<SubmapWrite> & writes) = 0;
+  virtual PointCloudPtr load(int index) const = 0;
+};
+
+class DiagnosticsPort
+{
+public:
+  virtual ~DiagnosticsPort() = default;
+  virtual void emit(const DiagnosticEvent & event) = 0;
+};
+
+// Artifact identifiers are interpreted by the outer adapter. A filesystem
+// adapter treats them as paths; an in-memory adapter treats them as keys.
+class MapOutputPort
+{
+public:
+  virtual ~MapOutputPort() = default;
+  virtual bool prepareDirectory(const std::string & directory) = 0;
+  virtual bool removeByExtension(
+    const std::string & directory, const std::vector<std::string> & extensions) = 0;
+  virtual bool writeBytes(const std::string & artifact, const std::string & bytes) = 0;
+  virtual bool appendBytes(const std::string & artifact, const std::string & bytes) = 0;
+  virtual bool writePointCloud(const std::string & artifact, const PointCloud & cloud) = 0;
+  virtual bool writePointCloudXyz(
+    const std::string & artifact, const PointCloudXyz & cloud) = 0;
+};
+
+struct ExternalIoPorts
+{
+  std::shared_ptr<ClockPort> clock;
+  std::shared_ptr<SubmapStoragePort> submap_storage;
+  std::shared_ptr<DiagnosticsPort> diagnostics;
+  std::shared_ptr<MapOutputPort> map_output;
+
+  void validate() const
+  {
+    if (!clock || !submap_storage || !diagnostics || !map_output) {
+      throw std::invalid_argument("all Graph SLAM external I/O ports are required");
+    }
+  }
+};
+
+class ManualClock final : public ClockPort
+{
+public:
+  explicit ManualClock(double seconds = 0.0)
+  : seconds_(seconds) {}
+
+  double nowSeconds() const override
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return seconds_;
+  }
+
+  void set(double seconds)
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    seconds_ = seconds;
+  }
+
+private:
+  mutable std::mutex mutex_;
+  double seconds_;
+};
+
+class InMemorySubmapStorage final : public SubmapStoragePort
+{
+public:
+  bool store(int index, const PointCloud & cloud) override
+  {
+    if (index < 0) {return false;}
+    std::lock_guard<std::mutex> lock(mutex_);
+    clouds_[index] = cloud;
+    return true;
+  }
+
+  std::vector<bool> storeBatch(const std::vector<SubmapWrite> & writes) override
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    std::vector<bool> results;
+    results.reserve(writes.size());
+    for (const auto & write : writes) {
+      const bool valid = write.index >= 0 && write.cloud;
+      results.push_back(valid);
+      if (valid) {
+        clouds_[write.index] = *write.cloud;
+      }
+    }
+    return results;
+  }
+
+  PointCloudPtr load(int index) const override
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    const auto found = clouds_.find(index);
+    if (found == clouds_.end()) {
+      return PointCloudPtr(new PointCloud);
+    }
+    return PointCloudPtr(new PointCloud(found->second));
+  }
+
+private:
+  mutable std::mutex mutex_;
+  std::map<int, PointCloud> clouds_;
+};
+
+class InMemoryDiagnostics final : public DiagnosticsPort
+{
+public:
+  void emit(const DiagnosticEvent & event) override
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    events_.push_back(event);
+  }
+
+  std::vector<DiagnosticEvent> events() const
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return events_;
+  }
+
+private:
+  mutable std::mutex mutex_;
+  std::vector<DiagnosticEvent> events_;
+};
+
+class InMemoryMapOutput final : public MapOutputPort
+{
+public:
+  bool prepareDirectory(const std::string &) override {return true;}
+  bool removeByExtension(
+    const std::string & directory, const std::vector<std::string> & extensions) override
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    eraseMatching(bytes_, directory, extensions);
+    eraseMatching(clouds_, directory, extensions);
+    eraseMatching(xyz_clouds_, directory, extensions);
+    return true;
+  }
+
+  bool writeBytes(const std::string & artifact, const std::string & bytes) override
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    bytes_[artifact] = bytes;
+    return true;
+  }
+
+  bool appendBytes(const std::string & artifact, const std::string & bytes) override
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    bytes_[artifact] += bytes;
+    return true;
+  }
+
+  bool writePointCloud(const std::string & artifact, const PointCloud & cloud) override
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    clouds_[artifact] = cloud;
+    return true;
+  }
+
+  bool writePointCloudXyz(
+    const std::string & artifact, const PointCloudXyz & cloud) override
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    xyz_clouds_[artifact] = cloud;
+    return true;
+  }
+
+  std::string bytes(const std::string & artifact) const
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    const auto found = bytes_.find(artifact);
+    return found == bytes_.end() ? std::string() : found->second;
+  }
+
+  PointCloudPtr pointCloud(const std::string & artifact) const
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    const auto found = clouds_.find(artifact);
+    if (found == clouds_.end()) {
+      return PointCloudPtr(new PointCloud);
+    }
+    return PointCloudPtr(new PointCloud(found->second));
+  }
+
+private:
+  template<typename ValueT>
+  static void eraseMatching(
+    std::map<std::string, ValueT> & artifacts, const std::string & directory,
+    const std::vector<std::string> & extensions)
+  {
+    const std::string prefix = directory.empty() ? std::string() : directory + "/";
+    for (auto current = artifacts.begin(); current != artifacts.end(); ) {
+      const std::string & artifact = current->first;
+      bool matches = prefix.empty() || artifact.compare(0, prefix.size(), prefix) == 0;
+      matches = matches && std::find_if(
+        extensions.begin(), extensions.end(), [&artifact](const std::string & extension) {
+          return artifact.size() >= extension.size() &&
+                 artifact.compare(artifact.size() - extension.size(), extension.size(),
+            extension) == 0;
+        }) != extensions.end();
+      if (matches) {
+        current = artifacts.erase(current);
+      } else {
+        ++current;
+      }
+    }
+  }
+
+  mutable std::mutex mutex_;
+  std::map<std::string, std::string> bytes_;
+  std::map<std::string, PointCloud> clouds_;
+  std::map<std::string, PointCloudXyz> xyz_clouds_;
+};
+
+}  // namespace ports
+}  // namespace graphslam
+
+#endif  // GRAPH_BASED_SLAM__EXTERNAL_IO_PORTS_HPP_

--- a/graph_based_slam/include/graph_based_slam/graph_slam_application.hpp
+++ b/graph_based_slam/include/graph_based_slam/graph_slam_application.hpp
@@ -77,7 +77,6 @@ struct PoseGraphRequest
   pose_graph::Chi2Collection chi2_collection {pose_graph::Chi2Collection::NONE};
   bool fix_first_vertex {true};
   int iterations {10};
-  std::string save_path;
   std::vector<pose_graph::PlaneRevisitConstraint> plane_constraints;
 };
 

--- a/graph_based_slam/include/graph_based_slam/pose_graph_optimization.hpp
+++ b/graph_based_slam/include/graph_based_slam/pose_graph_optimization.hpp
@@ -40,6 +40,7 @@
 #include <algorithm>
 #include <cmath>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -131,6 +132,9 @@ struct ImuEdgeConfig
 struct OptimizationResult
 {
   std::vector<Eigen::Isometry3d> poses;
+  // Canonical g2o artifact bytes. Persistence belongs to an outer output
+  // port; the optimizer never opens a path or touches the filesystem.
+  std::string pose_graph_g2o;
   // Post-optimization adjacent-edge chi2 contributions, for the caller's
   // NIS auto-scale update (finite values only, in edge construction order).
   std::vector<double> adjacent_chi2;
@@ -164,7 +168,6 @@ inline OptimizationResult optimizePoseGraph(
   // settle into the anchor (ENU) frame; the historical default pins it.
   bool fix_first_vertex = true,
   int iterations = 10,
-  const std::string & save_path = std::string(),
   const std::vector<PlaneRevisitConstraint> & plane_constraints = {})
 {
   g2o::SparseOptimizer optimizer;
@@ -315,11 +318,11 @@ inline OptimizationResult optimizePoseGraph(
 
   optimizer.initializeOptimization();
   optimizer.optimize(iterations);
-  if (!save_path.empty()) {
-    optimizer.save(save_path.c_str());
-  }
 
   OptimizationResult result;
+  std::ostringstream graph_stream;
+  optimizer.save(graph_stream);
+  result.pose_graph_g2o = graph_stream.str();
   result.plane_revisit_edges = static_cast<int>(plane_edges.size());
   result.plane_revisit_chi2_before = plane_chi2_before;
   result.poses.reserve(submaps_size);

--- a/graph_based_slam/src/filesystem_io_ports.cpp
+++ b/graph_based_slam/src/filesystem_io_ports.cpp
@@ -1,0 +1,155 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following disclaimer
+//    in the documentation and/or other materials provided with the
+//    distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "filesystem_io_ports.hpp"
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <utility>
+#include <vector>
+
+#include <pcl/io/pcd_io.h>  // NOLINT(build/include_order)
+
+#include "graph_based_slam/map_saver.hpp"
+
+namespace graphslam
+{
+namespace adapters
+{
+namespace
+{
+void createParentDirectory(const std::string & path)
+{
+  const std::filesystem::path parent = std::filesystem::path(path).parent_path();
+  if (!parent.empty()) {
+    std::filesystem::create_directories(parent);
+  }
+}
+}  // namespace
+
+PcdSubmapStorage::PcdSubmapStorage(std::string directory)
+: directory_(std::move(directory))
+{
+  std::filesystem::create_directories(directory_);
+}
+
+bool PcdSubmapStorage::store(int index, const ports::PointCloud & cloud)
+{
+  if (index < 0) {return false;}
+  std::lock_guard<std::mutex> lock(mutex_);
+  return pcl::io::savePCDFileBinaryCompressed(
+    map_saver::submapCachePath(directory_, index), cloud) == 0;
+}
+
+std::vector<bool> PcdSubmapStorage::storeBatch(
+  const std::vector<ports::SubmapWrite> & writes)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  std::vector<bool> results;
+  results.reserve(writes.size());
+  for (const auto & write : writes) {
+    const bool stored = write.index >= 0 && write.cloud &&
+      pcl::io::savePCDFileBinaryCompressed(
+      map_saver::submapCachePath(directory_, write.index), *write.cloud) == 0;
+    results.push_back(stored);
+  }
+  return results;
+}
+
+ports::PointCloudPtr PcdSubmapStorage::load(int index) const
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  ports::PointCloudPtr cloud(new ports::PointCloud);
+  if (index < 0 ||
+    pcl::io::loadPCDFile(map_saver::submapCachePath(directory_, index), *cloud) == -1)
+  {
+    cloud->clear();
+  }
+  return cloud;
+}
+
+bool FilesystemMapOutput::prepareDirectory(const std::string & directory)
+{
+  std::error_code error;
+  std::filesystem::create_directories(directory, error);
+  return !error;
+}
+
+bool FilesystemMapOutput::removeByExtension(
+  const std::string & directory, const std::vector<std::string> & extensions)
+{
+  if (!std::filesystem::exists(directory)) {return true;}
+  std::error_code error;
+  for (const auto & entry : std::filesystem::directory_iterator(directory)) {
+    const std::string extension = entry.path().extension().string();
+    if (std::find(extensions.begin(), extensions.end(), extension) != extensions.end()) {
+      std::filesystem::remove(entry.path(), error);
+      if (error) {return false;}
+    }
+  }
+  return true;
+}
+
+bool FilesystemMapOutput::writeBytes(
+  const std::string & artifact, const std::string & bytes)
+{
+  createParentDirectory(artifact);
+  std::ofstream output(artifact, std::ios::binary);
+  if (!output.is_open()) {return false;}
+  output.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+  return output.good();
+}
+
+bool FilesystemMapOutput::appendBytes(
+  const std::string & artifact, const std::string & bytes)
+{
+  createParentDirectory(artifact);
+  std::ofstream output(artifact, std::ios::binary | std::ios::app);
+  if (!output.is_open()) {return false;}
+  output.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+  return output.good();
+}
+
+bool FilesystemMapOutput::writePointCloud(
+  const std::string & artifact, const ports::PointCloud & cloud)
+{
+  createParentDirectory(artifact);
+  return pcl::io::savePCDFileBinaryCompressed(artifact, cloud) == 0;
+}
+
+bool FilesystemMapOutput::writePointCloudXyz(
+  const std::string & artifact, const ports::PointCloudXyz & cloud)
+{
+  createParentDirectory(artifact);
+  return pcl::io::savePCDFileBinary(artifact, cloud) == 0;
+}
+
+}  // namespace adapters
+}  // namespace graphslam

--- a/graph_based_slam/src/filesystem_io_ports.hpp
+++ b/graph_based_slam/src/filesystem_io_ports.hpp
@@ -1,0 +1,76 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following disclaimer
+//    in the documentation and/or other materials provided with the
+//    distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef FILESYSTEM_IO_PORTS_HPP_
+#define FILESYSTEM_IO_PORTS_HPP_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "graph_based_slam/external_io_ports.hpp"
+
+namespace graphslam
+{
+namespace adapters
+{
+
+// These are outer adapters. Their filesystem/PCL I/O dependencies must never
+// be linked into graph_slam_application.
+class PcdSubmapStorage final : public ports::SubmapStoragePort
+{
+public:
+  explicit PcdSubmapStorage(std::string directory);
+  bool store(int index, const ports::PointCloud & cloud) override;
+  std::vector<bool> storeBatch(const std::vector<ports::SubmapWrite> & writes) override;
+  ports::PointCloudPtr load(int index) const override;
+
+private:
+  std::string directory_;
+  mutable std::mutex mutex_;
+};
+
+class FilesystemMapOutput final : public ports::MapOutputPort
+{
+public:
+  bool prepareDirectory(const std::string & directory) override;
+  bool removeByExtension(
+    const std::string & directory, const std::vector<std::string> & extensions) override;
+  bool writeBytes(const std::string & artifact, const std::string & bytes) override;
+  bool appendBytes(const std::string & artifact, const std::string & bytes) override;
+  bool writePointCloud(
+    const std::string & artifact, const ports::PointCloud & cloud) override;
+  bool writePointCloudXyz(
+    const std::string & artifact, const ports::PointCloudXyz & cloud) override;
+};
+
+}  // namespace adapters
+}  // namespace graphslam
+
+#endif  // FILESYSTEM_IO_PORTS_HPP_

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -28,24 +28,24 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "graph_based_slam_component_impl.hpp"
-#include "graph_slam_composition.hpp"
 
 #include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <filesystem>
-#include <fstream>
+#include <sstream>
 #include <stdexcept>
 #include <unordered_map>
 
 #include <pcl/common/common.h>  // NOLINT(build/include_order)
-#include <pcl/io/pcd_io.h>  // NOLINT(build/include_order)
 #include <pcl/filters/voxel_grid.h>  // NOLINT(build/include_order)
 #include <pcl_conversions/pcl_conversions.h>  // NOLINT(build/include_order)
 #include <tf2_eigen/tf2_eigen.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2_sensor_msgs/tf2_sensor_msgs.hpp>
 
+#include "filesystem_io_ports.hpp"
+#include "graph_slam_composition.hpp"
 #include "graph_based_slam/adjacent_edge_auto_scale.hpp"
 #include "graph_based_slam/backend_core.hpp"
 #include "graph_based_slam/bev_mutual_visibility.hpp"
@@ -71,6 +71,63 @@ namespace graphslam
 {
 namespace
 {
+class RosClockPort final : public ports::ClockPort
+{
+public:
+  explicit RosClockPort(rclcpp::Clock::SharedPtr clock)
+  : clock_(std::move(clock)) {}
+
+  double nowSeconds() const override {return clock_->now().seconds();}
+
+private:
+  rclcpp::Clock::SharedPtr clock_;
+};
+
+class RosDiagnosticsPort final : public ports::DiagnosticsPort
+{
+public:
+  explicit RosDiagnosticsPort(rclcpp::Logger logger)
+  : logger_(std::move(logger)) {}
+
+  void emit(const ports::DiagnosticEvent & event) override
+  {
+    switch (event.level) {
+      case ports::DiagnosticLevel::DEBUG:
+        RCLCPP_DEBUG(logger_, "[%s] %s", event.code.c_str(), event.message.c_str());
+        break;
+      case ports::DiagnosticLevel::INFO:
+        RCLCPP_INFO(logger_, "[%s] %s", event.code.c_str(), event.message.c_str());
+        break;
+      case ports::DiagnosticLevel::WARNING:
+        RCLCPP_WARN(logger_, "[%s] %s", event.code.c_str(), event.message.c_str());
+        break;
+      case ports::DiagnosticLevel::ERROR:
+        RCLCPP_ERROR(logger_, "[%s] %s", event.code.c_str(), event.message.c_str());
+        break;
+    }
+  }
+
+private:
+  rclcpp::Logger logger_;
+};
+
+ports::ExternalIoPorts makeExternalIoPorts(
+  rclcpp::Node & node, const GraphSlamConfig & config)
+{
+  ports::ExternalIoPorts result;
+  result.clock = std::make_shared<RosClockPort>(node.get_clock());
+  if (config.use_pcd_cache_) {
+    result.submap_storage =
+      std::make_shared<adapters::PcdSubmapStorage>(config.pcd_cache_dir_);
+  } else {
+    result.submap_storage = std::make_shared<ports::InMemorySubmapStorage>();
+  }
+  result.diagnostics = std::make_shared<RosDiagnosticsPort>(node.get_logger());
+  result.map_output = std::make_shared<adapters::FilesystemMapOutput>();
+  result.validate();
+  return result;
+}
+
 GraphSlamConfig loadValidatedGraphSlamConfig(rclcpp::Node & node)
 {
   GraphSlamConfig config = loadGraphSlamConfig(node);
@@ -115,7 +172,8 @@ GraphBasedSlamComponent::Impl::Impl(GraphBasedSlamComponent & node)
   tfbuffer_(std::make_shared<rclcpp::Clock>(clock_)),
   listener_(tfbuffer_),
   broadcaster_(&node_),
-  backend_(std::make_unique<BackendWorkspace>(makeGraphSlamApplicationConfig(config_)))
+  backend_(std::make_unique<BackendWorkspace>(makeGraphSlamApplicationConfig(config_))),
+  io_ports_(makeExternalIoPorts(node_, config_))
 {
   RCLCPP_INFO(node_.get_logger(), "initialization start");
 
@@ -123,20 +181,17 @@ GraphBasedSlamComponent::Impl::Impl(GraphBasedSlamComponent & node)
   adjacent_edge_info_weight_trans_ = config_.adjacent_edge_info_weight_trans_;
   adjacent_edge_info_weight_rot_ = config_.adjacent_edge_info_weight_rot_;
 
-  if (config_.use_pcd_cache_) {
-    std::filesystem::create_directories(config_.pcd_cache_dir_);
-  }
   gnss_origin_accumulator_.configure(
     config_.gnss_origin_min_samples_, config_.gnss_origin_consistency_threshold_m_);
   logGraphSlamConfig(config_, node_.get_logger());
   if (!config_.degeneracy_diagnostics_csv_path_.empty()) {
-    degeneracy_csv_ofs_.open(config_.degeneracy_diagnostics_csv_path_);
-    if (degeneracy_csv_ofs_.is_open()) {
-      degeneracy_csv_ofs_ << degeneracy::degeneracyDiagnosticsCsvHeaderLine() << "\n";
-    } else {
-      RCLCPP_WARN(
-        node_.get_logger(), "failed to open degeneracy_diagnostics_csv_path: %s (CSV disabled)",
-        config_.degeneracy_diagnostics_csv_path_.c_str());
+    degeneracy_csv_enabled_ = io_ports_.map_output->writeBytes(
+      config_.degeneracy_diagnostics_csv_path_,
+      degeneracy::degeneracyDiagnosticsCsvHeaderLine() + "\n");
+    if (!degeneracy_csv_enabled_) {
+      io_ports_.diagnostics->emit(
+        {ports::DiagnosticLevel::WARNING, "degeneracy_csv_open_failed",
+          config_.degeneracy_diagnostics_csv_path_});
     }
   }
 
@@ -473,11 +528,9 @@ void GraphBasedSlamComponent::Impl::doPoseAdjustment(
     config_, adjacent_edge_info_weight_, adjacent_edge_info_weight_trans_,
     adjacent_edge_info_weight_rot_);
 
-  std::string pose_graph_save_path = config_.save_pose_graph_path_;
   const std::string bundle_pose_graph_path = config_.map_save_dir_ + "/pose_graph.g2o";
   if (do_save_map) {
-    std::filesystem::create_directories(config_.map_save_dir_);
-    pose_graph_save_path = bundle_pose_graph_path;
+    io_ports_.map_output->prepareDirectory(config_.map_save_dir_);
   }
   PoseGraphRequest optimization_request;
   optimization_request.submaps = submap_nodes;
@@ -488,23 +541,25 @@ void GraphBasedSlamComponent::Impl::doPoseAdjustment(
   optimization_request.imu_config = pose_graph_config.imu;
   optimization_request.chi2_collection = pose_graph_config.chi2_collection;
   optimization_request.fix_first_vertex = fix_first_vertex;
-  optimization_request.save_path = pose_graph_save_path;
   const pose_graph::OptimizationResult opt_result =
     backend_->application->optimize(optimization_request);
 
-  if (do_save_map && !config_.save_pose_graph_path_.empty() &&
-    std::filesystem::path(config_.save_pose_graph_path_).lexically_normal() !=
-    std::filesystem::path(bundle_pose_graph_path).lexically_normal())
+  if (do_save_map &&
+    !io_ports_.map_output->writeBytes(bundle_pose_graph_path, opt_result.pose_graph_g2o))
   {
-    std::error_code copy_error;
-    std::filesystem::copy_file(
-      bundle_pose_graph_path, config_.save_pose_graph_path_,
-      std::filesystem::copy_options::overwrite_existing, copy_error);
-    if (copy_error) {
-      RCLCPP_WARN(
-        node_.get_logger(), "failed to copy pose graph to configured path %s: %s",
-        config_.save_pose_graph_path_.c_str(), copy_error.message().c_str());
-    }
+    io_ports_.diagnostics->emit(
+      {ports::DiagnosticLevel::WARNING, "pose_graph_write_failed", bundle_pose_graph_path});
+  }
+  if (!config_.save_pose_graph_path_.empty() &&
+    (!do_save_map ||
+    std::filesystem::path(config_.save_pose_graph_path_).lexically_normal() !=
+    std::filesystem::path(bundle_pose_graph_path).lexically_normal()) &&
+    !io_ports_.map_output->writeBytes(
+      config_.save_pose_graph_path_, opt_result.pose_graph_g2o))
+  {
+    io_ports_.diagnostics->emit(
+      {ports::DiagnosticLevel::WARNING, "pose_graph_write_failed",
+        config_.save_pose_graph_path_});
   }
 
   if (config_.adjacent_edge_info_auto_scale_ && submaps_size > 1) {
@@ -657,7 +712,7 @@ void GraphBasedSlamComponent::Impl::receiveNavSatFix(const sensor_msgs::msg::Nav
   Eigen::Vector3d enu = geodeticToEnu(msg.latitude, msg.longitude, msg.altitude);
   const detail::GnssConstraintWeights gnss_weights =
     detail::computeGnssConstraintWeights(msg, makeGnssWeightingConfig(config_));
-  const double receive_time_sec = node_.get_clock()->now().seconds();
+  const double receive_time_sec = io_ports_.clock->nowSeconds();
   const double header_time_sec = rclcpp::Time(msg.header.stamp).seconds();
   const detail::GnssTimestampResolution stamp_resolution =
     detail::resolveGnssMeasurementStamp(
@@ -825,7 +880,7 @@ void GraphBasedSlamComponent::Impl::recordScanDegeneracy(const nav_msgs::msg::Od
   // Opt-in, report-only (v0.8 Phase 1): compute nothing at all unless one of
   // the two diagnostics outputs was requested, so the default path stays
   // byte-for-byte identical in behavior and cost.
-  const bool csv_enabled = degeneracy_csv_ofs_.is_open();
+  const bool csv_enabled = degeneracy_csv_enabled_;
   if (!csv_enabled && !config_.save_degeneracy_report_) {
     return;
   }
@@ -836,7 +891,9 @@ void GraphBasedSlamComponent::Impl::recordScanDegeneracy(const nav_msgs::msg::Od
 
   std::lock_guard<std::mutex> lock(degeneracy_mtx_);
   if (csv_enabled) {
-    degeneracy_csv_ofs_ << degeneracy::degeneracyDiagnosticsCsvRowLine(stamp_sec, result) << "\n";
+    io_ports_.map_output->appendBytes(
+      config_.degeneracy_diagnostics_csv_path_,
+      degeneracy::degeneracyDiagnosticsCsvRowLine(stamp_sec, result) + "\n");
   }
   if (config_.save_degeneracy_report_) {
     degeneracy_accumulator_.add(stamp_sec, result);
@@ -857,14 +914,15 @@ void GraphBasedSlamComponent::Impl::writeDegeneracyReport()
     summary = degeneracy_accumulator_.summary();
   }
   const std::string report_path = config_.map_save_dir_ + "/degeneracy_report.yaml";
-  std::ofstream report(report_path);
-  if (!report.is_open()) {
-    RCLCPP_WARN(node_.get_logger(), "failed to write degeneracy report: %s", report_path.c_str());
-    return;
-  }
   const std::vector<std::string> lines = degeneracy::degeneracyReportYamlLines(summary);
+  std::ostringstream report;
   for (size_t i = 0; i < lines.size(); ++i) {
     report << lines[i] << "\n";
+  }
+  if (!io_ports_.map_output->writeBytes(report_path, report.str())) {
+    io_ports_.diagnostics->emit(
+      {ports::DiagnosticLevel::WARNING, "degeneracy_report_write_failed", report_path});
+    return;
   }
   std::cout << "Degeneracy report: " << report_path << std::endl;
 }
@@ -900,8 +958,12 @@ void GraphBasedSlamComponent::Impl::tryCreateSubmap(
   if (config_.use_pcd_cache_) {
     pcl::PointCloud<pcl::PointXYZI>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZI>);
     pcl::fromROSMsg(submap.cloud, *cloud);
-    if (saveSubmapToPCD(submap_idx, cloud)) {
+    if (io_ports_.submap_storage->store(submap_idx, *cloud)) {
       submap.cloud = sensor_msgs::msg::PointCloud2();
+    } else {
+      io_ports_.diagnostics->emit(
+        {ports::DiagnosticLevel::WARNING, "submap_cache_write_failed",
+          "failed to store submap " + std::to_string(submap_idx)});
     }
   }
   std_msgs::msg::Header map_header;
@@ -922,51 +984,28 @@ void GraphBasedSlamComponent::Impl::tryCreateSubmap(
 void GraphBasedSlamComponent::Impl::stageMapArrayCloudCache(
   lidarslam_msgs::msg::MapArray & map_array_msg)
 {
-  // Treat a full MapArray cache refresh as one repository transaction so
-  // backend readers never observe a mixture of old and newly written files.
-  std::lock_guard<std::mutex> cache_lock(pcd_cache_mtx_);
+  std::vector<ports::SubmapWrite> writes;
   for (int i = 0; i < static_cast<int>(map_array_msg.submaps.size()); ++i) {
-    auto & submap = map_array_msg.submaps[i];
+    const auto & submap = map_array_msg.submaps[i];
     if (submap.cloud.data.empty()) {
       continue;
     }
     pcl::PointCloud<pcl::PointXYZI>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZI>);
     pcl::fromROSMsg(submap.cloud, *cloud);
-    if (!cloud->empty() && saveSubmapToPCDUnlocked(i, cloud)) {
-      submap.cloud = sensor_msgs::msg::PointCloud2();
+    if (!cloud->empty()) {
+      writes.push_back({i, cloud});
     }
   }
-}
-
-bool GraphBasedSlamComponent::Impl::saveSubmapToPCD(
-  int idx,
-  const pcl::PointCloud<pcl::PointXYZI>::Ptr & cloud)
-{
-  std::lock_guard<std::mutex> cache_lock(pcd_cache_mtx_);
-  return saveSubmapToPCDUnlocked(idx, cloud);
-}
-
-bool GraphBasedSlamComponent::Impl::saveSubmapToPCDUnlocked(
-  int idx,
-  const pcl::PointCloud<pcl::PointXYZI>::Ptr & cloud)
-{
-  std::string path = map_saver::submapCachePath(config_.pcd_cache_dir_, idx);
-  if (pcl::io::savePCDFileBinaryCompressed(path, *cloud) == 0) {
-    return true;
+  const std::vector<bool> stored = io_ports_.submap_storage->storeBatch(writes);
+  for (std::size_t i = 0; i < writes.size(); ++i) {
+    if (i < stored.size() && stored[i]) {
+      map_array_msg.submaps[writes[i].index].cloud = sensor_msgs::msg::PointCloud2();
+    } else {
+      io_ports_.diagnostics->emit(
+        {ports::DiagnosticLevel::WARNING, "submap_cache_write_failed",
+          "failed to store submap " + std::to_string(writes[i].index)});
+    }
   }
-  RCLCPP_WARN(node_.get_logger(), "Failed to save PCD: %s", path.c_str());
-  return false;
-}
-
-pcl::PointCloud<pcl::PointXYZI>::Ptr GraphBasedSlamComponent::Impl::loadSubmapFromPCD(int idx)
-{
-  std::lock_guard<std::mutex> cache_lock(pcd_cache_mtx_);
-  auto cloud = std::make_shared<pcl::PointCloud<pcl::PointXYZI>>();
-  std::string path = map_saver::submapCachePath(config_.pcd_cache_dir_, idx);
-  if (pcl::io::loadPCDFile(path, *cloud) == -1) {
-    RCLCPP_WARN(node_.get_logger(), "Failed to load PCD: %s", path.c_str());
-  }
-  return cloud;
 }
 
 pcl::PointCloud<pcl::PointXYZI>::Ptr GraphBasedSlamComponent::Impl::loadSubmapCloud(
@@ -975,7 +1014,7 @@ pcl::PointCloud<pcl::PointXYZI>::Ptr GraphBasedSlamComponent::Impl::loadSubmapCl
 {
   pcl::PointCloud<pcl::PointXYZI>::Ptr cloud;
   if (config_.use_pcd_cache_) {
-    cloud = loadSubmapFromPCD(idx);
+    cloud = io_ports_.submap_storage->load(idx);
     if (!cloud->empty()) {
       return cloud;
     }
@@ -992,53 +1031,52 @@ void GraphBasedSlamComponent::Impl::writeMapBundleArtifacts(
   const LoopEdges & loop_edges,
   const std::vector<Eigen::Isometry3d> & optimized_poses)
 {
-  std::filesystem::create_directories(config_.map_save_dir_);
+  io_ports_.map_output->prepareDirectory(config_.map_save_dir_);
 
   const std::string trajectory_path = config_.map_save_dir_ + "/trajectory_optimized.tum";
-  std::ofstream trajectory(trajectory_path);
-  if (!trajectory.is_open()) {
-    RCLCPP_WARN(
-      node_.get_logger(), "failed to write optimized trajectory: %s", trajectory_path.c_str());
-  } else {
-    const std::size_t count = std::min(map_array_msg.submaps.size(), optimized_poses.size());
-    for (std::size_t i = 0; i < count; ++i) {
-      const Eigen::Vector3d t = optimized_poses[i].translation();
-      const Eigen::Quaterniond q(optimized_poses[i].rotation());
-      map_saver::TrajectoryPose record;
-      record.timestamp = rclcpp::Time(map_array_msg.submaps[i].header.stamp).seconds();
-      record.tx = t.x();
-      record.ty = t.y();
-      record.tz = t.z();
-      record.qx = q.x();
-      record.qy = q.y();
-      record.qz = q.z();
-      record.qw = q.w();
-      trajectory << map_saver::trajectoryTumLine(record) << "\n";
-    }
+  std::ostringstream trajectory;
+  const std::size_t count = std::min(map_array_msg.submaps.size(), optimized_poses.size());
+  for (std::size_t i = 0; i < count; ++i) {
+    const Eigen::Vector3d t = optimized_poses[i].translation();
+    const Eigen::Quaterniond q(optimized_poses[i].rotation());
+    map_saver::TrajectoryPose record;
+    record.timestamp = rclcpp::Time(map_array_msg.submaps[i].header.stamp).seconds();
+    record.tx = t.x();
+    record.ty = t.y();
+    record.tz = t.z();
+    record.qx = q.x();
+    record.qy = q.y();
+    record.qz = q.z();
+    record.qw = q.w();
+    trajectory << map_saver::trajectoryTumLine(record) << "\n";
+  }
+  if (!io_ports_.map_output->writeBytes(trajectory_path, trajectory.str())) {
+    io_ports_.diagnostics->emit(
+      {ports::DiagnosticLevel::WARNING, "trajectory_write_failed", trajectory_path});
   }
 
   const std::string loop_edges_path = config_.map_save_dir_ + "/loop_edges.csv";
-  std::ofstream loop_csv(loop_edges_path);
-  if (!loop_csv.is_open()) {
-    RCLCPP_WARN(node_.get_logger(), "failed to write loop edges: %s", loop_edges_path.c_str());
-  } else {
-    loop_csv << map_saver::loopEdgesCsvHeader() << "\n";
-    for (const auto & edge : loop_edges) {
-      const Eigen::Vector3d t = edge.relative_pose.translation();
-      const Eigen::Quaterniond q(edge.relative_pose.rotation());
-      map_saver::LoopEdgeRecord record;
-      record.from = edge.pair_id.first;
-      record.to = edge.pair_id.second;
-      record.fitness = edge.fitness_score;
-      record.tx = t.x();
-      record.ty = t.y();
-      record.tz = t.z();
-      record.qx = q.x();
-      record.qy = q.y();
-      record.qz = q.z();
-      record.qw = q.w();
-      loop_csv << map_saver::loopEdgeCsvLine(record) << "\n";
-    }
+  std::ostringstream loop_csv;
+  loop_csv << map_saver::loopEdgesCsvHeader() << "\n";
+  for (const auto & edge : loop_edges) {
+    const Eigen::Vector3d t = edge.relative_pose.translation();
+    const Eigen::Quaterniond q(edge.relative_pose.rotation());
+    map_saver::LoopEdgeRecord record;
+    record.from = edge.pair_id.first;
+    record.to = edge.pair_id.second;
+    record.fitness = edge.fitness_score;
+    record.tx = t.x();
+    record.ty = t.y();
+    record.tz = t.z();
+    record.qx = q.x();
+    record.qy = q.y();
+    record.qz = q.z();
+    record.qw = q.w();
+    loop_csv << map_saver::loopEdgeCsvLine(record) << "\n";
+  }
+  if (!io_ports_.map_output->writeBytes(loop_edges_path, loop_csv.str())) {
+    io_ports_.diagnostics->emit(
+      {ports::DiagnosticLevel::WARNING, "loop_edges_write_failed", loop_edges_path});
   }
 
   map_saver::BundleManifest manifest;
@@ -1058,12 +1096,11 @@ void GraphBasedSlamComponent::Impl::writeMapBundleArtifacts(
     config_.planar_map_filter_min_middle_eigenvalue_ratio_;
   manifest.planar_map_filter_min_retained_ratio = config_.planar_map_filter_min_retained_ratio_;
   const std::string manifest_path = config_.map_save_dir_ + "/map_bundle.yaml";
-  std::ofstream manifest_file(manifest_path);
-  if (!manifest_file.is_open()) {
-    RCLCPP_WARN(
-      node_.get_logger(), "failed to write map bundle manifest: %s", manifest_path.c_str());
-  } else {
-    manifest_file << map_saver::bundleManifestYaml(manifest);
+  if (!io_ports_.map_output->writeBytes(
+      manifest_path, map_saver::bundleManifestYaml(manifest)))
+  {
+    io_ports_.diagnostics->emit(
+      {ports::DiagnosticLevel::WARNING, "manifest_write_failed", manifest_path});
   }
 
   RCLCPP_INFO(
@@ -1081,14 +1118,8 @@ void GraphBasedSlamComponent::Impl::saveGridDividedMap(
 
   // Create output directory (clean existing PCD files to prevent orphans)
   std::string out_dir = config_.map_save_dir_ + "/pointcloud_map";
-  if (std::filesystem::exists(out_dir)) {
-    for (auto & entry : std::filesystem::directory_iterator(out_dir)) {
-      if (entry.path().extension() == ".pcd" || entry.path().extension() == ".yaml") {
-        std::filesystem::remove(entry.path());
-      }
-    }
-  }
-  std::filesystem::create_directories(out_dir);
+  io_ports_.map_output->prepareDirectory(out_dir);
+  io_ports_.map_output->removeByExtension(out_dir, {".pcd", ".yaml"});
 
   // Downsample the map
   pcl::PointCloud<pcl::PointXYZI>::Ptr downsampled(new pcl::PointCloud<pcl::PointXYZI>);
@@ -1144,22 +1175,21 @@ void GraphBasedSlamComponent::Impl::saveGridDividedMap(
 
   // Save each grid cell as PCD and build the Autoware pointcloud_map_loader
   // metadata (content produced in map_saver.hpp)
-  std::ofstream meta(out_dir + "/pointcloud_map_metadata.yaml");
+  std::ostringstream meta;
   meta << map_saver::metadataHeader(grid_config);
 
   int saved = 0;
   for (auto & [key, cloud] : grid_cells) {
     if (cloud->empty()) {continue;}
     const map_saver::CellFile cell = map_saver::makeCellFile(key, grid_bounds, grid_config);
-    pcl::io::savePCDFileBinaryCompressed(out_dir + "/" + cell.filename, *cloud);
+    io_ports_.map_output->writePointCloud(out_dir + "/" + cell.filename, *cloud);
     meta << map_saver::metadataEntry(cell);
     saved++;
   }
-
-  meta.close();
+  io_ports_.map_output->writeBytes(out_dir + "/pointcloud_map_metadata.yaml", meta.str());
 
   // Also save the full map as a single PCD for convenience
-  pcl::io::savePCDFileBinaryCompressed(config_.map_save_dir_ + "/map.pcd", *downsampled);
+  io_ports_.map_output->writePointCloud(config_.map_save_dir_ + "/map.pcd", *downsampled);
 
   std::cout << map_saver::savedMapLogLine(saved, grid_config, out_dir) << std::endl;
   std::cout << "Total points: " << downsampled->size() << std::endl;
@@ -1167,10 +1197,10 @@ void GraphBasedSlamComponent::Impl::saveGridDividedMap(
 
   // Always emit map_projector_info.yaml so Autoware can load pointcloud-only maps.
   std::string proj_file = config_.map_save_dir_ + "/map_projector_info.yaml";
-  std::ofstream proj(proj_file);
-  proj << map_saver::projectorInfoYaml(gnss_origin_set_, gnss_origin_lat_, gnss_origin_lon_);
+  io_ports_.map_output->writeBytes(
+    proj_file,
+    map_saver::projectorInfoYaml(gnss_origin_set_, gnss_origin_lat_, gnss_origin_lon_));
   std::cout << map_saver::projectorInfoLogLine(gnss_origin_set_, proj_file) << std::endl;
-  proj.close();
 }
 }  // namespace graphslam
 

--- a/graph_based_slam/src/graph_based_slam_component_impl.hpp
+++ b/graph_based_slam/src/graph_based_slam_component_impl.hpp
@@ -41,7 +41,6 @@
 #include <tf2_ros/transform_broadcaster.h>  // NOLINT(build/include_order)
 #include <tf2_ros/transform_listener.h>  // NOLINT(build/include_order)
 
-#include <fstream>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -66,6 +65,7 @@
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <std_srvs/srv/empty.hpp>
 #include "graph_based_slam/degeneracy_report_summary.hpp"
+#include "graph_based_slam/external_io_ports.hpp"
 #include "graph_based_slam/gnss_origin_accumulator.hpp"
 #include "graph_based_slam/graph_state_store.hpp"
 #include "graph_based_slam/loop_edge_set.hpp"
@@ -93,6 +93,7 @@ private:
     // voxel filter and 3D-BBS verifier. Their PCL/pclomp/descriptor headers
     // stay in the component implementation translation unit.
   std::unique_ptr<BackendWorkspace> backend_;
+  ports::ExternalIoPorts io_ports_;
     // BackendWorkspace is single-threaded by contract. Keep that contract
     // when hosted by a MultiThreadedExecutor, while coalescing arrivals
     // during a long search.
@@ -149,15 +150,7 @@ private:
   int previous_submaps_num_ {0};
 
   // PCD disk cache for memory-efficient submap storage.
-  std::mutex pcd_cache_mtx_;
   void stageMapArrayCloudCache(lidarslam_msgs::msg::MapArray & map_array_msg);
-  bool saveSubmapToPCD(
-    int idx,
-    const pcl::PointCloud<pcl::PointXYZI>::Ptr & cloud);
-  bool saveSubmapToPCDUnlocked(
-    int idx,
-    const pcl::PointCloud<pcl::PointXYZI>::Ptr & cloud);
-  pcl::PointCloud<pcl::PointXYZI>::Ptr loadSubmapFromPCD(int idx);
   pcl::PointCloud<pcl::PointXYZI>::Ptr loadSubmapCloud(
     const lidarslam_msgs::msg::MapArray & map_array_msg, int idx);
 
@@ -201,7 +194,7 @@ private:
     // artifacts). Both default off: default behavior (and determinism) is
     // unchanged, and nothing here feeds back into any pose or edge weight.
   std::mutex degeneracy_mtx_;
-  std::ofstream degeneracy_csv_ofs_;
+  bool degeneracy_csv_enabled_ {false};
   degeneracy::DegeneracyReportAccumulator degeneracy_accumulator_;
   void recordScanDegeneracy(const nav_msgs::msg::Odometry & odom_msg);
   void writeDegeneracyReport();

--- a/graph_based_slam/src/graph_slam_application.cpp
+++ b/graph_based_slam/src/graph_slam_application.cpp
@@ -208,7 +208,7 @@ pose_graph::OptimizationResult GraphSlamApplication::optimize(
     request.submaps, loop_constraints, request.imu_constraints,
     request.gnss_constraints, request.adjacent_config, request.loop_config,
     request.imu_config, request.chi2_collection, request.fix_first_vertex,
-    request.iterations, request.save_path, request.plane_constraints);
+    request.iterations, request.plane_constraints);
 }
 
 }  // namespace graphslam

--- a/graph_based_slam/src/graph_slam_offline_runner.cpp
+++ b/graph_based_slam/src/graph_slam_offline_runner.cpp
@@ -76,6 +76,7 @@
 #include "graph_based_slam/plane_revisit_constraints.hpp"
 #include "graph_based_slam/pose_graph_optimization.hpp"
 #include "graph_based_slam/submap_creation.hpp"
+#include "filesystem_io_ports.hpp"
 
 namespace
 {
@@ -90,11 +91,11 @@ struct SubmapRecord
   CloudPtr cloud;
 };
 
-void writeTum(
-  const std::string & path, const std::vector<SubmapRecord> & records,
+std::string tumBytes(
+  const std::vector<SubmapRecord> & records,
   const std::vector<Eigen::Isometry3d> & poses)
 {
-  std::ofstream out(path);
+  std::ostringstream out;
   char line[256];
   for (std::size_t i = 0; i < records.size(); ++i) {
     const Eigen::Vector3d t = poses[i].translation();
@@ -104,6 +105,7 @@ void writeTum(
       records[i].stamp_sec, t.x(), t.y(), t.z(), q.x(), q.y(), q.z(), q.w());
     out << line << "\n";
   }
+  return out.str();
 }
 
 void loadFixedLoopEdges(
@@ -264,7 +266,12 @@ int main(int argc, char ** argv)
     rclcpp::shutdown();
     return 1;
   }
-  std::filesystem::create_directories(output_dir);
+  graphslam::adapters::FilesystemMapOutput map_output;
+  if (!map_output.prepareDirectory(output_dir)) {
+    RCLCPP_ERROR(logger, "failed to prepare output_dir: %s", output_dir.c_str());
+    rclcpp::shutdown();
+    return 1;
+  }
 
   // Same parameter names and defaults as the live component.
   std::string registration_method;
@@ -782,6 +789,7 @@ int main(int argc, char ** argv)
   }
 
   std::vector<Eigen::Isometry3d> optimized_poses;
+  std::string pose_graph_g2o;
   optimized_poses.reserve(records.size());
   if (!records.empty()) {
     graphslam::PoseGraphRequest request;
@@ -792,6 +800,7 @@ int main(int argc, char ** argv)
     request.plane_constraints = plane_revisit_result.constraints;
     const graphslam::pose_graph::OptimizationResult result = application.optimize(request);
     optimized_poses = result.poses;
+    pose_graph_g2o = result.pose_graph_g2o;
     if (use_plane_revisit_constraints) {
       std::ofstream report(output_dir + "/plane_revisit_report.yaml");
       report << "plane_revisit:\n";
@@ -833,7 +842,7 @@ int main(int argc, char ** argv)
   // --- Deterministic outputs. loop_edges.csv is the Phase 2 hard-gate
   // artifact: same bag + same config must reproduce it byte-identically.
   {
-    std::ofstream csv(output_dir + "/loop_edges.csv");
+    std::ostringstream csv;
     csv << "from,to,fitness,tx,ty,tz,qx,qy,qz,qw\n";
     char line[512];
     for (const auto & edge : loop_edges) {
@@ -845,6 +854,7 @@ int main(int argc, char ** argv)
         t.x(), t.y(), t.z(), q.x(), q.y(), q.z(), q.w());
       csv << line << "\n";
     }
+    map_output.writeBytes(output_dir + "/loop_edges.csv", csv.str());
   }
   {
     std::vector<Eigen::Isometry3d> raw_poses;
@@ -852,9 +862,12 @@ int main(int argc, char ** argv)
     for (const auto & record : records) {
       raw_poses.push_back(Eigen::Isometry3d(record.meta.pose.matrix()));
     }
-    writeTum(output_dir + "/trajectory_raw.tum", records, raw_poses);
+    map_output.writeBytes(
+      output_dir + "/trajectory_raw.tum", tumBytes(records, raw_poses));
     if (!optimized_poses.empty()) {
-      writeTum(output_dir + "/trajectory_optimized.tum", records, optimized_poses);
+      map_output.writeBytes(
+        output_dir + "/trajectory_optimized.tum", tumBytes(records, optimized_poses));
+      map_output.writeBytes(output_dir + "/pose_graph.g2o", pose_graph_g2o);
     }
   }
   if (refine && !optimized_poses.empty()) {
@@ -878,14 +891,16 @@ int main(int argc, char ** argv)
     for (const auto & pose : refined.poses) {
       refined_poses.push_back(Eigen::Isometry3d(pose));
     }
-    writeTum(output_dir + "/trajectory_refined.tum", records, refined_poses);
+    map_output.writeBytes(
+      output_dir + "/trajectory_refined.tum", tumBytes(records, refined_poses));
     {
-      std::ofstream report(output_dir + "/map_refinement_report.yaml");
+      std::ostringstream report;
       const std::vector<std::string> lines =
         graphslam::map_refinement::refinerReportYamlLines(refined, refiner_config);
       for (size_t i = 0; i < lines.size(); ++i) {
         report << lines[i] << "\n";
       }
+      map_output.writeBytes(output_dir + "/map_refinement_report.yaml", report.str());
     }
     RCLCPP_INFO(
       logger, "Refinement %s: %zu windows, status=%s",
@@ -898,7 +913,7 @@ int main(int argc, char ** argv)
       // differ between the two maps.
       const auto save_map =
         [&](const std::vector<Eigen::Matrix4d> & poses, const std::string & path) {
-          pcl::PointCloud<pcl::PointXYZ> map_cloud;
+          graphslam::ports::PointCloudXyz map_cloud;
           for (size_t i = 0; i < local_clouds.size(); ++i) {
             const Eigen::Matrix3d rotation = poses[i].block<3, 3>(0, 0);
             const Eigen::Vector3d translation = poses[i].block<3, 1>(0, 3);
@@ -910,7 +925,7 @@ int main(int argc, char ** argv)
                   static_cast<float>(world.z())));
             }
           }
-          pcl::io::savePCDFileBinary(path, map_cloud);
+          map_output.writePointCloudXyz(path, map_cloud);
         };
       save_map(initial_matrices, output_dir + "/map_optimized.pcd");
       save_map(refined.poses, output_dir + "/map_refined.pcd");

--- a/graph_based_slam/test/test_external_io_ports.cpp
+++ b/graph_based_slam/test/test_external_io_ports.cpp
@@ -1,0 +1,173 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following disclaimer
+//    in the documentation and/or other materials provided with the
+//    distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "filesystem_io_ports.hpp"
+#include "graph_based_slam/external_io_ports.hpp"
+
+namespace graphslam
+{
+namespace ports
+{
+namespace
+{
+
+TEST(ExternalIoPorts, RequiresEveryBoundary)
+{
+  ExternalIoPorts ports;
+  EXPECT_THROW(ports.validate(), std::invalid_argument);
+  ports.clock = std::make_shared<ManualClock>();
+  ports.submap_storage = std::make_shared<InMemorySubmapStorage>();
+  ports.diagnostics = std::make_shared<InMemoryDiagnostics>();
+  ports.map_output = std::make_shared<InMemoryMapOutput>();
+  EXPECT_NO_THROW(ports.validate());
+}
+
+TEST(ExternalIoPorts, ManualClockIsControlledByInput)
+{
+  ManualClock clock(12.5);
+  EXPECT_DOUBLE_EQ(clock.nowSeconds(), 12.5);
+  clock.set(42.25);
+  EXPECT_DOUBLE_EQ(clock.nowSeconds(), 42.25);
+}
+
+TEST(ExternalIoPorts, InMemoryStorageReturnsValueSnapshots)
+{
+  InMemorySubmapStorage storage;
+  PointCloud cloud;
+  pcl::PointXYZI point;
+  point.x = 1.0F;
+  point.intensity = 7.0F;
+  cloud.push_back(point);
+  ASSERT_TRUE(storage.store(3, cloud));
+
+  PointCloudPtr first = storage.load(3);
+  ASSERT_EQ(first->size(), 1U);
+  first->front().x = 99.0F;
+  PointCloudPtr second = storage.load(3);
+  ASSERT_EQ(second->size(), 1U);
+  EXPECT_FLOAT_EQ(second->front().x, 1.0F);
+  EXPECT_TRUE(storage.load(4)->empty());
+
+  PointCloudPtr second_cloud(new PointCloud(cloud));
+  second_cloud->front().x = 2.0F;
+  const auto stored = storage.storeBatch({{5, second_cloud}, {-1, second_cloud}});
+  ASSERT_EQ(stored.size(), 2U);
+  EXPECT_TRUE(stored[0]);
+  EXPECT_FALSE(stored[1]);
+  EXPECT_FLOAT_EQ(storage.load(5)->front().x, 2.0F);
+}
+
+TEST(ExternalIoPorts, InMemoryDiagnosticsPreservesEmissionOrder)
+{
+  InMemoryDiagnostics diagnostics;
+  diagnostics.emit({DiagnosticLevel::INFO, "first", "one"});
+  diagnostics.emit({DiagnosticLevel::WARNING, "second", "two"});
+  const auto events = diagnostics.events();
+  ASSERT_EQ(events.size(), 2U);
+  EXPECT_EQ(events[0].code, "first");
+  EXPECT_EQ(events[1].code, "second");
+}
+
+TEST(ExternalIoPorts, InMemoryOutputPreservesExactArtifactBytes)
+{
+  InMemoryMapOutput output;
+  const std::string bytes("g2o\0artifact\n", 13);
+  ASSERT_TRUE(output.writeBytes("pose_graph.g2o", bytes));
+  const std::string loaded = output.bytes("pose_graph.g2o");
+  ASSERT_EQ(loaded.size(), bytes.size());
+  EXPECT_EQ(std::memcmp(loaded.data(), bytes.data(), bytes.size()), 0);
+  ASSERT_TRUE(output.appendBytes("pose_graph.g2o", "tail"));
+  EXPECT_EQ(output.bytes("pose_graph.g2o"), bytes + "tail");
+  ASSERT_TRUE(output.writeBytes("map/stale.yaml", "stale"));
+  ASSERT_TRUE(output.writeBytes("map/keep.txt", "keep"));
+  ASSERT_TRUE(output.removeByExtension("map", {".yaml"}));
+  EXPECT_TRUE(output.bytes("map/stale.yaml").empty());
+  EXPECT_EQ(output.bytes("map/keep.txt"), "keep");
+
+  PointCloud cloud;
+  pcl::PointXYZI point;
+  point.z = 4.0F;
+  cloud.push_back(point);
+  ASSERT_TRUE(output.writePointCloud("map.pcd", cloud));
+  ASSERT_EQ(output.pointCloud("map.pcd")->size(), 1U);
+  EXPECT_FLOAT_EQ(output.pointCloud("map.pcd")->front().z, 4.0F);
+}
+
+TEST(ExternalIoPorts, FilesystemAdaptersRoundTripWithoutLeakingIntoEngine)
+{
+  const std::filesystem::path directory =
+    std::filesystem::temp_directory_path() / "graph_slam_external_io_ports_test";
+  std::filesystem::remove_all(directory);
+
+  adapters::FilesystemMapOutput output;
+  ASSERT_TRUE(output.prepareDirectory(directory.string()));
+  const std::string text_path = (directory / "artifact.txt").string();
+  ASSERT_TRUE(output.writeBytes(text_path, "first"));
+  ASSERT_TRUE(output.appendBytes(text_path, "-second"));
+  std::ifstream text_input(text_path, std::ios::binary);
+  const std::string loaded_text(
+    (std::istreambuf_iterator<char>(text_input)), std::istreambuf_iterator<char>());
+  EXPECT_EQ(loaded_text, "first-second");
+
+  adapters::PcdSubmapStorage storage((directory / "cache").string());
+  PointCloud cloud;
+  pcl::PointXYZI point;
+  point.x = 3.0F;
+  point.intensity = 9.0F;
+  cloud.push_back(point);
+  ASSERT_TRUE(storage.store(7, cloud));
+  PointCloudPtr loaded_cloud = storage.load(7);
+  ASSERT_EQ(loaded_cloud->size(), 1U);
+  EXPECT_FLOAT_EQ(loaded_cloud->front().x, 3.0F);
+  EXPECT_TRUE(storage.load(8)->empty());
+  const auto batch_result = storage.storeBatch({{8, loaded_cloud}});
+  ASSERT_EQ(batch_result.size(), 1U);
+  EXPECT_TRUE(batch_result.front());
+  EXPECT_EQ(storage.load(8)->size(), 1U);
+
+  ASSERT_TRUE(output.writeBytes((directory / "stale.yaml").string(), "stale"));
+  ASSERT_TRUE(output.writeBytes((directory / "keep.txt").string(), "keep"));
+  ASSERT_TRUE(output.removeByExtension(directory.string(), {".yaml"}));
+  EXPECT_FALSE(std::filesystem::exists(directory / "stale.yaml"));
+  EXPECT_TRUE(std::filesystem::exists(directory / "keep.txt"));
+  std::filesystem::remove_all(directory);
+}
+
+}  // namespace
+}  // namespace ports
+}  // namespace graphslam

--- a/graph_based_slam/test/test_pose_graph_optimization.cpp
+++ b/graph_based_slam/test/test_pose_graph_optimization.cpp
@@ -148,6 +148,8 @@ TEST(PoseGraphOptimization, SameInputsGiveBitwiseIdenticalPoses)
   for (size_t i = 0; i < a.adjacent_chi2.size(); ++i) {
     EXPECT_EQ(a.adjacent_chi2[i], b.adjacent_chi2[i]);
   }
+  EXPECT_FALSE(a.pose_graph_g2o.empty());
+  EXPECT_EQ(a.pose_graph_g2o, b.pose_graph_g2o);
 }
 
 TEST(PoseGraphOptimization, GnssAnchorPullsVertexTowardAnchor)
@@ -301,7 +303,7 @@ TEST(PoseGraphOptimization, PlaneRevisitCorrectsNormalDirectionDriftOnly)
   no_odometry.num_adjacent_pose_constraints = 0;
   const auto result = optimizePoseGraph(
     submaps, {}, {}, {}, no_odometry, LoopEdgeConfig{}, ImuEdgeConfig{},
-    Chi2Collection::NONE, true, 20, std::string(), {plane});
+    Chi2Collection::NONE, true, 20, {plane});
 
   ASSERT_EQ(result.plane_revisit_edges, 1);
   EXPECT_GT(result.plane_revisit_chi2_before, 1.0);
@@ -332,7 +334,7 @@ TEST(PoseGraphOptimization, PlaneRevisitAlignsNormalsWithoutConstrainingNormalYa
   no_odometry.num_adjacent_pose_constraints = 0;
   const auto result = optimizePoseGraph(
     submaps, {}, {}, {}, no_odometry, LoopEdgeConfig{}, ImuEdgeConfig{},
-    Chi2Collection::NONE, true, 20, std::string(), {plane});
+    Chi2Collection::NONE, true, 20, {plane});
   const Eigen::Vector3d corrected_normal =
     result.poses[1].rotation() * Eigen::Vector3d::UnitX();
   EXPECT_GT(corrected_normal.dot(Eigen::Vector3d::UnitX()), 0.999999);
@@ -453,7 +455,7 @@ TEST(PoseGraphOptimization, OrthogonalPlaneRevisitsReduceTrajectoryRmse)
   weak_odometry.info_weight = 1.0;
   const auto result = optimizePoseGraph(
     estimated, {}, {}, {}, weak_odometry, LoopEdgeConfig{}, ImuEdgeConfig{},
-    Chi2Collection::NONE, true, 50, std::string(), constraints);
+    Chi2Collection::NONE, true, 50, constraints);
 
   double squared_error_after = 0.0;
   for (std::size_t i = 0; i < result.poses.size(); ++i) {


### PR DESCRIPTION
## Summary

- introduce explicit clock, submap-storage, diagnostics, and map-output contracts with in-memory test adapters and filesystem/ROS production adapters
- remove optimizer save paths, return canonical g2o bytes, and persist deterministic live/offline artifacts through the map-output port
- preserve transactional PCD cache staging and the offline binary XYZ PCD artifact schema

## Architecture

This is Milestone 4 of the Graph SLAM architecture redesign and is stacked on #374.

The deterministic `graph_slam_application` target does not link the filesystem adapter target. The mapping engine and optimizer no longer open filesystem paths, read a ROS clock, or emit ROS logs. Filesystem and ROS behavior now lives at the composition boundary.

Live and offline paths use the same output contract for loop edges, trajectories, pose graphs, map artifacts, and reports. In-memory adapters make those boundaries directly testable.

## Validation

- `scripts/run_default_ci_checks.sh`: 4 packages, 2463 tests, 0 errors, 0 failures, 124 skipped
- graph_based_slam: all 157 CTest entries passed
- external I/O port filesystem and in-memory tests passed
- identical optimizer input produces byte-identical canonical g2o output
- ROS component startup smoke passed (expected timeout after successful initialization)
- `mkdocs build --strict` passed
- release-readiness passing fixture accepted at APE 0.10 m
- release-readiness failing fixture rejected with exit code 2
- `git diff --check` passed