### PR TITLE
Add held-out spatiotemporal camera calibration

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ python3 tools/colored_map/colored_map_pipeline.py \
 ```
 
 The pipeline caches `dense_corrected_trajectory.tum` and rebuilds stale
-downstream artifacts; use `--force-trajectory` for an explicit refresh.
+downstream artifacts; use `--force-trajectory` for an explicit refresh. Moving rigs can add `--refine-spatiotemporal-calibration`; see the [held-out-gated design and RTK-SLAM result](docs/research/colored-map-spatiotemporal-calibration-2026-07.md).
 
 ### Cross-repository SLAM benchmark
 

--- a/docs/research/colored-map-spatiotemporal-calibration-2026-07.md
+++ b/docs/research/colored-map-spatiotemporal-calibration-2026-07.md
@@ -1,0 +1,76 @@
+# Coloured-map spatiotemporal calibration (2026-07)
+
+## Motivation
+
+Camera-coloured point clouds turn small timing and extrinsic errors into colour
+halos at walls, pillars, and object boundaries. The previous `--time-offset
+auto` aligns camera and LiDAR clock domains, while the alignment evaluator's
+optional correction searched only a 6DoF camera pose. Neither recomposed every
+camera pose from the continuous SLAM trajectory while jointly searching the
+residual clock offset.
+
+## Architecture
+
+`evaluate_lidar_camera_alignment.py --optimize-spatiotemporal` now optimizes
+seven bounded parameters:
+
+1. residual camera-to-trajectory time offset;
+2. local optical-frame x/y/z extrinsic translation;
+3. local optical-frame roll/pitch/yaw extrinsic rotation.
+
+For every candidate it interpolates `world <- body` from the dense TUM
+trajectory and composes it with the refined `body <- camera` transform. The
+objective is the coverage-guarded distance from projected LiDAR depth
+discontinuities to strong image gradients. Image edge masks are cached across
+the deterministic coarse-to-fine coordinate search.
+
+The user-facing pipeline is deliberately staged as:
+
+```text
+posed images -> uncoloured calibration geometry -> 7DoF calibration
+             -> corrected camera poses -> final robust RGB map -> quality gates
+```
+
+The feature is opt-in. Without `--refine-spatiotemporal-calibration`, command
+composition and output paths are unchanged.
+
+## Safety and validation gates
+
+- Every Nth selected view is held out before optimization.
+- Training loss must decrease and held-out loss must decrease independently.
+- A configurable minimum number of LiDAR depth-edge pixels is required in both
+  partitions.
+- A nearly static trajectory is rejected because time offset is unobservable.
+- Time, translation, and rotation corrections have independent hard bounds.
+- Source camera poses must reproduce one static extrinsic within 1 mm and 0.05
+  degrees; otherwise their timestamps/conventions are treated as inconsistent.
+- Parameters that land on a search bound are listed in `boundary_axes` for
+  promotion review.
+- Rejected candidates export the original camera poses, never an unvalidated
+  correction, and record the rejection reason in JSON.
+- Frame timestamps and original images are preserved in the corrected
+  `transforms_spatiotemporal.json` dataset.
+
+## RTK-SLAM Construction Seq1 smoke result
+
+The first CPU smoke run used the existing K3 4.84 M-point map, deterministically
+sampled to 200,000 points, 13 of 260 camera views, two search rounds, and tight
+bounds of 40 ms / 4 cm / 0.5 degrees. Ten views were training data and three
+were held out.
+
+| metric | initial | refined |
+| --- | ---: | ---: |
+| training mean edge distance | 6.444 px | 6.004 px |
+| held-out mean edge distance | 6.887 px | 6.375 px |
+| held-out median edge distance | 6.325 px | 5.385 px |
+| held-out out-of-range fraction | 0.285 | 0.251 |
+
+The held-out mean improved by about 7.4%, so the candidate was accepted. The
+solution reached a translation bound on two axes; this establishes end-to-end
+functionality but is not a production calibration claim. Promotion requires a
+wider multi-scale search followed by rebuilding the map and running held-out
+RGB, appearance, trajectory, and geometry gates.
+
+The regression suite covers deterministic search, hard bounds, continuous-time
+pose recomposition, static-motion degeneracy, independent held-out rejection,
+pipeline staging, cache reuse, and unchanged default command composition.

--- a/graph_based_slam/test/test_colored_map_pipeline.py
+++ b/graph_based_slam/test/test_colored_map_pipeline.py
@@ -91,6 +91,49 @@ def test_time_offset_adjustment_reaches_image_extractor(tmp_path):
     assert extract[extract.index('--time-offset-adjustment') + 1] == '-0.02'
 
 
+def test_spatiotemporal_refinement_inserts_geometry_and_heldout_calibration(tmp_path):
+    commands = cmp.build_commands(_args(
+        tmp_path, '--refine-spatiotemporal-calibration',
+        '--calibration-max-time-offset', '0.04',
+        '--calibration-minimum-heldout-improvement', '0.02'))
+    assert [name for name, _ in commands] == [
+        'posed images', 'calibration geometry',
+        'spatiotemporal calibration', 'coloured map']
+    geometry = dict(commands)['calibration geometry']
+    calibration = dict(commands)['spatiotemporal calibration']
+    coloured = dict(commands)['coloured map']
+    assert '--color-transforms' not in geometry
+    assert '--optimize-spatiotemporal' in calibration
+    assert calibration[calibration.index('--max-time-offset') + 1] == '0.04'
+    assert calibration[calibration.index('--max-points') + 1] == '300000'
+    assert calibration[
+        calibration.index('--minimum-heldout-improvement') + 1] == '0.02'
+    refined = str(
+        tmp_path / 'out' / 'posed_images' /
+        'transforms_spatiotemporal.json')
+    assert calibration[
+        calibration.index('--corrected-transforms-out') + 1] == refined
+    assert coloured[coloured.index('--color-transforms') + 1] == refined
+
+
+def test_existing_spatiotemporal_outputs_are_reused(tmp_path):
+    out = tmp_path / 'out'
+    (out / 'posed_images').mkdir(parents=True)
+    (out / 'posed_images' / 'transforms.json').write_text('{}')
+    (out / 'spatiotemporal_calibration_geometry.ply').write_text('ply\n')
+    (out / 'posed_images' / 'transforms_spatiotemporal.json').write_text('{}')
+    (out / 'spatiotemporal_calibration.json').write_text('{}')
+    (out / 'colored_map.ply').write_text('ply\n')
+    assert cmp.build_commands(_args(
+        tmp_path, '--refine-spatiotemporal-calibration')) == []
+
+
+def test_force_calibration_requires_opt_in(tmp_path):
+    import pytest
+    with pytest.raises(ValueError, match='refine-spatiotemporal'):
+        cmp.run_pipeline(_args(tmp_path, '--force-calibration', '--dry-run'))
+
+
 def test_raw_trajectory_adds_densification_and_connects_dense_output(tmp_path):
     args = _args(tmp_path, '--raw-traj', str(tmp_path / 'raw.tum'))
     commands = cmp.build_commands(args)

--- a/graph_based_slam/test/test_lidar_camera_alignment.py
+++ b/graph_based_slam/test/test_lidar_camera_alignment.py
@@ -139,3 +139,93 @@ def test_write_corrected_transforms_preserves_images_and_updates_pose(tmp_path):
     loaded = lca.tg.load_transforms(output)
     np.testing.assert_allclose(loaded['viewmats'][0], correction @ original)
     assert loaded['image_paths'][0] == (images / '000.png').resolve()
+
+
+def _moving_samples():
+    return [
+        lca.pi.TrajectorySample(
+            float(index), np.array([float(index), 0.0, 0.0]),
+            np.array([0.0, 0.0, 0.0, 1.0]))
+        for index in range(4)
+    ]
+
+
+def test_recompose_viewmats_applies_continuous_time_and_extrinsic_delta():
+    parameters = np.array([0.25, 0.1, 0, 0, 0, 0, 0])
+    viewmat = lca.recompose_viewmats(
+        _moving_samples(), np.array([1.0]), np.eye(4), parameters)[0]
+    # world<-camera x is trajectory(1.25) + local extrinsic x correction.
+    np.testing.assert_allclose(np.linalg.inv(viewmat)[:3, 3], [1.35, 0, 0])
+
+
+def test_infer_body_camera_recovers_static_extrinsic_and_consistency():
+    samples = _moving_samples()
+    stamps = np.array([0.0, 1.0, 2.0])
+    extrinsic = lca.correction_matrix([0.1, -0.2, 0.3, 0.01, 0.02, -0.03])
+    viewmats = np.asarray([
+        np.linalg.inv(lca.pi.interpolate_pose(samples, stamp) @ extrinsic)
+        for stamp in stamps])
+    inferred, consistency = lca.infer_body_T_camera(
+        samples, stamps, viewmats)
+    np.testing.assert_allclose(inferred, extrinsic, atol=1e-12)
+    assert consistency['translation_spread_p95_m'] < 1e-12
+    assert consistency['rotation_spread_p95_deg'] < 1e-5
+
+
+def test_spatiotemporal_optimizer_is_deterministic_and_bounded(monkeypatch):
+    target = np.array([0.08, 0.08, -0.04, 0.0,
+                       np.deg2rad(0.4), 0.0, 0.0])
+
+    def objective(*args, reference_edge_points=None, **kwargs):
+        parameters = np.asarray(args[6])
+        loss = float(np.sum((parameters - target) ** 2))
+        return loss, {'edge_points': 100, 'mean_px': loss,
+                      'median_px': loss, 'coverage': 1.0}
+
+    monkeypatch.setattr(lca, 'spatiotemporal_objective', objective)
+    call = lambda: lca.optimize_spatiotemporal(
+        np.zeros((0, 3)), _moving_samples(), np.array([1.0]), np.eye(4),
+        np.eye(3), [], rounds=3, time_step=0.04,
+        translation_step=0.04, rotation_step_deg=0.4,
+        max_time_offset=0.05, max_translation=0.05,
+        max_rotation_deg=0.3)
+    first, before, after = call()
+    second, _, _ = call()
+    np.testing.assert_array_equal(first, second)
+    assert after['loss'] < before['loss']
+    assert abs(first[0]) <= 0.05
+    assert np.all(np.abs(first[1:4]) <= 0.05)
+    assert np.all(np.abs(np.rad2deg(first[4:])) <= 0.3 + 1e-12)
+
+
+def test_trajectory_excitation_rejects_static_time_offset():
+    static = [
+        lca.pi.TrajectorySample(
+            float(index), np.zeros(3), np.array([0.0, 0.0, 0.0, 1.0]))
+        for index in range(3)
+    ]
+    assert not lca.trajectory_excitation(
+        static, np.array([0.0, 1.0, 2.0]))['time_offset_observable']
+    assert lca.trajectory_excitation(
+        _moving_samples(), np.array([0.0, 1.0, 2.0]))['time_offset_observable']
+
+
+def test_calibration_acceptance_requires_heldout_improvement_and_support():
+    before = {'edge_points': 100, 'loss': 10.0}
+    improved = {'edge_points': 100, 'loss': 8.0}
+    accepted, reason = lca.calibration_acceptance(
+        before, improved, before, improved,
+        minimum_edge_points=50, minimum_heldout_improvement=0.1)
+    assert accepted and reason is None
+    accepted, reason = lca.calibration_acceptance(
+        before, improved, before, {'edge_points': 100, 'loss': 9.5},
+        minimum_edge_points=50, minimum_heldout_improvement=0.1)
+    assert not accepted and reason == 'heldout_or_training_loss_did_not_improve'
+    accepted, _ = lca.calibration_acceptance(
+        before, improved, before, before,
+        minimum_edge_points=50, minimum_heldout_improvement=0.0)
+    assert not accepted
+    accepted, reason = lca.calibration_acceptance(
+        {'edge_points': 10, 'loss': 10.0}, improved, before, improved,
+        minimum_edge_points=50, minimum_heldout_improvement=0.1)
+    assert not accepted and reason == 'insufficient_edge_support'

--- a/scripts/evaluate_lidar_camera_alignment.py
+++ b/scripts/evaluate_lidar_camera_alignment.py
@@ -167,16 +167,19 @@ def alignment_objective(points: np.ndarray, viewmats: np.ndarray,
                         K: np.ndarray, images: list[np.ndarray],
                         parameters: np.ndarray, *, edge_percentile: float = 95.0,
                         max_distance: int = 12,
-                        reference_edge_points: int | None = None) -> tuple[float, dict]:
+                        reference_edge_points: int | None = None,
+                        image_edge_masks: list[np.ndarray] | None = None
+                        ) -> tuple[float, dict]:
     """Return coverage-guarded mean edge distance for one SE(3) correction."""
     delta = correction_matrix(parameters)
     chunks = []
-    for viewmat, image in zip(viewmats, images):
+    targets = (image_edge_masks if image_edge_masks is not None else
+               [image_edges(image, edge_percentile) for image in images])
+    for viewmat, image, target in zip(viewmats, images, targets):
         height, width = image.shape[:2]
         lidar_edges = depth_edges(projected_depth(
             points, delta @ viewmat, K, width, height))
-        chunks.append(nearest_edge_distances(
-            lidar_edges, image_edges(image, edge_percentile), max_distance))
+        chunks.append(nearest_edge_distances(lidar_edges, target, max_distance))
     values = np.concatenate([item for item in chunks if item.size]) \
         if any(item.size for item in chunks) else np.zeros(0, np.float32)
     if not values.size:
@@ -205,6 +208,7 @@ def optimize_correction(points: np.ndarray, viewmats: np.ndarray, K: np.ndarray,
         edge_percentile=edge_percentile, max_distance=max_distance)
     best_loss = base_loss
     reference = before['edge_points']
+    edge_masks = [image_edges(image, edge_percentile) for image in images]
     steps = np.array([translation_step] * 3 +
                      [np.deg2rad(rotation_step_deg)] * 3)
     for _ in range(rounds):
@@ -216,17 +220,205 @@ def optimize_correction(points: np.ndarray, viewmats: np.ndarray, K: np.ndarray,
                     points, viewmats, K, images, candidate,
                     edge_percentile=edge_percentile,
                     max_distance=max_distance,
-                    reference_edge_points=reference)
+                    reference_edge_points=reference,
+                    image_edge_masks=edge_masks)
                 if loss < best_loss:
                     parameters, best_loss = candidate, loss
         steps *= 0.5
     _, after = alignment_objective(
         points, viewmats, K, images, parameters,
         edge_percentile=edge_percentile, max_distance=max_distance,
-        reference_edge_points=reference)
+        reference_edge_points=reference, image_edge_masks=edge_masks)
     before['loss'] = base_loss
     after['loss'] = best_loss
     return parameters, before, after
+
+
+def frame_stamps(transforms: Path) -> np.ndarray:
+    """Read the camera timestamps retained by ``extract_posed_images``."""
+    document = json.loads(Path(transforms).read_text())
+    try:
+        stamps = np.asarray([frame['stamp'] for frame in document['frames']],
+                            dtype=np.float64)
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError(
+            f'{transforms}: every frame needs a numeric stamp for temporal '
+            'calibration') from exc
+    if stamps.size == 0 or not np.all(np.isfinite(stamps)):
+        raise ValueError(f'{transforms}: frame stamps must be finite and non-empty')
+    return stamps
+
+
+def infer_body_T_camera(samples: list[pi.TrajectorySample], stamps: np.ndarray,
+                        viewmats: np.ndarray) -> tuple[np.ndarray, dict]:
+    """Recover the static body<-camera transform from extracted camera poses."""
+    estimates = []
+    for stamp, viewmat in zip(stamps, viewmats):
+        world_T_body = pi.interpolate_pose(samples, float(stamp))
+        world_T_camera = np.linalg.inv(viewmat)
+        estimates.append(np.linalg.inv(world_T_body) @ world_T_camera)
+    translations = np.asarray([item[:3, 3] for item in estimates])
+    centre = np.median(translations, axis=0)
+    representative = estimates[int(np.argmin(
+        np.linalg.norm(translations - centre, axis=1)))]
+    translation_spread = np.linalg.norm(
+        translations - representative[:3, 3], axis=1)
+    rotation_spread = []
+    for estimate in estimates:
+        relative = representative[:3, :3].T @ estimate[:3, :3]
+        cosine = np.clip((np.trace(relative) - 1.0) * 0.5, -1.0, 1.0)
+        rotation_spread.append(np.rad2deg(np.arccos(cosine)))
+    consistency = {
+        'frames': len(estimates),
+        'translation_spread_p95_m': float(np.percentile(translation_spread, 95)),
+        'rotation_spread_p95_deg': float(np.percentile(rotation_spread, 95)),
+    }
+    return representative, consistency
+
+
+def trajectory_excitation(samples: list[pi.TrajectorySample],
+                          stamps: np.ndarray) -> dict:
+    """Summarise motion that makes a camera/LiDAR time offset observable."""
+    poses = [pi.interpolate_pose(samples, float(stamp)) for stamp in stamps]
+    translations = np.asarray([pose[:3, 3] for pose in poses])
+    translation_path = float(np.linalg.norm(np.diff(translations, axis=0), axis=1).sum())
+    rotation_path = 0.0
+    for first, second in zip(poses, poses[1:]):
+        relative = first[:3, :3].T @ second[:3, :3]
+        cosine = np.clip((np.trace(relative) - 1.0) * 0.5, -1.0, 1.0)
+        rotation_path += float(np.rad2deg(np.arccos(cosine)))
+    return {'translation_path_m': translation_path,
+            'rotation_path_deg': rotation_path,
+            'time_offset_observable': bool(
+                translation_path >= 0.05 or rotation_path >= 1.0)}
+
+
+def recompose_viewmats(samples: list[pi.TrajectorySample], stamps: np.ndarray,
+                       body_T_camera: np.ndarray,
+                       parameters: np.ndarray) -> np.ndarray:
+    """Compose world-to-camera poses for a time and local SE(3) correction."""
+    values = np.asarray(parameters, dtype=np.float64).reshape(7)
+    time_offset = float(values[0])
+    corrected_extrinsic = body_T_camera @ correction_matrix(values[1:])
+    return np.asarray([
+        np.linalg.inv(pi.interpolate_pose(samples, float(stamp + time_offset)) @
+                      corrected_extrinsic)
+        for stamp in stamps
+    ])
+
+
+def spatiotemporal_objective(
+        points: np.ndarray, samples: list[pi.TrajectorySample],
+        stamps: np.ndarray, body_T_camera: np.ndarray, K: np.ndarray,
+        images: list[np.ndarray], parameters: np.ndarray, *,
+        edge_percentile: float = 95.0, max_distance: int = 12,
+        reference_edge_points: int | None = None,
+        image_edge_masks: list[np.ndarray] | None = None) -> tuple[float, dict]:
+    """Evaluate a continuous-time pose recomposition against image edges."""
+    try:
+        viewmats = recompose_viewmats(
+            samples, stamps, body_T_camera, parameters)
+    except ValueError:
+        return float('inf'), {'edge_points': 0, 'mean_px': None,
+                              'median_px': None, 'coverage': 0.0}
+    return alignment_objective(
+        points, viewmats, K, images, np.zeros(6),
+        edge_percentile=edge_percentile, max_distance=max_distance,
+        reference_edge_points=reference_edge_points,
+        image_edge_masks=image_edge_masks)
+
+
+def optimize_spatiotemporal(
+        points: np.ndarray, samples: list[pi.TrajectorySample],
+        stamps: np.ndarray, body_T_camera: np.ndarray, K: np.ndarray,
+        images: list[np.ndarray], *, rounds: int = 3,
+        time_step: float = 0.02, translation_step: float = 0.02,
+        rotation_step_deg: float = 0.2, max_time_offset: float = 0.1,
+        max_translation: float = 0.1, max_rotation_deg: float = 2.0,
+        edge_percentile: float = 95.0,
+        max_distance: int = 12) -> tuple[np.ndarray, dict, dict]:
+    """Bounded deterministic coordinate search over dt plus a local SE(3)."""
+    parameters = np.zeros(7, dtype=np.float64)
+    base_loss, before = spatiotemporal_objective(
+        points, samples, stamps, body_T_camera, K, images, parameters,
+        edge_percentile=edge_percentile, max_distance=max_distance)
+    reference = before['edge_points']
+    edge_masks = [image_edges(image, edge_percentile) for image in images]
+    best_loss = base_loss
+    steps = np.array([time_step] + [translation_step] * 3 +
+                     [np.deg2rad(rotation_step_deg)] * 3)
+    bounds = np.array([max_time_offset] + [max_translation] * 3 +
+                      [np.deg2rad(max_rotation_deg)] * 3)
+    for _ in range(rounds):
+        changed = True
+        while changed:
+            changed = False
+            for axis in range(7):
+                for direction in (-1.0, 1.0):
+                    candidate = parameters.copy()
+                    candidate[axis] += direction * steps[axis]
+                    if abs(candidate[axis]) > bounds[axis] + 1e-12:
+                        continue
+                    loss, _ = spatiotemporal_objective(
+                        points, samples, stamps, body_T_camera, K, images,
+                        candidate, edge_percentile=edge_percentile,
+                        max_distance=max_distance,
+                        reference_edge_points=reference,
+                        image_edge_masks=edge_masks)
+                    if loss + 1e-12 < best_loss:
+                        parameters, best_loss = candidate, loss
+                        changed = True
+        steps *= 0.5
+    _, after = spatiotemporal_objective(
+        points, samples, stamps, body_T_camera, K, images, parameters,
+        edge_percentile=edge_percentile, max_distance=max_distance,
+        reference_edge_points=reference, image_edge_masks=edge_masks)
+    before['loss'] = base_loss
+    after['loss'] = best_loss
+    return parameters, before, after
+
+
+def calibration_acceptance(train_before: dict, train_after: dict,
+                           heldout_before: dict, heldout_after: dict, *,
+                           minimum_edge_points: int,
+                           minimum_heldout_improvement: float) -> tuple[bool, str | None]:
+    """Apply the independent validation gate used before exporting poses."""
+    enough_edges = (
+        train_before['edge_points'] >= minimum_edge_points and
+        heldout_before['edge_points'] >= minimum_edge_points)
+    if not enough_edges:
+        return False, 'insufficient_edge_support'
+    train_loss = train_after['loss']
+    heldout_loss = heldout_after['loss']
+    heldout_limit = heldout_before['loss'] * (
+        1.0 - minimum_heldout_improvement)
+    heldout_failed = (heldout_loss > heldout_limit or
+                      (minimum_heldout_improvement == 0.0 and
+                       heldout_loss >= heldout_limit))
+    if (not np.isfinite(train_loss) or not np.isfinite(heldout_loss) or
+            train_loss >= train_before['loss'] or heldout_failed):
+        return False, 'heldout_or_training_loss_did_not_improve'
+    return True, None
+
+
+def write_recomposed_transforms(source: Path, output: Path,
+                                viewmats: np.ndarray) -> Path:
+    """Write continuous-time recomposed poses while preserving frame metadata."""
+    source, output = Path(source).resolve(), Path(output).resolve()
+    if source == output:
+        raise ValueError('recomposed transforms output must differ from source')
+    document = json.loads(source.read_text())
+    dataset = tg.load_transforms(source)
+    if len(document['frames']) != len(viewmats):
+        raise ValueError('frame and recomposed viewmat counts differ')
+    for frame, viewmat, image_path in zip(
+            document['frames'], viewmats, dataset['image_paths']):
+        frame['transform_matrix'] = (
+            np.linalg.inv(viewmat) @ pi.ROS_OPTICAL_TO_OPENGL).tolist()
+        frame['file_path'] = os.path.relpath(image_path, output.parent)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(document, indent=2) + '\n')
+    return output
 
 
 def write_corrected_transforms(source: Path, output: Path,
@@ -257,22 +449,50 @@ def main() -> int:
     parser.add_argument('--transforms', type=Path, required=True)
     parser.add_argument('--out', type=Path, required=True)
     parser.add_argument('--view-stride', type=int, default=10)
+    parser.add_argument('--max-points', type=int, default=0,
+                        help='deterministically subsample this many geometry '
+                             'points for evaluation (0 keeps all)')
     parser.add_argument('--edge-percentile', type=float, default=95.0,
                         help='retain this percentile of nonzero image gradients; '
                              '95 focuses the metric on structural edges')
     parser.add_argument('--max-distance', type=int, default=12)
-    parser.add_argument('--optimize-extrinsic', action='store_true')
+    optimization_mode = parser.add_mutually_exclusive_group()
+    optimization_mode.add_argument('--optimize-extrinsic', action='store_true')
+    optimization_mode.add_argument('--optimize-spatiotemporal', action='store_true')
+    parser.add_argument('--trajectory', type=Path,
+                        help='dense TUM world<-body trajectory; required for '
+                             'spatiotemporal optimization')
     parser.add_argument('--optimization-rounds', type=int, default=3)
+    parser.add_argument('--time-step', type=float, default=0.02)
     parser.add_argument('--translation-step', type=float, default=0.02)
     parser.add_argument('--rotation-step-deg', type=float, default=0.2)
+    parser.add_argument('--max-time-offset', type=float, default=0.1)
+    parser.add_argument('--max-translation', type=float, default=0.1)
+    parser.add_argument('--max-rotation-deg', type=float, default=2.0)
+    parser.add_argument('--holdout-modulo', type=int, default=5,
+                        help='every Nth selected view is validation-only')
+    parser.add_argument('--minimum-edge-points', type=int, default=50)
+    parser.add_argument('--minimum-heldout-improvement', type=float, default=0.0,
+                        help='fractional held-out loss reduction required to '
+                             'accept and export the correction')
     parser.add_argument('--corrected-transforms-out', type=Path)
     args = parser.parse_args()
     if (args.view_stride < 1 or args.max_distance < 1 or
             args.optimization_rounds < 1 or args.translation_step <= 0.0 or
-            args.rotation_step_deg <= 0.0):
+            args.rotation_step_deg <= 0.0 or args.time_step <= 0.0 or
+            args.max_time_offset < 0.0 or args.max_translation < 0.0 or
+            args.max_rotation_deg < 0.0 or args.holdout_modulo < 2 or
+            args.minimum_edge_points < 1 or args.max_points < 0 or
+            not 0.0 <= args.minimum_heldout_improvement < 1.0):
         raise SystemExit('stride, distance, rounds, and search steps must be > 0')
+    if args.optimize_spatiotemporal and args.trajectory is None:
+        raise SystemExit('--optimize-spatiotemporal requires --trajectory')
     import imageio.v3 as iio
     points, _ = pcio.read_ply_xyz(args.pointcloud)
+    if args.max_points and len(points) > args.max_points:
+        indices = np.linspace(
+            0, len(points) - 1, args.max_points, dtype=np.int64)
+        points = points[indices]
     dataset = tg.load_transforms(args.transforms)
     viewmats = np.asarray(dataset['viewmats'], dtype=np.float64)
     selected = list(range(0, len(viewmats), args.view_stride))
@@ -280,7 +500,92 @@ def main() -> int:
               for index in selected]
     optimization = None
     delta = np.eye(4)
-    if args.optimize_extrinsic:
+    effective_viewmats = viewmats.copy()
+    if args.optimize_spatiotemporal:
+        samples = pi.read_tum_trajectory(args.trajectory)
+        stamps = frame_stamps(args.transforms)
+        if len(stamps) != len(viewmats):
+            raise SystemExit('frame stamp and camera pose counts differ')
+        body_T_camera, consistency = infer_body_T_camera(
+            samples, stamps, viewmats)
+        if (consistency['translation_spread_p95_m'] > 0.001 or
+                consistency['rotation_spread_p95_deg'] > 0.05):
+            raise SystemExit(
+                'camera poses are inconsistent with one static body-to-camera '
+                'extrinsic (p95 spread exceeds 1 mm or 0.05 degree)')
+        excitation = trajectory_excitation(samples, stamps[selected])
+        if not excitation['time_offset_observable']:
+            raise SystemExit(
+                'time offset is unobservable: selected views contain less than '
+                '0.05 m translation and 1 degree rotation')
+        heldout = [index for ordinal, index in enumerate(selected)
+                   if ordinal % args.holdout_modulo == 0]
+        train = [index for index in selected if index not in heldout]
+        if not train or not heldout:
+            raise SystemExit('spatiotemporal calibration needs train and held-out views')
+        image_by_index = dict(zip(selected, images))
+        train_images = [image_by_index[index] for index in train]
+        heldout_images = [image_by_index[index] for index in heldout]
+        parameters, train_before, train_after = optimize_spatiotemporal(
+            points, samples, stamps[train], body_T_camera, dataset['K'],
+            train_images, rounds=args.optimization_rounds,
+            time_step=args.time_step, translation_step=args.translation_step,
+            rotation_step_deg=args.rotation_step_deg,
+            max_time_offset=args.max_time_offset,
+            max_translation=args.max_translation,
+            max_rotation_deg=args.max_rotation_deg,
+            edge_percentile=args.edge_percentile,
+            max_distance=args.max_distance)
+        zero = np.zeros(7)
+        heldout_before_loss, heldout_before = spatiotemporal_objective(
+            points, samples, stamps[heldout], body_T_camera, dataset['K'],
+            heldout_images, zero, edge_percentile=args.edge_percentile,
+            max_distance=args.max_distance)
+        heldout_after_loss, heldout_after = spatiotemporal_objective(
+            points, samples, stamps[heldout], body_T_camera, dataset['K'],
+            heldout_images, parameters,
+            edge_percentile=args.edge_percentile,
+            max_distance=args.max_distance,
+            reference_edge_points=heldout_before['edge_points'])
+        heldout_before['loss'], heldout_after['loss'] = (
+            heldout_before_loss, heldout_after_loss)
+        accepted, rejection_reason = calibration_acceptance(
+            train_before, train_after, heldout_before, heldout_after,
+            minimum_edge_points=args.minimum_edge_points,
+            minimum_heldout_improvement=args.minimum_heldout_improvement)
+        if accepted:
+            effective_viewmats = recompose_viewmats(
+                samples, stamps, body_T_camera, parameters)
+        parameter_bounds = np.array([
+            args.max_time_offset, args.max_translation,
+            args.max_translation, args.max_translation,
+            args.max_rotation_deg, args.max_rotation_deg,
+            args.max_rotation_deg])
+        reported_parameters = np.array(
+            [parameters[0], *parameters[1:4],
+             *np.rad2deg(parameters[4:])])
+        names = ['dt', 'tx', 'ty', 'tz', 'roll', 'pitch', 'yaw']
+        boundary_axes = [
+            name for name, value, bound in zip(
+                names, reported_parameters, parameter_bounds)
+            if bound > 0.0 and abs(value) >= bound - 1e-12]
+        optimization = {
+            'accepted': accepted,
+            'parameters_dt_s_xyz_m_rpy_deg': [float(parameters[0])] +
+            parameters[1:4].tolist() + np.rad2deg(parameters[4:]).tolist(),
+            'body_T_camera_initial': body_T_camera.tolist(),
+            'extrinsic_consistency': consistency,
+            'trajectory_excitation': excitation,
+            'train_view_indices': train,
+            'heldout_view_indices': heldout,
+            'minimum_edge_points': args.minimum_edge_points,
+            'search_bounds_dt_s_xyz_m_rpy_deg': parameter_bounds.tolist(),
+            'boundary_axes': boundary_axes,
+            'train': {'before': train_before, 'after': train_after},
+            'heldout': {'before': heldout_before, 'after': heldout_after},
+            'rejection_reason': rejection_reason,
+        }
+    elif args.optimize_extrinsic:
         parameters, before, after = optimize_correction(
             points, viewmats[selected], dataset['K'], images,
             rounds=args.optimization_rounds,
@@ -289,6 +594,8 @@ def main() -> int:
             edge_percentile=args.edge_percentile,
             max_distance=args.max_distance)
         delta = correction_matrix(parameters)
+        effective_viewmats = np.asarray(
+            [delta @ viewmat for viewmat in viewmats])
         optimization = {
             'parameters_xyz_m_rpy_deg': parameters[:3].tolist() +
             np.rad2deg(parameters[3:]).tolist(),
@@ -298,7 +605,7 @@ def main() -> int:
     per_view = []
     for index, image in zip(selected, images):
         score = score_view(
-            points, delta @ viewmats[index], dataset['K'], image,
+            points, effective_viewmats[index], dataset['K'], image,
             edge_percentile=args.edge_percentile,
             max_distance=args.max_distance)
         score['view_index'] = index
@@ -309,19 +616,27 @@ def main() -> int:
     weights = np.asarray([item['edge_points'] for item in valid], dtype=float)
     report = {'pointcloud': str(args.pointcloud.resolve()),
               'transforms': str(args.transforms.resolve()),
+              'points_scored': len(points),
               'views_scored': len(valid), 'edge_points': int(weights.sum())}
     for name in ('median_px', 'p90_px', 'inlier_2px',
                  'out_of_range_fraction'):
         report[f'weighted_{name}'] = float(np.average(
             [item[name] for item in valid], weights=weights))
-    if optimization is not None:
+    if args.optimize_spatiotemporal:
+        report['spatiotemporal_optimization'] = optimization
+        if args.corrected_transforms_out is not None:
+            corrected = write_recomposed_transforms(
+                args.transforms, args.corrected_transforms_out,
+                effective_viewmats)
+            report['corrected_transforms'] = str(corrected)
+    elif optimization is not None:
         report['extrinsic_optimization'] = optimization
         if args.corrected_transforms_out is not None:
             corrected = write_corrected_transforms(
                 args.transforms, args.corrected_transforms_out, delta)
             report['corrected_transforms'] = str(corrected)
     elif args.corrected_transforms_out is not None:
-        raise SystemExit('--corrected-transforms-out requires --optimize-extrinsic')
+        raise SystemExit('--corrected-transforms-out requires an optimization mode')
     report['per_view'] = per_view
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(json.dumps(report, indent=2) + '\n')

--- a/tools/colored_map/COLORING_HANDOFF.md
+++ b/tools/colored_map/COLORING_HANDOFF.md
@@ -1,5 +1,11 @@
 # 点群着色 品質改善 引き継ぎ (2026-07-18)
 
+> 2026-07-19 追記: residual time offset と6DoF外部較正を dense TUM 軌跡から
+> 連続時間で再合成する opt-in stage を追加した。train/held-out の双方で
+> LiDAR depth edge と画像edgeの距離が改善した場合だけ
+> `transforms_spatiotemporal.json` を採用する。設計とRTK Seq1 smoke結果は
+> `docs/research/colored-map-spatiotemporal-calibration-2026-07.md` を参照。
+
 BIM 枝の `BIM_HANDOFF.md` と同じ趣旨の引き継ぎ文書。README の
 camera-coloured flythrough の色が濁っていた問題を起点に、着色パイプライン・
 リアルタイムノード・評価系を一気に改善した一連の作業(lidar_slam_ros2

--- a/tools/colored_map/colored_map_pipeline.py
+++ b/tools/colored_map/colored_map_pipeline.py
@@ -142,7 +142,10 @@ def build_commands(args) -> list[tuple[str, list[str]]]:
     """Return the missing/forced pipeline stages as ``(name, argv)`` pairs."""
     out_dir = Path(args.out)
     posed_dir = out_dir / 'posed_images'
-    transforms = posed_dir / 'transforms.json'
+    extracted_transforms = posed_dir / 'transforms.json'
+    refined_transforms = posed_dir / 'transforms_spatiotemporal.json'
+    transforms = (refined_transforms if args.refine_spatiotemporal_calibration
+                  else extracted_transforms)
     colored_map = out_dir / 'colored_map.ply'
     extrinsic_path = (Path(args.extrinsic) if args.extrinsic is not None else
                       out_dir / 'generated_body_camera_extrinsic.json')
@@ -162,7 +165,7 @@ def build_commands(args) -> list[tuple[str, list[str]]]:
         ]))
 
     rebuild_images = (rebuild_trajectory or args.force_images or
-                      is_stale(transforms, [trajectory]))
+                      is_stale(extracted_transforms, [trajectory]))
     if rebuild_images:
         extract = [
             sys.executable, str(TOOL_DIR / 'extract_posed_images.py'),
@@ -182,46 +185,98 @@ def build_commands(args) -> list[tuple[str, list[str]]]:
             extract.extend(['--intrinsics-yaml', str(args.intrinsics_yaml)])
         commands.append(('posed images', extract))
 
-    if (rebuild_images or args.force_map or
-            is_stale(colored_map, [trajectory, transforms])):
-        build = [
+    def map_command(output: Path, color_transforms: Path | None = None) -> list[str]:
+        command = [
             sys.executable, str(TOOL_DIR / 'build_lidar_init.py'),
             '--bag', str(args.bag), '--traj', str(trajectory),
-            '--points-topic', args.points_topic, '--out', str(colored_map),
+            '--points-topic', args.points_topic, '--out', str(output),
             '--voxel', str(args.voxel), '--max-points', str(args.max_points),
             '--min-range', str(args.min_range), '--max-range', str(args.max_range),
             '--min-neighbors', str(args.min_neighbors),
             '--sparse-voxel', str(args.sparse_voxel),
             '--stride', str(args.scan_stride),
             '--start-time', str(args.start_time), '--end-time', str(args.end_time),
-            '--color-transforms', str(transforms), '--color-robust',
-            '--color-exposure-scale-limit', str(args.color_exposure_scale_limit),
-            '--color-max-samples', str(args.color_max_samples),
-            '--color-image-margin', str(args.color_image_margin),
-            '--color-vignette-gain-limit',
-            str(args.color_vignette_gain_limit),
-            '--color-min-samples', str(args.color_min_samples),
         ]
-        if not args.color_normalize_exposure:
-            build.append('--color-no-normalize-exposure')
-        if args.color_overlap_balance:
-            build.append('--color-overlap-balance')
-        if args.color_view_confidence:
-            build.extend([
-                '--color-view-confidence',
-                '--color-normal-voxel', str(args.color_normal_voxel),
-                '--color-min-view-cosine', str(args.color_min_view_cosine),
-                '--color-min-projected-scale', str(args.color_min_projected_scale),
-                '--color-view-score-power', str(args.color_view_score_power),
-            ])
         if args.lidar_calibration is not None:
-            build.extend([
+            command.extend([
                 '--lidar-calibration', str(args.lidar_calibration),
                 '--lidar-key', args.lidar_key,
             ])
         if args.no_deskew:
-            build.append('--no-deskew')
-        commands.append(('coloured map', build))
+            command.append('--no-deskew')
+        if color_transforms is not None:
+            command.extend([
+                '--color-transforms', str(color_transforms), '--color-robust',
+                '--color-exposure-scale-limit',
+                str(args.color_exposure_scale_limit),
+                '--color-max-samples', str(args.color_max_samples),
+                '--color-image-margin', str(args.color_image_margin),
+                '--color-vignette-gain-limit',
+                str(args.color_vignette_gain_limit),
+                '--color-min-samples', str(args.color_min_samples),
+            ])
+            if not args.color_normalize_exposure:
+                command.append('--color-no-normalize-exposure')
+            if args.color_overlap_balance:
+                command.append('--color-overlap-balance')
+            if args.color_view_confidence:
+                command.extend([
+                    '--color-view-confidence',
+                    '--color-normal-voxel', str(args.color_normal_voxel),
+                    '--color-min-view-cosine', str(args.color_min_view_cosine),
+                    '--color-min-projected-scale',
+                    str(args.color_min_projected_scale),
+                    '--color-view-score-power', str(args.color_view_score_power),
+                ])
+        return command
+
+    rebuild_calibration = False
+    if args.refine_spatiotemporal_calibration:
+        calibration_cloud = out_dir / 'spatiotemporal_calibration_geometry.ply'
+        calibration_report = out_dir / 'spatiotemporal_calibration.json'
+        rebuild_calibration_cloud = (
+            rebuild_trajectory or args.force_map or args.force_calibration or
+            is_stale(calibration_cloud, [trajectory]))
+        if rebuild_calibration_cloud:
+            commands.append(('calibration geometry', map_command(
+                calibration_cloud)))
+        rebuild_calibration = (
+            rebuild_images or rebuild_calibration_cloud or
+            args.force_calibration or
+            is_stale(refined_transforms, [trajectory, extracted_transforms,
+                                          calibration_cloud]) or
+            is_stale(calibration_report, [trajectory, extracted_transforms,
+                                          calibration_cloud]))
+        if rebuild_calibration:
+            commands.append(('spatiotemporal calibration', [
+                sys.executable,
+                str(REPO_ROOT / 'scripts' /
+                    'evaluate_lidar_camera_alignment.py'),
+                '--pointcloud', str(calibration_cloud),
+                '--transforms', str(extracted_transforms),
+                '--trajectory', str(trajectory),
+                '--out', str(calibration_report),
+                '--optimize-spatiotemporal',
+                '--corrected-transforms-out', str(refined_transforms),
+                '--view-stride', str(args.calibration_view_stride),
+                '--max-points', str(args.calibration_max_points),
+                '--optimization-rounds', str(args.calibration_rounds),
+                '--time-step', str(args.calibration_time_step),
+                '--translation-step', str(args.calibration_translation_step),
+                '--rotation-step-deg', str(args.calibration_rotation_step_deg),
+                '--max-time-offset', str(args.calibration_max_time_offset),
+                '--max-translation', str(args.calibration_max_translation),
+                '--max-rotation-deg', str(args.calibration_max_rotation_deg),
+                '--holdout-modulo', str(args.calibration_holdout_modulo),
+                '--minimum-edge-points',
+                str(args.calibration_minimum_edge_points),
+                '--minimum-heldout-improvement',
+                str(args.calibration_minimum_heldout_improvement),
+            ]))
+
+    if (rebuild_images or rebuild_calibration or args.force_map or
+            is_stale(colored_map, [trajectory, transforms])):
+        commands.append(('coloured map', map_command(colored_map, transforms)))
 
     if args.quality_profile is not None:
         alignment_report = out_dir / 'lidar_camera_alignment.json'
@@ -300,6 +355,23 @@ def run_pipeline(args) -> dict:
     out_dir = Path(args.out)
     if args.kalibr_camchain is not None and args.lidar_calibration is None:
         raise ValueError('--kalibr-camchain requires --lidar-calibration')
+    if args.force_calibration and not args.refine_spatiotemporal_calibration:
+        raise ValueError(
+            '--force-calibration requires --refine-spatiotemporal-calibration')
+    if args.refine_spatiotemporal_calibration and (
+            args.calibration_view_stride < 1 or
+            args.calibration_max_points < 1 or
+            args.calibration_rounds < 1 or
+            args.calibration_time_step <= 0.0 or
+            args.calibration_translation_step <= 0.0 or
+            args.calibration_rotation_step_deg <= 0.0 or
+            args.calibration_max_time_offset < 0.0 or
+            args.calibration_max_translation < 0.0 or
+            args.calibration_max_rotation_deg < 0.0 or
+            args.calibration_holdout_modulo < 2 or
+            args.calibration_minimum_edge_points < 1 or
+            not 0.0 <= args.calibration_minimum_heldout_improvement < 1.0):
+        raise ValueError('invalid spatiotemporal calibration search settings')
     if not args.dry_run:
         out_dir.mkdir(parents=True, exist_ok=True)
         if args.kalibr_camchain is not None:
@@ -329,7 +401,9 @@ def run_pipeline(args) -> dict:
         validate_trajectory_density(trajectory, args.max_trajectory_gap)
     return {
         'stages': [name for name, _ in commands],
-        'transforms': out_dir / 'posed_images' / 'transforms.json',
+        'transforms': out_dir / 'posed_images' / (
+            'transforms_spatiotemporal.json'
+            if args.refine_spatiotemporal_calibration else 'transforms.json'),
         'colored_map': out_dir / 'colored_map.ply',
         'trajectory': trajectory,
     }
@@ -365,6 +439,22 @@ def build_parser() -> argparse.ArgumentParser:
                    help='camera-to-trajectory clock offset or auto')
     p.add_argument('--time-offset-adjustment', type=float, default=0.0,
                    help='seconds added after fixed or auto clock correction')
+    p.add_argument('--refine-spatiotemporal-calibration', action='store_true',
+                   help='optimize camera time offset and 6DoF extrinsic on '
+                        'LiDAR/image edges, accepting only held-out improvement')
+    p.add_argument('--calibration-view-stride', type=int, default=10)
+    p.add_argument('--calibration-max-points', type=int, default=300000)
+    p.add_argument('--calibration-rounds', type=int, default=3)
+    p.add_argument('--calibration-time-step', type=float, default=0.02)
+    p.add_argument('--calibration-translation-step', type=float, default=0.02)
+    p.add_argument('--calibration-rotation-step-deg', type=float, default=0.2)
+    p.add_argument('--calibration-max-time-offset', type=float, default=0.1)
+    p.add_argument('--calibration-max-translation', type=float, default=0.1)
+    p.add_argument('--calibration-max-rotation-deg', type=float, default=2.0)
+    p.add_argument('--calibration-holdout-modulo', type=int, default=5)
+    p.add_argument('--calibration-minimum-edge-points', type=int, default=50)
+    p.add_argument('--calibration-minimum-heldout-improvement', type=float,
+                   default=0.0)
     p.add_argument('--max-trajectory-gap', type=float, default=0.5,
                    help='reject sparse pose streams with a larger gap (s); '
                         'set <=0 to disable')
@@ -411,6 +501,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument('--force-images', action='store_true')
     p.add_argument('--force-map', action='store_true')
     p.add_argument('--force-trajectory', action='store_true')
+    p.add_argument('--force-calibration', action='store_true')
     p.add_argument('--quality-profile', type=Path,
                    help='run alignment, held-out colour, and integrated quality '
                         'checks using this profile')


### PR DESCRIPTION
## What changed

- add a deterministic seven-parameter calibration engine for residual camera time offset plus local 6DoF body-to-camera refinement
- recompose camera poses continuously from the dense TUM trajectory for every candidate
- split selected views into training and deterministic held-out validation sets
- reject static/unobservable motion, insufficient edge support, inconsistent source extrinsics, and candidates that do not improve held-out alignment
- add bounded-search and boundary-axis reporting, deterministic point subsampling, and cached image-edge masks
- integrate an opt-in calibration geometry -> calibration -> final robust RGB map flow into the coloured-map pipeline
- document the architecture, safeguards, and RTK-SLAM Construction Seq1 smoke result

## Why

Small camera/LiDAR timing and extrinsic errors produce visible RGB halos around structural boundaries. Existing automatic time handling only aligned clock domains, and the previous optimizer refined a static camera correction without continuous-time trajectory recomposition or independent validation.

## Impact

The existing pipeline remains unchanged unless `--refine-spatiotemporal-calibration` is supplied. Opt-in runs produce `spatiotemporal_calibration.json` and `transforms_spatiotemporal.json`; rejected candidates preserve the original poses.

On the RTK-SLAM Seq1 K3 smoke run, held-out mean edge distance improved from 6.887 px to 6.375 px (about 7.4%), median from 6.325 px to 5.385 px, and out-of-range fraction from 0.285 to 0.251. Two axes reached the intentionally tight smoke-test bounds, so the document treats this as end-to-end evidence rather than a production calibration claim.

## Validation

- `python3 -m pytest -q graph_based_slam/test`
  - 1217 passed, 13 skipped
- focused coloured-map and documentation suites
  - 173 passed
- fatal flake8 checks and `git diff --check`
