### PR TITLE
Fix spatiotemporal calibration test lint

### DIFF
--- a/graph_based_slam/test/test_lidar_camera_alignment.py
+++ b/graph_based_slam/test/test_lidar_camera_alignment.py
@@ -183,12 +183,13 @@ def test_spatiotemporal_optimizer_is_deterministic_and_bounded(monkeypatch):
                       'median_px': loss, 'coverage': 1.0}
 
     monkeypatch.setattr(lca, 'spatiotemporal_objective', objective)
-    call = lambda: lca.optimize_spatiotemporal(
-        np.zeros((0, 3)), _moving_samples(), np.array([1.0]), np.eye(4),
-        np.eye(3), [], rounds=3, time_step=0.04,
-        translation_step=0.04, rotation_step_deg=0.4,
-        max_time_offset=0.05, max_translation=0.05,
-        max_rotation_deg=0.3)
+    def call():
+        return lca.optimize_spatiotemporal(
+            np.zeros((0, 3)), _moving_samples(), np.array([1.0]), np.eye(4),
+            np.eye(3), [], rounds=3, time_step=0.04,
+            translation_step=0.04, rotation_step_deg=0.4,
+            max_time_offset=0.05, max_translation=0.05,
+            max_rotation_deg=0.3)
     first, before, after = call()
     second, _, _ = call()
     np.testing.assert_array_equal(first, second)

--- a/graph_based_slam/test/test_lidar_camera_alignment.py
+++ b/graph_based_slam/test/test_lidar_camera_alignment.py
@@ -183,6 +183,7 @@ def test_spatiotemporal_optimizer_is_deterministic_and_bounded(monkeypatch):
                       'median_px': loss, 'coverage': 1.0}
 
     monkeypatch.setattr(lca, 'spatiotemporal_objective', objective)
+
     def call():
         return lca.optimize_spatiotemporal(
             np.zeros((0, 3)), _moving_samples(), np.array([1.0]), np.eye(4),


### PR DESCRIPTION
## What changed

- replace the assigned lambda in the spatiotemporal optimizer regression with a local function

## Why

PR #377 passed its functional pytest suite but failed both Humble and Jazzy default workflows on `ament_flake8` rule E731. The two reported failures were the package-level and xUnit representations of this same lint violation.

## Impact

Test behavior is unchanged. This restores the merged `develop` branch to a CI-clean state.

## Validation

- `python3 -m flake8 --select E731 graph_based_slam/test/test_lidar_camera_alignment.py`
- `python3 -m pytest -q graph_based_slam/test`
  - 1217 passed, 13 skipped
- `git diff --check`
