### PR TITLE
Gate geometry fusion with paired real-data validation

### DIFF
--- a/docs/research/colored-map-geometry-aware-fusion-2026-07.md
+++ b/docs/research/colored-map-geometry-aware-fusion-2026-07.md
@@ -107,3 +107,19 @@ unnecessarily strict. It recovered screening coverage above the corrected-pose
 baseline while retaining most of S4's held-out improvement. S6 traded less
 coverage for less improvement and was rejected. S5 was promoted to the final
 full-density trial.
+
+Full-density S5 (candidate N) recovered coverage to 0.7712 and further improved
+held-out median/inlier 20 to 39.94/0.3007. Global roughness was 5.75/24.61 and
+chroma retention was 0.9964, but planar roughness was 8.67/28.02 and therefore
+failed the existing 7.6/25.0 profile. N cannot be promoted against K3 alone
+because it also includes the newly accepted camera calibration. A full-density
+corrected-pose baseline without geometry guards is required to separate the
+calibration effect from the guard effect.
+
+That baseline (candidate O) measured coverage 0.7408, held-out median/inlier 20
+40.23/0.2928, global roughness 5.20/20.33, and planar roughness 7.72/22.65.
+Compared directly with O, N improved coverage and held-out colour fidelity but
+worsened planar roughness to 8.67/28.02. The boundary guard was therefore not
+promoted and the existing quality threshold was not relaxed. CLI boundary
+margins default to zero; dynamic masks, uncertainty propagation, and explicitly
+validated dataset-specific margins remain available independently.

--- a/docs/research/colored-map-geometry-aware-fusion-2026-07.md
+++ b/docs/research/colored-map-geometry-aware-fusion-2026-07.md
@@ -59,8 +59,9 @@ non-exclusion dataset preparation.
 - Uncertainty propagation requires finite, strictly increasing frame timestamps
   and an accepted calibration with seven finite non-negative uncertainty values.
 - Rejected calibration metadata is never silently used.
-- Per-run diagnostics count projected samples, occlusion rejects, depth-edge
-  rejects, dynamic-mask rejects, and accepted samples.
+- Per-run diagnostics count projected samples, same-pixel z-buffer rejects,
+  additional silhouette-margin rejects, their aggregate occlusion rejects,
+  depth-edge rejects, dynamic-mask rejects, and accepted samples.
 - Existing colour options and output selection are unchanged unless explicitly
   enabled.
 
@@ -72,3 +73,37 @@ camera motion, uncertainty expansion, manifest hashes and completeness, loader
 metadata retention, end-to-end mask consumption, pipeline ordering, cache
 invalidation, and legacy opt-in behavior. Production threshold selection and
 real-data A/B promotion are intentionally the next dataset-level stage.
+
+## Construction Seq1 guard screening
+
+The first full-density candidate used 2 px silhouette and depth-edge margins
+with 0.15 m + 2% discontinuity tolerance. It was rejected: coverage fell from
+the K3 reference 0.7476 to 0.3519, held-out RGB L2 median rose from 41.17 to
+51.87, and planar roughness median rose from 7.23 to 10.79.
+
+Subsequent candidates used the same deterministic every-tenth-point subset of
+the 4,840,318-point K3 map and the accepted corrected camera poses. This is a
+paired parameter screen, not a substitute for full-density promotion.
+
+| candidate | guard | coverage | held-out median | inlier 20 |
+| --- | --- | ---: | ---: | ---: |
+| S0 | corrected-pose baseline | 0.77784 | 43.372 | 0.26297 |
+| S1 | silhouette 1 px | 0.75823 | 43.181 | 0.26489 |
+| S2 | edge 1 px, 0.5 m + 5% | 0.75653 | 42.922 | 0.26758 |
+| S3 | S1 + S2 | 0.74858 | 42.846 | 0.26862 |
+| S4 | edge 1 px, 1.0 m + 10% | 0.76650 | 42.958 | 0.26659 |
+| S5 | S4, minimum 2 samples | 0.82875 | 42.924 | 0.26717 |
+| S6 | edge 1 px, 2.0 m + 20% | 0.77313 | 43.013 | 0.26563 |
+
+S3 had the best held-out score but missed the 0.75 screening coverage floor.
+S4 retained about one additional coverage point over S2 for nearly the same
+held-out improvement and was promoted to a full-density trial. Full-density S4
+improved held-out median from the K3 reference 41.17 to 40.04 and inlier 20 from
+0.2863 to 0.2995, but coverage fell to 0.7060 and planar roughness worsened from
+7.23/23.89 to 8.27/25.01. It was rejected.
+
+S5 tests whether the geometry guard makes the previous three-observation floor
+unnecessarily strict. It recovered screening coverage above the corrected-pose
+baseline while retaining most of S4's held-out improvement. S6 traded less
+coverage for less improvement and was rejected. S5 was promoted to the final
+full-density trial.

--- a/docs/research/colored-map-geometry-aware-fusion-2026-07.md
+++ b/docs/research/colored-map-geometry-aware-fusion-2026-07.md
@@ -1,0 +1,74 @@
+# Geometry-aware camera-colour fusion (2026-07)
+
+## Problem
+
+Robust RGB medoids, exposure balancing, and view confidence improve the colour
+chosen from valid camera observations. They cannot repair a candidate set that
+already contains the wrong surface: a background LiDAR point projected beside
+a foreground silhouette, either side of a depth discontinuity, or a moving
+object observed in only part of the sequence. Calibration uncertainty also
+makes a fixed pixel guard inconsistent across range and vehicle motion.
+
+## Architecture
+
+The robust projector now constructs a full-resolution per-view z-buffer and
+applies four opt-in guards before colour sampling:
+
+1. **Occlusion silhouette:** compare projected depth with the minimum finite
+   depth in a circular pixel neighbourhood.
+2. **Depth edge:** reject both sides when local finite depth range exceeds an
+   absolute plus range-relative threshold.
+3. **Dynamic image mask:** reject a pixel when any excluded mask pixel lies in
+   its circular neighbourhood.
+4. **Calibration uncertainty:** convert accepted 7DoF uncertainty into a
+   per-observation pixel radius and add it to enabled geometry guards. The
+   translation term scales by focal length over range. Rotation is range
+   independent. Residual time uncertainty is multiplied by the camera's local
+   linear and angular speeds before projection.
+
+The final radius is configurable and clipped. Larger uncertainty also lowers
+the observation quality used by bounded sample selection. The previous robust
+fusion path is byte-compatible at default values because all new margins and
+the uncertainty multiplier are zero at the library boundary.
+
+## Dynamic-mask contract
+
+Segmentation inference is deliberately outside the mapping core. The adapter
+accepts PNG files named after each posed image stem, validates their dimensions,
+and writes `dynamic_mask_path` into each frame. Non-zero means excluded. It also
+records `dynamic-image-mask-v1` provenance with frame coverage, masked-pixel
+fraction, and SHA-256 for every attached file.
+
+The production pipeline stages data as:
+
+```text
+posed images -> validated dynamic-mask manifest -> optional 7DoF calibration
+             -> geometry-aware robust RGB map -> quality reports
+```
+
+Calibration consumes the mask-attached transforms document and preserves the
+frame metadata in its corrected output. Cache invalidation includes the source
+transforms, mask directory, and individual PNG modification times. Dynamic
+exclusion requires a complete mask set; partial manifests are allowed only for
+non-exclusion dataset preparation.
+
+## Safety and diagnostics
+
+- Geometry-aware fusion requires a one-pixel z-buffer; coarse bins are rejected.
+- Negative radii, thresholds, and uncertainty multipliers are rejected.
+- Uncertainty propagation requires finite, strictly increasing frame timestamps
+  and an accepted calibration with seven finite non-negative uncertainty values.
+- Rejected calibration metadata is never silently used.
+- Per-run diagnostics count projected samples, occlusion rejects, depth-edge
+  rejects, dynamic-mask rejects, and accepted samples.
+- Existing colour options and output selection are unchanged unless explicitly
+  enabled.
+
+## Validation status
+
+Unit and integration coverage includes variable-radius depth neighbourhoods,
+silhouette rejection, two-sided edge rejection, mask dilation, timestamped
+camera motion, uncertainty expansion, manifest hashes and completeness, loader
+metadata retention, end-to-end mask consumption, pipeline ordering, cache
+invalidation, and legacy opt-in behavior. Production threshold selection and
+real-data A/B promotion are intentionally the next dataset-level stage.

--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -795,6 +795,16 @@ if(BUILD_TESTING)
     TIMEOUT 120
   )
   ament_add_pytest_test(
+    test_geometry_aware_fusion
+    test/test_geometry_aware_fusion.py
+    TIMEOUT 120
+  )
+  ament_add_pytest_test(
+    test_attach_dynamic_image_masks
+    test/test_attach_dynamic_image_masks.py
+    TIMEOUT 120
+  )
+  ament_add_pytest_test(
     test_heldout_point_colors
     test/test_heldout_point_colors.py
     TIMEOUT 120

--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -805,6 +805,11 @@ if(BUILD_TESTING)
     TIMEOUT 120
   )
   ament_add_pytest_test(
+    test_recolor_pointcloud
+    test/test_recolor_pointcloud.py
+    TIMEOUT 120
+  )
+  ament_add_pytest_test(
     test_heldout_point_colors
     test/test_heldout_point_colors.py
     TIMEOUT 120

--- a/graph_based_slam/package.xml
+++ b/graph_based_slam/package.xml
@@ -25,6 +25,8 @@
   <depend>libg2o</depend>
   <depend>libpcl-all-dev</depend>
 
+  <exec_depend>python3-imageio</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>

--- a/graph_based_slam/test/test_attach_dynamic_image_masks.py
+++ b/graph_based_slam/test/test_attach_dynamic_image_masks.py
@@ -35,7 +35,7 @@ import json
 from pathlib import Path
 import sys
 
-import imageio.v3 as iio
+import imageio as iio
 import numpy as np
 
 REPO_ROOT = Path(__file__).resolve().parents[2]

--- a/graph_based_slam/test/test_attach_dynamic_image_masks.py
+++ b/graph_based_slam/test/test_attach_dynamic_image_masks.py
@@ -1,0 +1,107 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for dynamic-image-mask manifest attachment."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+import imageio.v3 as iio
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL_DIR = REPO_ROOT / 'tools' / 'colored_map'
+if str(TOOL_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOL_DIR))
+
+import attach_dynamic_image_masks as adm  # noqa: E402, I100
+
+
+def _dataset(root: Path, frames: int = 2) -> Path:
+    images = root / 'images'
+    images.mkdir(parents=True)
+    entries = []
+    for index in range(frames):
+        iio.imwrite(images / f'{index}.png', np.zeros((6, 8, 3), np.uint8))
+        entries.append({
+            'file_path': f'images/{index}.png',
+            'transform_matrix': np.eye(4).tolist(),
+        })
+    source = root / 'transforms.json'
+    source.write_text(json.dumps({
+        'w': 8, 'h': 6, 'fl_x': 5, 'fl_y': 5, 'cx': 4, 'cy': 3,
+        'frames': entries,
+    }))
+    return source
+
+
+def test_attach_masks_records_paths_hashes_and_coverage(tmp_path):
+    source = _dataset(tmp_path / 'source')
+    masks = tmp_path / 'masks'
+    masks.mkdir()
+    first = np.zeros((6, 8), np.uint8)
+    first[1:3, 2:4] = 255
+    iio.imwrite(masks / '0.png', first)
+    iio.imwrite(masks / '1.png', np.zeros((6, 8), np.uint8))
+    output = tmp_path / 'result' / 'transforms_masks.json'
+    report = adm.attach_masks(source, masks, output)
+    assert report['complete'] and report['frames_with_masks'] == 2
+    assert report['masked_pixel_fraction'] == 4 / (2 * 6 * 8)
+    assert len(report['sha256_by_frame_index']['0']) == 64
+    document = json.loads(output.read_text())
+    for frame in document['frames']:
+        assert (output.parent / frame['file_path']).resolve().is_file()
+        assert (output.parent / frame['dynamic_mask_path']).resolve().is_file()
+
+
+def test_attach_masks_rejects_missing_and_wrong_shape(tmp_path):
+    source = _dataset(tmp_path / 'source', frames=1)
+    masks = tmp_path / 'masks'
+    masks.mkdir()
+    with np.testing.assert_raises(FileNotFoundError):
+        adm.attach_masks(source, masks, tmp_path / 'missing.json')
+    iio.imwrite(masks / '0.png', np.zeros((5, 8), np.uint8))
+    with np.testing.assert_raises(ValueError):
+        adm.attach_masks(source, masks, tmp_path / 'wrong.json')
+
+
+def test_attach_masks_can_mark_partial_dataset(tmp_path):
+    source = _dataset(tmp_path / 'source')
+    masks = tmp_path / 'masks'
+    masks.mkdir()
+    iio.imwrite(masks / '0.png', np.zeros((6, 8), np.uint8))
+    output = tmp_path / 'partial.json'
+    report = adm.attach_masks(source, masks, output, allow_missing=True)
+    assert not report['complete'] and report['frames_with_masks'] == 1
+    frames = json.loads(output.read_text())['frames']
+    assert 'dynamic_mask_path' in frames[0]
+    assert 'dynamic_mask_path' not in frames[1]

--- a/graph_based_slam/test/test_colored_map_pipeline.py
+++ b/graph_based_slam/test/test_colored_map_pipeline.py
@@ -120,6 +120,59 @@ def test_spatiotemporal_refinement_inserts_geometry_and_heldout_calibration(tmp_
     assert coloured[coloured.index('--color-transforms') + 1] == refined
 
 
+def test_geometry_aware_fusion_forwards_all_production_guards(tmp_path):
+    commands = cmp.build_commands(_args(
+        tmp_path, '--refine-spatiotemporal-calibration',
+        '--color-geometry-aware', '--color-occlusion-margin-px', '3',
+        '--color-depth-edge-margin-px', '4',
+        '--dynamic-mask-dir', str(tmp_path / 'masks'),
+        '--color-dynamic-exclusion', '--color-dynamic-mask-margin-px', '5',
+        '--color-calibration-sigma-multiplier', '1.5',
+        '--color-max-uncertainty-margin-px', '9'))
+    coloured = dict(commands)['coloured map']
+    assert '--color-geometry-aware' in coloured
+    assert coloured[coloured.index('--color-occlusion-margin-px') + 1] == '3'
+    assert coloured[coloured.index('--color-depth-edge-margin-px') + 1] == '4'
+    assert '--color-dynamic-exclusion' in coloured
+    assert coloured[coloured.index('--color-dynamic-mask-margin-px') + 1] == '5'
+    assert coloured[
+        coloured.index('--color-calibration-sigma-multiplier') + 1] == '1.5'
+    assert coloured[
+        coloured.index('--color-max-uncertainty-margin-px') + 1] == '9'
+    attach = dict(commands)['dynamic image masks']
+    masked = str(tmp_path / 'out' / 'posed_images' /
+                 'transforms_dynamic_masks.json')
+    calibration = dict(commands)['spatiotemporal calibration']
+    assert attach[attach.index('--mask-dir') + 1] == str(tmp_path / 'masks')
+    assert attach[attach.index('--out') + 1] == masked
+    assert calibration[calibration.index('--transforms') + 1] == masked
+
+
+def test_dynamic_masks_are_cached_and_new_masks_rebuild_dependents(tmp_path):
+    out = tmp_path / 'out'
+    masks = tmp_path / 'masks'
+    masks.mkdir()
+    _write_at(tmp_path / 'traj.tum', 'dense\n', 1)
+    _write_at(out / 'posed_images' / 'transforms.json', '{}', 2)
+    _write_at(masks / 'frame.png', 'mask', 2)
+    os.utime(masks, ns=(2, 2))
+    _write_at(out / 'posed_images' / 'transforms_dynamic_masks.json', '{}', 3)
+    _write_at(out / 'colored_map.ply', 'ply\n', 4)
+    args = _args(tmp_path, '--dynamic-mask-dir', str(masks))
+    assert cmp.build_commands(args) == []
+    os.utime(masks / 'frame.png', ns=(5, 5))
+    assert [name for name, _ in cmp.build_commands(args)] == [
+        'dynamic image masks', 'coloured map']
+
+
+def test_dynamic_exclusion_requires_mask_dataset(tmp_path):
+    import pytest
+    args = _args(tmp_path, '--color-geometry-aware',
+                 '--color-dynamic-exclusion', '--dry-run')
+    with pytest.raises(ValueError, match='dynamic-mask-dir'):
+        cmp.run_pipeline(args)
+
+
 def test_existing_spatiotemporal_outputs_are_reused(tmp_path):
     out = tmp_path / 'out'
     (out / 'posed_images').mkdir(parents=True)

--- a/graph_based_slam/test/test_colored_map_pipeline.py
+++ b/graph_based_slam/test/test_colored_map_pipeline.py
@@ -148,6 +148,13 @@ def test_geometry_aware_fusion_forwards_all_production_guards(tmp_path):
     assert calibration[calibration.index('--transforms') + 1] == masked
 
 
+def test_geometry_boundary_guards_are_default_off(tmp_path):
+    args = _args(tmp_path, '--color-geometry-aware')
+    coloured = dict(cmp.build_commands(args))['coloured map']
+    assert coloured[coloured.index('--color-occlusion-margin-px') + 1] == '0'
+    assert coloured[coloured.index('--color-depth-edge-margin-px') + 1] == '0'
+
+
 def test_dynamic_masks_are_cached_and_new_masks_rebuild_dependents(tmp_path):
     out = tmp_path / 'out'
     masks = tmp_path / 'masks'

--- a/graph_based_slam/test/test_colored_map_pipeline.py
+++ b/graph_based_slam/test/test_colored_map_pipeline.py
@@ -33,7 +33,7 @@ import os
 from pathlib import Path
 import sys
 
-import imageio.v3 as iio
+import imageio as iio
 import numpy as np
 
 REPO_ROOT = Path(__file__).resolve().parents[2]

--- a/graph_based_slam/test/test_gaussian_splatting_pointcloud.py
+++ b/graph_based_slam/test/test_gaussian_splatting_pointcloud.py
@@ -572,6 +572,8 @@ def test_geometry_occlusion_margin_rejects_adjacent_background():
     assert seen.tolist() == [True, False]
     np.testing.assert_array_equal(rgb[0], [200, 0, 0])
     assert diagnostics['rejected_occlusion'] == 1
+    assert diagnostics['rejected_zbuffer'] == 0
+    assert diagnostics['rejected_occlusion_margin'] == 1
 
 
 def test_geometry_depth_edge_rejects_both_sides_but_keeps_flat_surface():

--- a/graph_based_slam/test/test_gaussian_splatting_pointcloud.py
+++ b/graph_based_slam/test/test_gaussian_splatting_pointcloud.py
@@ -560,6 +560,121 @@ def test_colorize_robust_observation_mask_rejects_bad_view():
     np.testing.assert_array_equal(rgb[0], [50, 50, 50])
 
 
+def test_geometry_occlusion_margin_rejects_adjacent_background():
+    vms, K, width, height = _cam()
+    image = np.zeros((height, width, 3), dtype=np.uint8)
+    image[50, 50], image[50, 51] = [200, 0, 0], [0, 200, 0]
+    points = np.array([[0.0, 0.0, 5.0], [0.1, 0.0, 10.0]])
+    rgb, seen, diagnostics = pcio.colorize_by_projection_robust(
+        points, vms, K, [image], width, height,
+        normalize_exposure=False, interp='nearest',
+        occlusion_margin_px=1, return_diagnostics=True)
+    assert seen.tolist() == [True, False]
+    np.testing.assert_array_equal(rgb[0], [200, 0, 0])
+    assert diagnostics['rejected_occlusion'] == 1
+
+
+def test_geometry_depth_edge_rejects_both_sides_but_keeps_flat_surface():
+    vms, K, width, height = _cam()
+    image = np.full((height, width, 3), 100, dtype=np.uint8)
+    discontinuity = np.array([[0.0, 0.0, 5.0], [0.1, 0.0, 10.0]])
+    _, seen, diagnostics = pcio.colorize_by_projection_robust(
+        discontinuity, vms, K, [image], width, height,
+        normalize_exposure=False, depth_edge_margin_px=1,
+        depth_edge_tolerance=0.2, return_diagnostics=True)
+    assert seen.tolist() == [False, False]
+    assert diagnostics['rejected_depth_edge'] == 2
+
+    flat = np.array([[0.0, 0.0, 5.0], [0.05, 0.0, 5.0]])
+    _, flat_seen = pcio.colorize_by_projection_robust(
+        flat, vms, K, [image], width, height,
+        normalize_exposure=False, depth_edge_margin_px=1,
+        depth_edge_tolerance=0.2)
+    assert flat_seen.all()
+
+
+def test_geometry_dynamic_mask_and_margin_reject_image_regions():
+    vms, K, width, height = _cam()
+    image = np.full((height, width, 3), 100, dtype=np.uint8)
+    mask = np.zeros((height, width), dtype=bool)
+    mask[50, 50] = True
+    points = np.array([[0.0, 0.0, 5.0], [0.05, 0.0, 5.0]])
+    _, seen, diagnostics = pcio.colorize_by_projection_robust(
+        points, vms, K, [image], width, height,
+        normalize_exposure=False, exclusion_masks=[mask],
+        dynamic_mask_margin_px=1, return_diagnostics=True)
+    assert seen.tolist() == [False, False]
+    assert diagnostics['rejected_dynamic_mask'] == 2
+
+
+def test_calibration_uncertainty_expands_geometry_margin():
+    vms, K, width, height = _cam()
+    image = np.full((height, width, 3), 100, dtype=np.uint8)
+    points = np.array([[0.0, 0.0, 5.0], [0.1, 0.0, 10.0]])
+    calibration = {
+        'accepted': True,
+        'uncertainty_dt_s_xyz_m_rpy_rad':
+            [0.0, 0.01, 0.0, 0.0, 0.0, 0.0, 0.0],
+    }
+    _, seen = pcio.colorize_by_projection_robust(
+        points, vms, K, [image], width, height,
+        normalize_exposure=False, calibration=calibration,
+        view_timestamps=[0.0], calibration_sigma_multiplier=1.0,
+        maximum_uncertainty_margin_px=2, depth_edge_tolerance=100.0)
+    assert seen.tolist() == [True, False]
+
+
+def test_geometry_fusion_rejects_coarse_zbuffer_and_missing_timestamps():
+    vms, K, width, height = _cam()
+    image = np.zeros((height, width, 3), dtype=np.uint8)
+    point = np.array([[0.0, 0.0, 5.0]])
+    with np.testing.assert_raises(ValueError):
+        pcio.colorize_by_projection_robust(
+            point, vms, K, [image], width, height,
+            occlusion_margin_px=1, zbuf_bin=2)
+    with np.testing.assert_raises(ValueError):
+        pcio.colorize_by_projection_robust(
+            point, vms, K, [image], width, height,
+            calibration={'accepted': True,
+                         'uncertainty_dt_s_xyz_m_rpy_rad': [0.0] * 7},
+            calibration_sigma_multiplier=1.0)
+
+
+def test_builder_loads_manifest_dynamic_masks_for_geometry_fusion(tmp_path):
+    import imageio.v3 as iio
+    import json
+
+    images = tmp_path / 'images'
+    masks = tmp_path / 'masks'
+    images.mkdir()
+    masks.mkdir()
+    image = np.full((100, 100, 3), 120, dtype=np.uint8)
+    mask = np.zeros((100, 100), dtype=np.uint8)
+    mask[50, 50] = 255
+    iio.imwrite(images / '0.png', image)
+    iio.imwrite(masks / '0.png', mask)
+    document = {
+        'w': 100, 'h': 100, 'fl_x': 100.0, 'fl_y': 100.0,
+        'cx': 50.0, 'cy': 50.0,
+        'frames': [{
+            'file_path': 'images/0.png', 'dynamic_mask_path': 'masks/0.png',
+            'timestamp': 0.0,
+            'transform_matrix': np.diag([1.0, -1.0, -1.0, 1.0]).tolist(),
+        }],
+    }
+    transforms = tmp_path / 'transforms.json'
+    transforms.write_text(json.dumps(document))
+    rgb, seen, diagnostics = bli._colorize(
+        np.array([[0.0, 0.0, 5.0]]), str(transforms), robust=True,
+        normalize_exposure=False, geometry_aware=True,
+        occlusion_margin_px=0, depth_edge_margin_px=0,
+        dynamic_exclusion=True, dynamic_mask_margin_px=0,
+        return_diagnostics=True)
+    assert not seen[0]
+    np.testing.assert_array_equal(rgb[0], [128, 128, 128])
+    assert diagnostics['rejected_dynamic_mask'] == 1
+
+
 def test_colorize_robust_normalizes_mono_images_and_broadcasts_rgb():
     vms1, K, W, H = _cam()
     vms = np.concatenate([vms1, vms1], axis=0)

--- a/graph_based_slam/test/test_gaussian_splatting_pointcloud.py
+++ b/graph_based_slam/test/test_gaussian_splatting_pointcloud.py
@@ -641,7 +641,7 @@ def test_geometry_fusion_rejects_coarse_zbuffer_and_missing_timestamps():
 
 
 def test_builder_loads_manifest_dynamic_masks_for_geometry_fusion(tmp_path):
-    import imageio.v3 as iio
+    import imageio as iio
     import json
 
     images = tmp_path / 'images'

--- a/graph_based_slam/test/test_gaussian_splatting_train.py
+++ b/graph_based_slam/test/test_gaussian_splatting_train.py
@@ -348,6 +348,35 @@ def test_load_transforms_groups_default_zero(tmp_path):
     assert ds['groups'] == [0]
 
 
+def test_load_transforms_retains_fusion_metadata(tmp_path):
+    import json
+
+    (tmp_path / 'images').mkdir()
+    (tmp_path / 'masks').mkdir()
+    (tmp_path / 'images' / '0.png').write_bytes(b'stub')
+    (tmp_path / 'masks' / '0.png').write_bytes(b'mask')
+    calibration = {
+        'accepted': True,
+        'uncertainty_dt_s_xyz_m_rpy_rad': [0.01] * 7,
+    }
+    document = {
+        'w': 8, 'h': 6, 'fl_x': 5.0, 'fl_y': 5.0,
+        'cx': 4.0, 'cy': 3.0,
+        'spatiotemporal_calibration': calibration,
+        'frames': [{
+            'file_path': 'images/0.png',
+            'dynamic_mask_path': 'masks/0.png', 'timestamp': 1.25,
+            'transform_matrix': np.eye(4).tolist(),
+        }],
+    }
+    (tmp_path / 'transforms.json').write_text(json.dumps(document))
+    dataset = tg.load_transforms(tmp_path / 'transforms.json')
+    assert dataset['timestamps'].tolist() == [1.25]
+    assert dataset['dynamic_mask_paths'][0] == (
+        tmp_path / 'masks' / '0.png').resolve()
+    assert dataset['spatiotemporal_calibration'] == calibration
+
+
 def test_parser_pose_group_and_exposure_flags():
     args = tg.build_parser().parse_args(['--transforms', 't', '--out', 'o'])
     assert args.optimize_pose_groups is False

--- a/graph_based_slam/test/test_geometry_aware_fusion.py
+++ b/graph_based_slam/test/test_geometry_aware_fusion.py
@@ -104,6 +104,9 @@ def test_calibration_uncertainty_is_default_off_and_requires_acceptance():
         depth, 100.0, None).tolist() == [0]
     with np.testing.assert_raises(ValueError):
         gaf.calibration_pixel_radii(
+            depth, 100.0, None, sigma_multiplier=1.0)
+    with np.testing.assert_raises(ValueError):
+        gaf.calibration_pixel_radii(
             depth, 100.0,
             {'accepted': False,
              'uncertainty_dt_s_xyz_m_rpy_rad': [0.0] * 7},

--- a/graph_based_slam/test/test_geometry_aware_fusion.py
+++ b/graph_based_slam/test/test_geometry_aware_fusion.py
@@ -1,0 +1,110 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for geometry-aware RGB fusion guards."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL_DIR = REPO_ROOT / 'tools' / 'colored_map'
+if str(TOOL_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOL_DIR))
+
+import geometry_aware_fusion as gaf  # noqa: E402, I100
+
+
+def test_depth_neighborhood_reports_sparse_discontinuity():
+    depth = np.full((5, 5), np.inf)
+    depth[2, 2], depth[2, 3] = 2.0, 8.0
+    minimum, maximum, support = gaf.neighborhood_depth_statistics(
+        depth, np.array([2, 3]), np.array([2, 2]), np.array([1, 1]))
+    np.testing.assert_array_equal(minimum, [2.0, 2.0])
+    np.testing.assert_array_equal(maximum, [8.0, 8.0])
+    np.testing.assert_array_equal(support, [2, 2])
+
+
+def test_depth_neighborhood_honours_per_query_radius():
+    depth = np.full((5, 5), np.inf)
+    depth[2, 1], depth[2, 2] = 3.0, 7.0
+    minimum, maximum, support = gaf.neighborhood_depth_statistics(
+        depth, np.array([2, 2]), np.array([2, 2]), np.array([0, 1]))
+    np.testing.assert_array_equal(minimum, [7.0, 3.0])
+    np.testing.assert_array_equal(maximum, [7.0, 7.0])
+    np.testing.assert_array_equal(support, [1, 2])
+
+
+def test_mask_neighborhood_dilates_only_requested_queries():
+    mask = np.zeros((5, 5), dtype=bool)
+    mask[2, 2] = True
+    result = gaf.mask_neighborhood_any(
+        mask, np.array([2, 3, 4]), np.array([2, 2, 2]),
+        np.array([0, 1, 1]))
+    assert result.tolist() == [True, True, False]
+
+
+def test_camera_motion_rates_use_pose_and_timestamp_spacing():
+    poses = np.repeat(np.eye(4)[None], 3, axis=0)
+    poses[:, 0, 3] = [0.0, 1.0, 3.0]
+    linear, angular = gaf.camera_motion_rates(
+        np.linalg.inv(poses), [0.0, 1.0, 2.0])
+    np.testing.assert_allclose(linear, [1.0, 1.5, 2.0])
+    np.testing.assert_allclose(angular, 0.0)
+
+
+def test_calibration_uncertainty_expands_near_points_more():
+    calibration = {
+        'accepted': True,
+        'uncertainty_dt_s_xyz_m_rpy_rad':
+            [0.01, 0.01, 0.0, 0.0, 0.0, 0.0, 0.0],
+    }
+    radii = gaf.calibration_pixel_radii(
+        np.array([2.0, 10.0]), 100.0, calibration,
+        sigma_multiplier=1.0, maximum_radius=10)
+    assert radii.tolist() == [1, 1]
+    stronger = gaf.calibration_pixel_radii(
+        np.array([2.0, 10.0]), 100.0, calibration,
+        linear_speed=2.0, sigma_multiplier=2.0, maximum_radius=10)
+    assert stronger[0] > stronger[1]
+
+
+def test_calibration_uncertainty_is_default_off_and_requires_acceptance():
+    depth = np.array([5.0])
+    assert gaf.calibration_pixel_radii(
+        depth, 100.0, None).tolist() == [0]
+    with np.testing.assert_raises(ValueError):
+        gaf.calibration_pixel_radii(
+            depth, 100.0,
+            {'accepted': False,
+             'uncertainty_dt_s_xyz_m_rpy_rad': [0.0] * 7},
+            sigma_multiplier=1.0)

--- a/graph_based_slam/test/test_recolor_pointcloud.py
+++ b/graph_based_slam/test/test_recolor_pointcloud.py
@@ -62,3 +62,5 @@ def test_parser_exposes_default_off_screening_stride(tmp_path):
         '--out', str(tmp_path / 'out.ply'),
     ])
     assert args.point_stride == 1
+    assert args.occlusion_margin_px == 0
+    assert args.depth_edge_margin_px == 0

--- a/graph_based_slam/test/test_recolor_pointcloud.py
+++ b/graph_based_slam/test/test_recolor_pointcloud.py
@@ -1,0 +1,64 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for deterministic paired recolouring subsets."""
+
+from pathlib import Path
+import sys
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL_DIR = REPO_ROOT / 'tools' / 'colored_map'
+if str(TOOL_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOL_DIR))
+
+import recolor_pointcloud as recolor  # noqa: E402, I100
+
+
+def test_select_paired_subset_keeps_stable_input_indices():
+    points = np.arange(30).reshape(10, 3)
+    np.testing.assert_array_equal(
+        recolor.select_paired_subset(points, 3), points[[0, 3, 6, 9]])
+    np.testing.assert_array_equal(
+        recolor.select_paired_subset(points, 1), points)
+
+
+def test_select_paired_subset_rejects_invalid_stride():
+    with np.testing.assert_raises(ValueError):
+        recolor.select_paired_subset(np.zeros((2, 3)), 0)
+
+
+def test_parser_exposes_default_off_screening_stride(tmp_path):
+    args = recolor.build_parser().parse_args([
+        '--input', str(tmp_path / 'in.ply'),
+        '--transforms', str(tmp_path / 'transforms.json'),
+        '--out', str(tmp_path / 'out.ply'),
+    ])
+    assert args.point_stride == 1

--- a/tools/colored_map/COLORING_HANDOFF.md
+++ b/tools/colored_map/COLORING_HANDOFF.md
@@ -288,3 +288,26 @@ render voxel 0.03、soft edge 1px、surface aspect 2.5、normal voxel 0.12、cin
 0.21180→0.19265、temporal delta p90 0.01589→0.01113、flicker p90
 0.00800→0.00688。WebP/MP4/GIFをK3から再生成した。成果物・JSON・棄却したK/K2は
 `/media/sasaki/aiueo/benchmarks/rtkslam_seq1_colored_map_20260718/`に保存。
+
+## 15. 追記 (2026-07-19): geometry-aware RGB fusion
+
+K3までのrobust medoid/view confidenceは、同じ3D点に届いた色の選択には強いが、
+silhouette隣接pixelへ投影された背景点、深度境界そのもの、移動物体の色を静的地図へ
+焼き付ける問題は入力候補の段階で除けなかった。そこでprojection fusionへ次の4 guard
+を統合した（全てdefault-off）。
+
+1. 1 pixel z-buffer近傍の最小深度によるforeground silhouette margin
+2. 近傍深度rangeによる不連続両側の除外
+3. frameごとの外部dynamic maskと可変dilation
+4. accepted 7DoF calibration covarianceのrange/focal/motion依存pixel伝播
+
+`attach_dynamic_image_masks.py`はsegmentation modelには依存せず、posed imageと同じ
+stemのPNGを検証して`dynamic_mask_path`をframeへ付与する。rootにはmask schema、
+全frame完備性、mask pixel率、frame別SHA-256を保存する。pipelineの工程は
+`posed images -> dynamic image masks -> calibration -> coloured map`となり、較正済み
+transformsにもmask参照と来歴が保持される。動的除外時は部分maskを拒否する。
+
+実装時点の集中回帰は129 pass / 4 skip、graph_based_slam全Python回帰も実行した。
+実データ閾値の採用は次段階で行い、coverageだけでなくheld-out色誤差、appearance、
+各棄却理由、boundary cropを同時比較する。設計記録は
+`docs/research/colored-map-geometry-aware-fusion-2026-07.md`。

--- a/tools/colored_map/README.md
+++ b/tools/colored_map/README.md
@@ -53,8 +53,7 @@ camera速度をpixel半径へ伝播し、各guardを観測ごとに拡張する�
 ```bash
 python3 tools/colored_map/colored_map_pipeline.py BAG TRAJECTORY OUT \
   --extrinsic BODY_CAMERA.json --refine-spatiotemporal-calibration \
-  --color-geometry-aware --color-occlusion-margin-px 2 \
-  --color-depth-edge-margin-px 2 \
+  --color-geometry-aware \
   --dynamic-mask-dir dynamic_masks --color-dynamic-exclusion \
   --color-dynamic-mask-margin-px 2 \
   --color-calibration-sigma-multiplier 1.0
@@ -64,6 +63,9 @@ maskは各posed imageと同じstemのPNGで、非zero pixelを除外領域とす
 有効にする場合は全frameのmaskが必須。詳しい設計と安全条件は
 [`colored-map-geometry-aware-fusion-2026-07.md`](../../docs/research/colored-map-geometry-aware-fusion-2026-07.md)
 を参照。
+silhouette/depth-edge marginはConstruction Seq1の全量候補が既存planar quality
+gateを通らなかったため既定0。dataset固有のpaired A/Bと既存profileを通すまで
+明示的に有効化しないこと。
 
 README動画の再現設定は `render_map_flythrough.py --device cpu
 --soft-edge-px 1 --surface-splat --surface-aspect-limit 2.5

--- a/tools/colored_map/README.md
+++ b/tools/colored_map/README.md
@@ -13,6 +13,7 @@ numpy ラスタライザで CUDA / torch 不要)。歴史的経緯で
 |---|---|
 | `colored_map_pipeline.py` | bag + TUM 軌跡 → posed images → 着色マップ → 品質ゲートまでの一括実行 |
 | `extract_posed_images.py` | bag から姿勢付きカメラ画像 (`transforms.json`) を抽出 |
+| `attach_dynamic_image_masks.py` | 外部の動的物体PNG maskを検証し、hash/coverage付きmanifestへ接続 |
 | `build_lidar_init.py` | スキャン蓄積 + robust着色（overlap RGB balance / view confidence対応） |
 | `recolor_pointcloud.py` | 既存PLYのXYZを保持してcamera画像から再着色し、coverage JSONを出力 |
 | `render_map_flythrough.py` | 着色マップ動画（cinematic path / surface splat / 描画指標対応） |
@@ -39,6 +40,30 @@ K3構成ではさらに `--color-overlap-balance --color-view-confidence
 --color-normal-voxel 0.12 --color-view-score-power 1` を使う。前者は同じ3D点を
 見る画像間のRGB差から露出・white balanceを安定化し、後者はsurface normalの
 入射角と投影解像度で観測を順位付けする。いずれもdefault-off。
+
+物体境界の色滲みを抑えるgeometry-aware fusionもdefault-offで利用できる。
+`--color-geometry-aware`は1 pixel z-buffer近傍で、手前silhouetteの隣に投影された
+背景点と、深度不連続の両側をRGB候補から除外する。外部segmentationのPNGを
+`--dynamic-mask-dir`で接続し`--color-dynamic-exclusion`を指定すると動的領域も
+除外する。`--refine-spatiotemporal-calibration`と
+`--color-calibration-sigma-multiplier`を組み合わせると、較正の7DoF不確実性と
+camera速度をpixel半径へ伝播し、各guardを観測ごとに拡張する。棄却数は
+`fusion_diagnostics`としてmap/recolor reportへ残る。
+
+```bash
+python3 tools/colored_map/colored_map_pipeline.py BAG TRAJECTORY OUT \
+  --extrinsic BODY_CAMERA.json --refine-spatiotemporal-calibration \
+  --color-geometry-aware --color-occlusion-margin-px 2 \
+  --color-depth-edge-margin-px 2 \
+  --dynamic-mask-dir dynamic_masks --color-dynamic-exclusion \
+  --color-dynamic-mask-margin-px 2 \
+  --color-calibration-sigma-multiplier 1.0
+```
+
+maskは各posed imageと同じstemのPNGで、非zero pixelを除外領域とする。動的除外を
+有効にする場合は全frameのmaskが必須。詳しい設計と安全条件は
+[`colored-map-geometry-aware-fusion-2026-07.md`](../../docs/research/colored-map-geometry-aware-fusion-2026-07.md)
+を参照。
 
 README動画の再現設定は `render_map_flythrough.py --device cpu
 --soft-edge-px 1 --surface-splat --surface-aspect-limit 2.5

--- a/tools/colored_map/attach_dynamic_image_masks.py
+++ b/tools/colored_map/attach_dynamic_image_masks.py
@@ -42,7 +42,7 @@ import numpy as np
 def attach_masks(source: Path, mask_dir: Path, output: Path, *,
                  allow_missing: bool = False) -> dict:
     """Validate masks, rewrite relative paths, and return provenance summary."""
-    import imageio.v3 as iio
+    import imageio as iio
 
     source, mask_dir, output = (
         Path(source).resolve(), Path(mask_dir).resolve(), Path(output).resolve())

--- a/tools/colored_map/attach_dynamic_image_masks.py
+++ b/tools/colored_map/attach_dynamic_image_masks.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Attach externally generated dynamic-object masks to a transforms dataset."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Optional, Sequence
+
+import numpy as np
+
+
+def attach_masks(source: Path, mask_dir: Path, output: Path, *,
+                 allow_missing: bool = False) -> dict:
+    """Validate masks, rewrite relative paths, and return provenance summary."""
+    import imageio.v3 as iio
+
+    source, mask_dir, output = (
+        Path(source).resolve(), Path(mask_dir).resolve(), Path(output).resolve())
+    if source == output:
+        raise ValueError('dynamic-mask output must differ from source transforms')
+    document = json.loads(source.read_text())
+    height, width = int(document['h']), int(document['w'])
+    attached = 0
+    masked_pixels = 0
+    hashes = {}
+    for index, frame in enumerate(document['frames']):
+        image_path = (source.parent / frame['file_path']).resolve()
+        candidate = mask_dir / (Path(frame['file_path']).stem + '.png')
+        frame['file_path'] = os.path.relpath(image_path, output.parent)
+        if not candidate.is_file():
+            if allow_missing:
+                frame.pop('dynamic_mask_path', None)
+                continue
+            raise FileNotFoundError(
+                f'missing dynamic mask for frame {index}: {candidate}')
+        mask = np.asarray(iio.imread(candidate))
+        if mask.shape[:2] != (height, width):
+            raise ValueError(
+                f'dynamic mask {candidate} has shape {mask.shape[:2]}, '
+                f'expected {(height, width)}')
+        if mask.ndim == 3:
+            mask = np.any(mask != 0, axis=2)
+        elif mask.ndim == 2:
+            mask = mask != 0
+        else:
+            raise ValueError(f'dynamic mask must be HxW or HxWxC: {candidate}')
+        frame['dynamic_mask_path'] = os.path.relpath(candidate, output.parent)
+        attached += 1
+        masked_pixels += int(mask.sum())
+        hashes[str(index)] = hashlib.sha256(candidate.read_bytes()).hexdigest()
+    frames = len(document['frames'])
+    provenance = {
+        'schema': 'dynamic-image-mask-v1',
+        'frames_total': frames,
+        'frames_with_masks': attached,
+        'complete': attached == frames,
+        'masked_pixel_fraction': (
+            masked_pixels / (frames * height * width) if frames else 0.0),
+        'sha256_by_frame_index': hashes,
+    }
+    document['dynamic_mask_provenance'] = provenance
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(document, indent=2) + '\n')
+    return provenance
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Construct the command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--transforms', type=Path, required=True)
+    parser.add_argument('--mask-dir', type=Path, required=True,
+                        help='PNG masks named after each image stem')
+    parser.add_argument('--out', type=Path, required=True)
+    parser.add_argument('--allow-missing', action='store_true')
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """CLI entry point."""
+    args = build_parser().parse_args(argv)
+    print(json.dumps(attach_masks(
+        args.transforms, args.mask_dir, args.out,
+        allow_missing=args.allow_missing), indent=2))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/colored_map/build_lidar_init.py
+++ b/tools/colored_map/build_lidar_init.py
@@ -266,7 +266,7 @@ def _colorize(world: np.ndarray, transforms_path: str, *, robust: bool = False,
               maximum_uncertainty_margin_px: int = 8,
               return_diagnostics: bool = False):
     """Project ``world`` points into the posed images of a transforms.json."""
-    import imageio.v3 as iio
+    import imageio as iio
     import train_gsplat as tg
 
     ds = tg.load_transforms(transforms_path)

--- a/tools/colored_map/build_lidar_init.py
+++ b/tools/colored_map/build_lidar_init.py
@@ -256,10 +256,10 @@ def _colorize(world: np.ndarray, transforms_path: str, *, robust: bool = False,
               view_score_power: float = 0.0,
               min_samples: int = 1,
               geometry_aware: bool = False,
-              occlusion_margin_px: int = 2,
-              depth_edge_margin_px: int = 2,
-              depth_edge_tolerance: float = 0.15,
-              depth_edge_relative_tolerance: float = 0.02,
+              occlusion_margin_px: int = 0,
+              depth_edge_margin_px: int = 0,
+              depth_edge_tolerance: float = 1.0,
+              depth_edge_relative_tolerance: float = 0.10,
               dynamic_exclusion: bool = False,
               dynamic_mask_margin_px: int = 2,
               calibration_sigma_multiplier: float = 0.0,
@@ -397,11 +397,11 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument('--color-geometry-aware', action='store_true',
                    help='enable depth-edge, silhouette, dynamic-mask, and '
                         'calibration-uncertainty guards')
-    p.add_argument('--color-occlusion-margin-px', type=int, default=2)
-    p.add_argument('--color-depth-edge-margin-px', type=int, default=2)
-    p.add_argument('--color-depth-edge-tolerance', type=float, default=0.15)
+    p.add_argument('--color-occlusion-margin-px', type=int, default=0)
+    p.add_argument('--color-depth-edge-margin-px', type=int, default=0)
+    p.add_argument('--color-depth-edge-tolerance', type=float, default=1.0)
     p.add_argument('--color-depth-edge-relative-tolerance', type=float,
-                   default=0.02)
+                   default=0.10)
     p.add_argument('--color-dynamic-exclusion', action='store_true',
                    help='exclude per-frame dynamic_mask_path pixels')
     p.add_argument('--color-dynamic-mask-margin-px', type=int, default=2)

--- a/tools/colored_map/build_lidar_init.py
+++ b/tools/colored_map/build_lidar_init.py
@@ -201,8 +201,9 @@ def build(args: argparse.Namespace) -> dict:
         world = world[keep]
     rgb = None
     colored = 0
+    fusion_diagnostics = None
     if args.color_transforms:
-        rgb, seen = _colorize(
+        color_result = _colorize(
             world, args.color_transforms, robust=args.color_robust,
             normalize_exposure=args.color_normalize_exposure,
             exposure_scale_limit=args.color_exposure_scale_limit,
@@ -215,11 +216,30 @@ def build(args: argparse.Namespace) -> dict:
             min_view_cosine=args.color_min_view_cosine,
             min_projected_scale=args.color_min_projected_scale,
             view_score_power=args.color_view_score_power,
-            min_samples=args.color_min_samples)
+            min_samples=args.color_min_samples,
+            geometry_aware=args.color_geometry_aware,
+            occlusion_margin_px=args.color_occlusion_margin_px,
+            depth_edge_margin_px=args.color_depth_edge_margin_px,
+            depth_edge_tolerance=args.color_depth_edge_tolerance,
+            depth_edge_relative_tolerance=(
+                args.color_depth_edge_relative_tolerance),
+            dynamic_exclusion=args.color_dynamic_exclusion,
+            dynamic_mask_margin_px=args.color_dynamic_mask_margin_px,
+            calibration_sigma_multiplier=(
+                args.color_calibration_sigma_multiplier),
+            maximum_uncertainty_margin_px=(
+                args.color_max_uncertainty_margin_px),
+            return_diagnostics=args.color_geometry_aware)
+        if args.color_geometry_aware:
+            rgb, seen, fusion_diagnostics = color_result
+        else:
+            rgb, seen = color_result
         colored = int(seen.sum())
     out = pcio.write_ply(args.out, world, rgb)
-    return {'scans_used': used, 'scans_deskewed': deskewed, 'scans_skipped': skipped,
-            'points': int(world.shape[0]), 'colored': colored, 'out': str(out)}
+    return {'scans_used': used, 'scans_deskewed': deskewed,
+            'scans_skipped': skipped, 'points': int(world.shape[0]),
+            'colored': colored, 'fusion_diagnostics': fusion_diagnostics,
+            'out': str(out)}
 
 
 def _colorize(world: np.ndarray, transforms_path: str, *, robust: bool = False,
@@ -234,7 +254,17 @@ def _colorize(world: np.ndarray, transforms_path: str, *, robust: bool = False,
               min_view_cosine: float = 0.0,
               min_projected_scale: float = 0.0,
               view_score_power: float = 0.0,
-              min_samples: int = 1):
+              min_samples: int = 1,
+              geometry_aware: bool = False,
+              occlusion_margin_px: int = 2,
+              depth_edge_margin_px: int = 2,
+              depth_edge_tolerance: float = 0.15,
+              depth_edge_relative_tolerance: float = 0.02,
+              dynamic_exclusion: bool = False,
+              dynamic_mask_margin_px: int = 2,
+              calibration_sigma_multiplier: float = 0.0,
+              maximum_uncertainty_margin_px: int = 8,
+              return_diagnostics: bool = False):
     """Project ``world`` points into the posed images of a transforms.json."""
     import imageio.v3 as iio
     import train_gsplat as tg
@@ -246,7 +276,23 @@ def _colorize(world: np.ndarray, transforms_path: str, *, robust: bool = False,
             world, ds['viewmats'], ds['K'], images, ds['width'], ds['height'])
     normals = (pcio.estimate_voxel_normals(world, voxel=normal_voxel)
                if view_confidence else None)
-    rgb, seen, counts = pcio.colorize_by_projection_robust(
+    if dynamic_exclusion and not geometry_aware:
+        raise ValueError('dynamic exclusion requires geometry-aware fusion')
+    exclusion_masks = None
+    if geometry_aware and dynamic_exclusion:
+        mask_paths = ds['dynamic_mask_paths']
+        if any(path is None for path in mask_paths):
+            raise ValueError('dynamic exclusion requires dynamic_mask_path for '
+                             'every transforms frame')
+        exclusion_masks = [
+            np.asarray(iio.imread(path)) != 0 for path in mask_paths]
+        exclusion_masks = [
+            np.any(mask, axis=2) if mask.ndim == 3 else mask
+            for mask in exclusion_masks]
+    calibration = (ds['spatiotemporal_calibration']
+                   if geometry_aware and calibration_sigma_multiplier > 0.0
+                   else None)
+    result = pcio.colorize_by_projection_robust(
         world, ds['viewmats'], ds['K'], images, ds['width'], ds['height'],
         normalize_exposure=normalize_exposure,
         exposure_scale_limit=exposure_scale_limit,
@@ -257,7 +303,22 @@ def _colorize(world: np.ndarray, transforms_path: str, *, robust: bool = False,
         min_view_cosine=min_view_cosine,
         min_projected_scale=min_projected_scale,
         view_score_power=view_score_power,
-        return_counts=True)
+        occlusion_margin_px=occlusion_margin_px if geometry_aware else 0,
+        depth_edge_margin_px=depth_edge_margin_px if geometry_aware else 0,
+        depth_edge_tolerance=depth_edge_tolerance,
+        depth_edge_relative_tolerance=depth_edge_relative_tolerance,
+        exclusion_masks=exclusion_masks,
+        dynamic_mask_margin_px=dynamic_mask_margin_px,
+        calibration=calibration,
+        view_timestamps=(ds['timestamps'] if calibration is not None else None),
+        calibration_sigma_multiplier=(
+            calibration_sigma_multiplier if geometry_aware else 0.0),
+        maximum_uncertainty_margin_px=maximum_uncertainty_margin_px,
+        return_counts=True, return_diagnostics=return_diagnostics)
+    if return_diagnostics:
+        rgb, seen, counts, diagnostics = result
+    else:
+        rgb, seen, counts = result
     if min_samples > 1:
         # Colours confirmed by too few camera observations are unreliable
         # (occlusion-fringe or specular one-offs that pepper flat surfaces);
@@ -265,7 +326,7 @@ def _colorize(world: np.ndarray, transforms_path: str, *, robust: bool = False,
         low = seen & (counts < min_samples)
         rgb[low] = (128, 128, 128)
         seen = seen & ~low
-    return rgb, seen
+    return (rgb, seen, diagnostics) if return_diagnostics else (rgb, seen)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -333,6 +394,20 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument('--color-min-view-cosine', type=float, default=0.0)
     p.add_argument('--color-min-projected-scale', type=float, default=0.0)
     p.add_argument('--color-view-score-power', type=float, default=1.0)
+    p.add_argument('--color-geometry-aware', action='store_true',
+                   help='enable depth-edge, silhouette, dynamic-mask, and '
+                        'calibration-uncertainty guards')
+    p.add_argument('--color-occlusion-margin-px', type=int, default=2)
+    p.add_argument('--color-depth-edge-margin-px', type=int, default=2)
+    p.add_argument('--color-depth-edge-tolerance', type=float, default=0.15)
+    p.add_argument('--color-depth-edge-relative-tolerance', type=float,
+                   default=0.02)
+    p.add_argument('--color-dynamic-exclusion', action='store_true',
+                   help='exclude per-frame dynamic_mask_path pixels')
+    p.add_argument('--color-dynamic-mask-margin-px', type=int, default=2)
+    p.add_argument('--color-calibration-sigma-multiplier', type=float,
+                   default=0.0)
+    p.add_argument('--color-max-uncertainty-margin-px', type=int, default=8)
     p.add_argument('--min-neighbors', type=int, default=2,
                    help='drop points whose 3x3x3 voxel neighbourhood (see '
                         '--sparse-voxel) holds fewer points; default 2 requires '

--- a/tools/colored_map/colored_map_pipeline.py
+++ b/tools/colored_map/colored_map_pipeline.py
@@ -64,7 +64,7 @@ def is_stale(output: Path, inputs: Sequence[Path]) -> bool:
     if not output.is_file():
         return True
     output_mtime = output.stat().st_mtime_ns
-    return any(path.is_file() and path.stat().st_mtime_ns > output_mtime
+    return any(path.exists() and path.stat().st_mtime_ns > output_mtime
                for path in inputs)
 
 
@@ -143,9 +143,13 @@ def build_commands(args) -> list[tuple[str, list[str]]]:
     out_dir = Path(args.out)
     posed_dir = out_dir / 'posed_images'
     extracted_transforms = posed_dir / 'transforms.json'
+    masked_transforms = posed_dir / 'transforms_dynamic_masks.json'
     refined_transforms = posed_dir / 'transforms_spatiotemporal.json'
+    calibration_transforms = (
+        masked_transforms if args.dynamic_mask_dir is not None
+        else extracted_transforms)
     transforms = (refined_transforms if args.refine_spatiotemporal_calibration
-                  else extracted_transforms)
+                  else calibration_transforms)
     colored_map = out_dir / 'colored_map.ply'
     extrinsic_path = (Path(args.extrinsic) if args.extrinsic is not None else
                       out_dir / 'generated_body_camera_extrinsic.json')
@@ -184,6 +188,25 @@ def build_commands(args) -> list[tuple[str, list[str]]]:
         if args.intrinsics_yaml is not None:
             extract.extend(['--intrinsics-yaml', str(args.intrinsics_yaml)])
         commands.append(('posed images', extract))
+
+    rebuild_masks = False
+    if args.dynamic_mask_dir is not None:
+        mask_dir = Path(args.dynamic_mask_dir)
+        mask_inputs = [extracted_transforms, mask_dir]
+        if mask_dir.is_dir():
+            mask_inputs.extend(sorted(mask_dir.glob('*.png')))
+        rebuild_masks = (
+            rebuild_images or args.force_dynamic_masks or
+            is_stale(masked_transforms, mask_inputs))
+        if rebuild_masks:
+            attach = [
+                sys.executable, str(TOOL_DIR / 'attach_dynamic_image_masks.py'),
+                '--transforms', str(extracted_transforms),
+                '--mask-dir', str(mask_dir), '--out', str(masked_transforms),
+            ]
+            if args.allow_missing_dynamic_masks:
+                attach.append('--allow-missing')
+            commands.append(('dynamic image masks', attach))
 
     def map_command(output: Path, color_transforms: Path | None = None) -> list[str]:
         command = [
@@ -228,6 +251,26 @@ def build_commands(args) -> list[tuple[str, list[str]]]:
                     str(args.color_min_projected_scale),
                     '--color-view-score-power', str(args.color_view_score_power),
                 ])
+            if args.color_geometry_aware:
+                command.extend([
+                    '--color-geometry-aware',
+                    '--color-occlusion-margin-px',
+                    str(args.color_occlusion_margin_px),
+                    '--color-depth-edge-margin-px',
+                    str(args.color_depth_edge_margin_px),
+                    '--color-depth-edge-tolerance',
+                    str(args.color_depth_edge_tolerance),
+                    '--color-depth-edge-relative-tolerance',
+                    str(args.color_depth_edge_relative_tolerance),
+                    '--color-dynamic-mask-margin-px',
+                    str(args.color_dynamic_mask_margin_px),
+                    '--color-calibration-sigma-multiplier',
+                    str(args.color_calibration_sigma_multiplier),
+                    '--color-max-uncertainty-margin-px',
+                    str(args.color_max_uncertainty_margin_px),
+                ])
+                if args.color_dynamic_exclusion:
+                    command.append('--color-dynamic-exclusion')
         return command
 
     rebuild_calibration = False
@@ -241,11 +284,11 @@ def build_commands(args) -> list[tuple[str, list[str]]]:
             commands.append(('calibration geometry', map_command(
                 calibration_cloud)))
         rebuild_calibration = (
-            rebuild_images or rebuild_calibration_cloud or
+            rebuild_masks or rebuild_calibration_cloud or
             args.force_calibration or
-            is_stale(refined_transforms, [trajectory, extracted_transforms,
+            is_stale(refined_transforms, [trajectory, calibration_transforms,
                                           calibration_cloud]) or
-            is_stale(calibration_report, [trajectory, extracted_transforms,
+            is_stale(calibration_report, [trajectory, calibration_transforms,
                                           calibration_cloud]))
         if rebuild_calibration:
             commands.append(('spatiotemporal calibration', [
@@ -253,7 +296,7 @@ def build_commands(args) -> list[tuple[str, list[str]]]:
                 str(REPO_ROOT / 'scripts' /
                     'evaluate_lidar_camera_alignment.py'),
                 '--pointcloud', str(calibration_cloud),
-                '--transforms', str(extracted_transforms),
+                '--transforms', str(calibration_transforms),
                 '--trajectory', str(trajectory),
                 '--out', str(calibration_report),
                 '--optimize-spatiotemporal',
@@ -292,7 +335,8 @@ def build_commands(args) -> list[tuple[str, list[str]]]:
                 str(args.calibration_minimum_heldout_improvement),
             ]))
 
-    if (rebuild_images or rebuild_calibration or args.force_map or
+    if (rebuild_images or rebuild_masks or rebuild_calibration or
+            args.force_map or
             is_stale(colored_map, [trajectory, transforms])):
         commands.append(('coloured map', map_command(colored_map, transforms)))
 
@@ -381,6 +425,30 @@ def run_pipeline(args) -> dict:
     if args.force_calibration and not args.refine_spatiotemporal_calibration:
         raise ValueError(
             '--force-calibration requires --refine-spatiotemporal-calibration')
+    if args.color_dynamic_exclusion and not args.color_geometry_aware:
+        raise ValueError('--color-dynamic-exclusion requires '
+                         '--color-geometry-aware')
+    if args.color_dynamic_exclusion and args.dynamic_mask_dir is None:
+        raise ValueError('--color-dynamic-exclusion requires '
+                         '--dynamic-mask-dir')
+    if args.force_dynamic_masks and args.dynamic_mask_dir is None:
+        raise ValueError('--force-dynamic-masks requires --dynamic-mask-dir')
+    if (args.color_dynamic_exclusion and
+            args.allow_missing_dynamic_masks):
+        raise ValueError('dynamic exclusion requires complete masks; remove '
+                         '--allow-missing-dynamic-masks')
+    if (args.color_calibration_sigma_multiplier > 0.0 and
+            not args.refine_spatiotemporal_calibration):
+        raise ValueError('calibration uncertainty fusion requires '
+                         '--refine-spatiotemporal-calibration')
+    if (args.color_occlusion_margin_px < 0 or
+            args.color_depth_edge_margin_px < 0 or
+            args.color_depth_edge_tolerance < 0.0 or
+            args.color_depth_edge_relative_tolerance < 0.0 or
+            args.color_dynamic_mask_margin_px < 0 or
+            args.color_calibration_sigma_multiplier < 0.0 or
+            args.color_max_uncertainty_margin_px < 0):
+        raise ValueError('invalid geometry-aware colour fusion settings')
     if args.refine_spatiotemporal_calibration and (
             args.calibration_view_stride < 1 or
             args.calibration_max_points < 1 or
@@ -443,7 +511,9 @@ def run_pipeline(args) -> dict:
         'stages': [name for name, _ in commands],
         'transforms': out_dir / 'posed_images' / (
             'transforms_spatiotemporal.json'
-            if args.refine_spatiotemporal_calibration else 'transforms.json'),
+            if args.refine_spatiotemporal_calibration else
+            ('transforms_dynamic_masks.json'
+             if args.dynamic_mask_dir is not None else 'transforms.json')),
         'colored_map': out_dir / 'colored_map.ply',
         'trajectory': trajectory,
     }
@@ -548,6 +618,21 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument('--color-min-view-cosine', type=float, default=0.0)
     p.add_argument('--color-min-projected-scale', type=float, default=0.0)
     p.add_argument('--color-view-score-power', type=float, default=1.0)
+    p.add_argument('--color-geometry-aware', action='store_true')
+    p.add_argument('--color-occlusion-margin-px', type=int, default=2)
+    p.add_argument('--color-depth-edge-margin-px', type=int, default=2)
+    p.add_argument('--color-depth-edge-tolerance', type=float, default=0.15)
+    p.add_argument('--color-depth-edge-relative-tolerance', type=float,
+                   default=0.02)
+    p.add_argument('--color-dynamic-exclusion', action='store_true')
+    p.add_argument('--dynamic-mask-dir', type=Path,
+                   help='PNG dynamic-object masks named after image stems')
+    p.add_argument('--allow-missing-dynamic-masks', action='store_true',
+                   help='attach available masks while retaining unmasked frames')
+    p.add_argument('--color-dynamic-mask-margin-px', type=int, default=2)
+    p.add_argument('--color-calibration-sigma-multiplier', type=float,
+                   default=0.0)
+    p.add_argument('--color-max-uncertainty-margin-px', type=int, default=8)
     p.add_argument('--color-min-samples', type=int, default=1,
                    help='demote colours confirmed by fewer surviving camera '
                         'samples than this to unseen (1 keeps all)')
@@ -555,6 +640,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument('--force-map', action='store_true')
     p.add_argument('--force-trajectory', action='store_true')
     p.add_argument('--force-calibration', action='store_true')
+    p.add_argument('--force-dynamic-masks', action='store_true')
     p.add_argument('--quality-profile', type=Path,
                    help='run alignment, held-out colour, and integrated quality '
                         'checks using this profile')

--- a/tools/colored_map/colored_map_pipeline.py
+++ b/tools/colored_map/colored_map_pipeline.py
@@ -619,11 +619,11 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument('--color-min-projected-scale', type=float, default=0.0)
     p.add_argument('--color-view-score-power', type=float, default=1.0)
     p.add_argument('--color-geometry-aware', action='store_true')
-    p.add_argument('--color-occlusion-margin-px', type=int, default=2)
-    p.add_argument('--color-depth-edge-margin-px', type=int, default=2)
-    p.add_argument('--color-depth-edge-tolerance', type=float, default=0.15)
+    p.add_argument('--color-occlusion-margin-px', type=int, default=0)
+    p.add_argument('--color-depth-edge-margin-px', type=int, default=0)
+    p.add_argument('--color-depth-edge-tolerance', type=float, default=1.0)
     p.add_argument('--color-depth-edge-relative-tolerance', type=float,
-                   default=0.02)
+                   default=0.10)
     p.add_argument('--color-dynamic-exclusion', action='store_true')
     p.add_argument('--dynamic-mask-dir', type=Path,
                    help='PNG dynamic-object masks named after image stems')

--- a/tools/colored_map/colored_map_pipeline.py
+++ b/tools/colored_map/colored_map_pipeline.py
@@ -109,7 +109,7 @@ def validate_trajectory_density(path: Path, max_gap: float) -> None:
 def validate_colour_source(transforms: Path, allow_monochrome: bool = False
                            ) -> dict:
     """Reject mono posed images unless the caller explicitly allows them."""
-    import imageio.v3 as iio
+    import imageio as iio
 
     document = json.loads(Path(transforms).read_text())
     frames = document.get('frames', [])

--- a/tools/colored_map/colorize_planar_references.py
+++ b/tools/colored_map/colorize_planar_references.py
@@ -93,7 +93,7 @@ def main() -> int:
     args = build_parser().parse_args()
     if args.folds < 1 or not 0 <= args.fold < args.folds:
         raise SystemExit('--folds must be >= 1 and --fold must be valid')
-    import imageio.v3 as iio
+    import imageio as iio
 
     points, _ = pcio.read_ply_xyz(args.pointcloud)
     dataset = tg.load_transforms(args.transforms)

--- a/tools/colored_map/extract_posed_images.py
+++ b/tools/colored_map/extract_posed_images.py
@@ -353,7 +353,7 @@ def decode_compressed_image(fmt: str, data: bytes) -> np.ndarray:
     ``format`` (e.g. ``"bgr8; jpeg compressed bgr8"``); decoding such a payload
     yields swapped channels, so honour a leading ``bgr`` tag.
     """
-    import imageio.v3 as iio
+    import imageio as iio
 
     img = iio.imread(bytes(data))
     if img.ndim == 3 and img.shape[2] >= 3 and \
@@ -466,7 +466,7 @@ def resolve_time_offset(args: argparse.Namespace) -> float:
 
 def extract(args: argparse.Namespace) -> dict:
     """Run the full extraction and return a small summary dict."""
-    import imageio.v3 as iio
+    import imageio as iio
     from rclpy.serialization import deserialize_message
     from sensor_msgs.msg import CompressedImage, Image
 

--- a/tools/colored_map/geometry_aware_fusion.py
+++ b/tools/colored_map/geometry_aware_fusion.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Pure NumPy geometry guards for camera-to-LiDAR RGB fusion."""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+import numpy as np
+
+
+def neighborhood_depth_statistics(
+        depth: np.ndarray, u: np.ndarray, v: np.ndarray,
+        radii: int | np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return finite min/max depth and support in each circular pixel window."""
+    image = np.asarray(depth, dtype=np.float64)
+    columns = np.asarray(u, dtype=np.int64)
+    rows = np.asarray(v, dtype=np.int64)
+    if image.ndim != 2:
+        raise ValueError('depth must be HxW')
+    if columns.shape != rows.shape:
+        raise ValueError('u and v must have matching shapes')
+    radius = np.broadcast_to(
+        np.asarray(radii, dtype=np.int64), columns.shape)
+    if np.any(radius < 0):
+        raise ValueError('depth-neighborhood radii must be non-negative')
+    if (np.any(columns < 0) or np.any(columns >= image.shape[1]) or
+            np.any(rows < 0) or np.any(rows >= image.shape[0])):
+        raise ValueError('query pixels must lie inside the depth image')
+    minimum = np.full(columns.shape, np.inf, dtype=np.float64)
+    maximum = np.full(columns.shape, -np.inf, dtype=np.float64)
+    support = np.zeros(columns.shape, dtype=np.uint16)
+    largest = int(radius.max()) if radius.size else 0
+    for dy in range(-largest, largest + 1):
+        for dx in range(-largest, largest + 1):
+            active = radius * radius >= dx * dx + dy * dy
+            query_u, query_v = columns + dx, rows + dy
+            active &= ((query_u >= 0) & (query_u < image.shape[1]) &
+                       (query_v >= 0) & (query_v < image.shape[0]))
+            if not active.any():
+                continue
+            indices = np.flatnonzero(active)
+            values = image[query_v[indices], query_u[indices]]
+            finite = np.isfinite(values)
+            indices, values = indices[finite], values[finite]
+            minimum[indices] = np.minimum(minimum[indices], values)
+            maximum[indices] = np.maximum(maximum[indices], values)
+            support[indices] += 1
+    return minimum, maximum, support
+
+
+def mask_neighborhood_any(mask: np.ndarray, u: np.ndarray, v: np.ndarray,
+                          radii: int | np.ndarray) -> np.ndarray:
+    """Return whether any excluded mask pixel lies in each circular window."""
+    excluded = np.asarray(mask, dtype=bool)
+    if excluded.ndim != 2:
+        raise ValueError('exclusion mask must be HxW')
+    depth = np.where(excluded, 1.0, np.inf)
+    _, _, support = neighborhood_depth_statistics(depth, u, v, radii)
+    return support > 0
+
+
+def camera_motion_rates(viewmats: np.ndarray,
+                        timestamps: Sequence[float]) -> tuple[np.ndarray, np.ndarray]:
+    """Estimate per-view translational and angular camera speed."""
+    views = np.asarray(viewmats, dtype=np.float64)
+    stamps = np.asarray(timestamps, dtype=np.float64)
+    if views.ndim != 3 or views.shape[1:] != (4, 4):
+        raise ValueError('viewmats must be Nx4x4')
+    if stamps.shape != (len(views),) or not np.all(np.isfinite(stamps)):
+        raise ValueError('timestamps must contain one finite value per view')
+    if len(views) == 0:
+        return np.zeros(0), np.zeros(0)
+    if len(views) == 1:
+        return np.zeros(1), np.zeros(1)
+    camera_poses = np.linalg.inv(views)
+    centres = camera_poses[:, :3, 3]
+    segment_dt = np.diff(stamps)
+    if np.any(segment_dt <= 0.0):
+        raise ValueError('timestamps must be strictly increasing')
+    linear_segment = np.linalg.norm(np.diff(centres, axis=0), axis=1) / segment_dt
+    angular_segment = []
+    for first, second, duration in zip(
+            camera_poses, camera_poses[1:], segment_dt):
+        relative = first[:3, :3].T @ second[:3, :3]
+        cosine = np.clip((np.trace(relative) - 1.0) * 0.5, -1.0, 1.0)
+        angular_segment.append(np.arccos(cosine) / duration)
+    angular_segment = np.asarray(angular_segment)
+    linear = np.r_[linear_segment[0],
+                   0.5 * (linear_segment[:-1] + linear_segment[1:]),
+                   linear_segment[-1]]
+    angular = np.r_[angular_segment[0],
+                    0.5 * (angular_segment[:-1] + angular_segment[1:]),
+                    angular_segment[-1]]
+    return linear, angular
+
+
+def calibration_pixel_radii(
+        depth: np.ndarray, focal_px: float, calibration: Optional[dict], *,
+        linear_speed: float = 0.0, angular_speed: float = 0.0,
+        sigma_multiplier: float = 0.0,
+        maximum_radius: int = 12) -> np.ndarray:
+    """Propagate 7DoF calibration uncertainty to conservative pixel radii."""
+    ranges = np.asarray(depth, dtype=np.float64)
+    if np.any(ranges <= 0.0) or not np.all(np.isfinite(ranges)):
+        raise ValueError('depth must contain finite positive ranges')
+    if focal_px <= 0.0 or sigma_multiplier < 0.0 or maximum_radius < 0:
+        raise ValueError('focal, sigma multiplier, and maximum radius are invalid')
+    if calibration is None or sigma_multiplier == 0.0:
+        return np.zeros(ranges.shape, dtype=np.int16)
+    if not calibration.get('accepted', False):
+        raise ValueError('calibration uncertainty requires an accepted calibration')
+    uncertainty = np.asarray(
+        calibration.get('uncertainty_dt_s_xyz_m_rpy_rad'), dtype=np.float64)
+    if (uncertainty.shape != (7,) or not np.all(np.isfinite(uncertainty)) or
+            np.any(uncertainty < 0.0)):
+        raise ValueError('calibration uncertainty must contain seven finite '
+                         'non-negative values')
+    time_sigma = uncertainty[0]
+    translation_sigma = np.sqrt(
+        np.sum(uncertainty[1:4] ** 2) + (linear_speed * time_sigma) ** 2)
+    rotation_sigma = np.sqrt(
+        np.sum(uncertainty[4:7] ** 2) + (angular_speed * time_sigma) ** 2)
+    pixel_sigma = float(focal_px) * np.sqrt(
+        (translation_sigma / ranges) ** 2 + rotation_sigma ** 2)
+    return np.clip(
+        np.ceil(sigma_multiplier * pixel_sigma), 0, maximum_radius
+    ).astype(np.int16)

--- a/tools/colored_map/geometry_aware_fusion.py
+++ b/tools/colored_map/geometry_aware_fusion.py
@@ -131,8 +131,10 @@ def calibration_pixel_radii(
         raise ValueError('depth must contain finite positive ranges')
     if focal_px <= 0.0 or sigma_multiplier < 0.0 or maximum_radius < 0:
         raise ValueError('focal, sigma multiplier, and maximum radius are invalid')
-    if calibration is None or sigma_multiplier == 0.0:
+    if sigma_multiplier == 0.0:
         return np.zeros(ranges.shape, dtype=np.int16)
+    if calibration is None:
+        raise ValueError('calibration uncertainty metadata is required')
     if not calibration.get('accepted', False):
         raise ValueError('calibration uncertainty requires an accepted calibration')
     uncertainty = np.asarray(

--- a/tools/colored_map/pointcloud_io.py
+++ b/tools/colored_map/pointcloud_io.py
@@ -37,8 +37,9 @@ binary-little-endian or ascii. See
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Sequence
 
+import geometry_aware_fusion as gaf
 import numpy as np
 
 
@@ -616,7 +617,20 @@ def colorize_by_projection_robust(points: np.ndarray, viewmats: np.ndarray,
                                   min_view_cosine: float = 0.0,
                                   min_projected_scale: float = 0.0,
                                   view_score_power: float = 0.0,
-                                  return_counts: bool = False):
+                                  occlusion_margin_px: int = 0,
+                                  depth_edge_margin_px: int = 0,
+                                  depth_edge_tolerance: float = 0.15,
+                                  depth_edge_relative_tolerance: float = 0.02,
+                                  exclusion_masks: Optional[
+                                      Sequence[Optional[np.ndarray]]] = None,
+                                  dynamic_mask_margin_px: int = 0,
+                                  calibration: Optional[dict] = None,
+                                  view_timestamps: Optional[
+                                      Sequence[float]] = None,
+                                  calibration_sigma_multiplier: float = 0.0,
+                                  maximum_uncertainty_margin_px: int = 12,
+                                  return_counts: bool = False,
+                                  return_diagnostics: bool = False):
     """Occlusion-aware, exposure-normalised, median-robust point colorization.
 
     ``colorize_by_projection`` averages every view a point lands in, so points
@@ -655,6 +669,14 @@ def colorize_by_projection_robust(points: np.ndarray, viewmats: np.ndarray,
     Returns ``(rgb uint8 (N,3), seen bool (N,))``, or with ``return_counts`` the
     triple ``(rgb, seen, counts uint16 (N,))`` giving each point's surviving
     sample count (a colour-confidence signal). Unseen points get ``default_rgb``.
+
+    Geometry-aware fusion is opt-in. ``occlusion_margin_px`` tests nearby
+    z-buffer cells so a foreground silhouette suppresses background colour
+    samples in adjacent pixels. ``depth_edge_margin_px`` rejects both sides of
+    a measured depth discontinuity. Per-frame ``exclusion_masks`` remove
+    dynamic image regions. Accepted calibration uncertainty can expand all
+    three guards per observation after propagation through range, focal length,
+    and camera motion. ``return_diagnostics`` appends rejection counters.
     """
     points = np.asarray(points, dtype=np.float64)
     n = points.shape[0]
@@ -666,11 +688,23 @@ def colorize_by_projection_robust(points: np.ndarray, viewmats: np.ndarray,
         point_normals = np.asarray(point_normals, dtype=np.float64)
         if point_normals.shape != (n, 3):
             raise ValueError('point_normals must be Nx3')
+    if exclusion_masks is not None:
+        if len(exclusion_masks) != len(images):
+            raise ValueError('exclusion_masks must match the image count')
+        for mask in exclusion_masks:
+            if mask is not None and np.asarray(mask).shape != (height, width):
+                raise ValueError('each exclusion mask must be HxW')
     rgb = np.tile(np.asarray(default_rgb, dtype=np.uint8), (n, 1))
     counts = np.zeros(n, dtype=np.uint16)
+    diagnostics = {
+        'projected': 0, 'rejected_occlusion': 0,
+        'rejected_depth_edge': 0, 'rejected_dynamic_mask': 0,
+        'accepted_samples': 0,
+    }
     if n == 0 or max_samples <= 0:
         seen = np.zeros(n, dtype=bool)
-        return (rgb, seen, counts) if return_counts else (rgb, seen)
+        result = (rgb, seen, counts) if return_counts else (rgb, seen)
+        return result + (diagnostics,) if return_diagnostics else result
     if zbuf_bin < 1:
         raise ValueError('zbuf_bin must be >= 1')
     if exposure_scale_limit < 1.0:
@@ -684,6 +718,29 @@ def colorize_by_projection_robust(points: np.ndarray, viewmats: np.ndarray,
         raise ValueError('min_view_cosine must be in [0, 1]')
     if min_projected_scale < 0.0 or view_score_power < 0.0:
         raise ValueError('min_projected_scale and view_score_power must be >= 0')
+    geometry_values = (
+        occlusion_margin_px, depth_edge_margin_px, dynamic_mask_margin_px,
+        maximum_uncertainty_margin_px)
+    if any(value < 0 for value in geometry_values):
+        raise ValueError('geometry-aware pixel margins must be non-negative')
+    if (depth_edge_tolerance < 0.0 or
+            depth_edge_relative_tolerance < 0.0 or
+            calibration_sigma_multiplier < 0.0):
+        raise ValueError('geometry tolerances and calibration sigma must be '
+                         'non-negative')
+    geometry_enabled = bool(
+        occlusion_margin_px or depth_edge_margin_px or
+        exclusion_masks is not None or calibration_sigma_multiplier)
+    if geometry_enabled and zbuf_bin != 1:
+        raise ValueError('geometry-aware fusion requires a one-pixel z-buffer')
+    if calibration_sigma_multiplier > 0.0 and view_timestamps is None:
+        raise ValueError('calibration uncertainty requires view timestamps')
+
+    linear_speeds = np.zeros(len(images), dtype=np.float64)
+    angular_speeds = np.zeros(len(images), dtype=np.float64)
+    if calibration_sigma_multiplier > 0.0:
+        linear_speeds, angular_speeds = gaf.camera_motion_rates(
+            np.asarray(viewmats), view_timestamps)
 
     fx, fy, cx, cy = K[0, 0], K[1, 1], K[0, 2], K[1, 2]
     zb_w = (int(width) + zbuf_bin - 1) // zbuf_bin
@@ -732,10 +789,49 @@ def colorize_by_projection_robust(points: np.ndarray, viewmats: np.ndarray,
         inb = (z > 1e-6) & (u >= 0) & (u < width) & (v >= 0) & (v < height)
         if not inb.any():
             continue
+        diagnostics['projected'] += int(inb.sum())
         zbin = (v[inb] // zbuf_bin) * zb_w + (u[inb] // zbuf_bin)
         zbuf = np.full(zb_w * zb_h, np.inf, dtype=np.float32)
         np.minimum.at(zbuf, zbin, z[inb].astype(np.float32))
-        visible = z[inb] <= zbuf[zbin] + depth_tol + 0.02 * z[inb]
+        projected_z = z[inb].astype(np.float32)
+        uncertainty_margin = gaf.calibration_pixel_radii(
+            projected_z, max(float(fx), float(fy)), calibration,
+            linear_speed=linear_speeds[vi],
+            angular_speed=angular_speeds[vi],
+            sigma_multiplier=calibration_sigma_multiplier,
+            maximum_radius=maximum_uncertainty_margin_px)
+        zbuffer_image = zbuf.reshape(zb_h, zb_w)
+        occlusion_radii = uncertainty_margin + int(occlusion_margin_px)
+        if np.any(occlusion_radii > 0):
+            local_minimum, _, _ = gaf.neighborhood_depth_statistics(
+                zbuffer_image, u[inb], v[inb], occlusion_radii)
+        else:
+            local_minimum = zbuf[zbin]
+        visible = projected_z <= (
+            local_minimum + depth_tol + 0.02 * projected_z)
+        diagnostics['rejected_occlusion'] += int((~visible).sum())
+
+        edge_radii = uncertainty_margin + int(depth_edge_margin_px)
+        if np.any(edge_radii > 0):
+            local_minimum, local_maximum, support = \
+                gaf.neighborhood_depth_statistics(
+                    zbuffer_image, u[inb], v[inb], edge_radii)
+            discontinuity = (
+                (support >= 2) &
+                ((local_maximum - local_minimum) >
+                 depth_edge_tolerance +
+                 depth_edge_relative_tolerance * local_minimum))
+            diagnostics['rejected_depth_edge'] += int(
+                (visible & discontinuity).sum())
+            visible &= ~discontinuity
+
+        if exclusion_masks is not None and exclusion_masks[vi] is not None:
+            mask_radii = uncertainty_margin + int(dynamic_mask_margin_px)
+            dynamic = gaf.mask_neighborhood_any(
+                exclusion_masks[vi], u[inb], v[inb], mask_radii)
+            diagnostics['rejected_dynamic_mask'] += int(
+                (visible & dynamic).sum())
+            visible &= ~dynamic
         if image_margin > 0:
             # The z-buffer above still uses the full frame (occlusion geometry
             # is valid to the border); only colour sampling skips the margin.
@@ -751,6 +847,11 @@ def colorize_by_projection_robust(points: np.ndarray, viewmats: np.ndarray,
         else:
             cand_z = z[inb][visible].astype(np.float32)
         quality = (float(fx) / np.maximum(cand_z, 1.0e-6)).astype(np.float32)
+        if calibration_sigma_multiplier > 0.0 and cand.size:
+            kept_uncertainty = uncertainty_margin[visible]
+            if observation_mask is not None:
+                kept_uncertainty = kept_uncertainty[keep]
+            quality /= 1.0 + kept_uncertainty.astype(np.float32)
         if point_normals is not None and cand.size:
             camera_centre = -vm[:3, :3].T @ vm[:3, 3]
             sight = camera_centre[None, :] - points[cand]
@@ -777,6 +878,7 @@ def colorize_by_projection_robust(points: np.ndarray, viewmats: np.ndarray,
                                      quality[confidence])
         if cand.size == 0:
             continue
+        diagnostics['accepted_samples'] += int(cand.size)
         cols = _sample_pixels(
             img, uf[cand], vf[cand], width, height, interp, edge_threshold)
         if vignette_gains is not None:
@@ -819,7 +921,8 @@ def colorize_by_projection_robust(points: np.ndarray, viewmats: np.ndarray,
     for c in np.unique(counts[seen_idx]):
         group = seen_idx[counts[seen_idx] == c]
         rgb[group] = observed_color_medoids(samples[group, :int(c), :])
-    return (rgb, seen, counts) if return_counts else (rgb, seen)
+    result = (rgb, seen, counts) if return_counts else (rgb, seen)
+    return result + (diagnostics,) if return_diagnostics else result
 
 
 def project_depth_maps(points: np.ndarray, viewmats, K: np.ndarray,

--- a/tools/colored_map/pointcloud_io.py
+++ b/tools/colored_map/pointcloud_io.py
@@ -697,7 +697,8 @@ def colorize_by_projection_robust(points: np.ndarray, viewmats: np.ndarray,
     rgb = np.tile(np.asarray(default_rgb, dtype=np.uint8), (n, 1))
     counts = np.zeros(n, dtype=np.uint16)
     diagnostics = {
-        'projected': 0, 'rejected_occlusion': 0,
+        'projected': 0, 'rejected_zbuffer': 0,
+        'rejected_occlusion': 0, 'rejected_occlusion_margin': 0,
         'rejected_depth_edge': 0, 'rejected_dynamic_mask': 0,
         'accepted_samples': 0,
     }
@@ -807,8 +808,13 @@ def colorize_by_projection_robust(points: np.ndarray, viewmats: np.ndarray,
                 zbuffer_image, u[inb], v[inb], occlusion_radii)
         else:
             local_minimum = zbuf[zbin]
+        zbuffer_visible = projected_z <= (
+            zbuf[zbin] + depth_tol + 0.02 * projected_z)
+        diagnostics['rejected_zbuffer'] += int((~zbuffer_visible).sum())
         visible = projected_z <= (
             local_minimum + depth_tol + 0.02 * projected_z)
+        diagnostics['rejected_occlusion_margin'] += int(
+            (zbuffer_visible & ~visible).sum())
         diagnostics['rejected_occlusion'] += int((~visible).sum())
 
         edge_radii = uncertainty_margin + int(depth_edge_margin_px)

--- a/tools/colored_map/recolor_pointcloud.py
+++ b/tools/colored_map/recolor_pointcloud.py
@@ -41,6 +41,13 @@ import build_lidar_init as builder
 import pointcloud_io as pcio
 
 
+def select_paired_subset(xyz, stride: int):
+    """Return a deterministic index-strided subset for paired A/B trials."""
+    if stride < 1:
+        raise ValueError('point stride must be at least one')
+    return xyz[::stride]
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Construct the command-line parser."""
     parser = argparse.ArgumentParser(description=__doc__)
@@ -49,6 +56,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument('--transforms', required=True)
     parser.add_argument('--out', required=True)
     parser.add_argument('--report', default=None)
+    parser.add_argument('--point-stride', type=int, default=1,
+                        help='deterministically use every Nth input point; '
+                             'intended for paired parameter screening')
     parser.add_argument('--exposure-scale-limit', type=float, default=1.5)
     parser.add_argument('--max-samples', type=int, default=12)
     parser.add_argument('--min-samples', type=int, default=1)
@@ -79,6 +89,8 @@ def build_parser() -> argparse.ArgumentParser:
 def run(args: argparse.Namespace) -> dict:
     """Colour one existing map and return a compact coverage report."""
     xyz, _ = pcio.read_ply_xyz(args.input)
+    input_points = len(xyz)
+    xyz = select_paired_subset(xyz, args.point_stride)
     result = builder._colorize(
         xyz, args.transforms, robust=True,
         normalize_exposure=args.normalize_exposure,
@@ -110,7 +122,9 @@ def run(args: argparse.Namespace) -> dict:
     output = pcio.write_ply(args.out, xyz, rgb)
     report = {
         'input': str(args.input), 'output': str(output),
+        'input_points': int(input_points),
         'points': int(len(xyz)), 'colored': int(seen.sum()),
+        'point_stride': int(args.point_stride),
         'coverage': float(seen.mean()) if len(seen) else 0.0,
         'overlap_balance': bool(args.overlap_balance),
         'view_confidence': bool(args.view_confidence),

--- a/tools/colored_map/recolor_pointcloud.py
+++ b/tools/colored_map/recolor_pointcloud.py
@@ -60,6 +60,17 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument('--min-view-cosine', type=float, default=0.0)
     parser.add_argument('--min-projected-scale', type=float, default=0.0)
     parser.add_argument('--view-score-power', type=float, default=1.0)
+    parser.add_argument('--geometry-aware', action='store_true')
+    parser.add_argument('--occlusion-margin-px', type=int, default=2)
+    parser.add_argument('--depth-edge-margin-px', type=int, default=2)
+    parser.add_argument('--depth-edge-tolerance', type=float, default=0.15)
+    parser.add_argument('--depth-edge-relative-tolerance', type=float,
+                        default=0.02)
+    parser.add_argument('--dynamic-exclusion', action='store_true')
+    parser.add_argument('--dynamic-mask-margin-px', type=int, default=2)
+    parser.add_argument('--calibration-sigma-multiplier', type=float,
+                        default=0.0)
+    parser.add_argument('--max-uncertainty-margin-px', type=int, default=8)
     parser.add_argument('--no-normalize-exposure', action='store_false',
                         dest='normalize_exposure')
     return parser
@@ -68,7 +79,7 @@ def build_parser() -> argparse.ArgumentParser:
 def run(args: argparse.Namespace) -> dict:
     """Colour one existing map and return a compact coverage report."""
     xyz, _ = pcio.read_ply_xyz(args.input)
-    rgb, seen = builder._colorize(
+    result = builder._colorize(
         xyz, args.transforms, robust=True,
         normalize_exposure=args.normalize_exposure,
         exposure_scale_limit=args.exposure_scale_limit,
@@ -81,7 +92,21 @@ def run(args: argparse.Namespace) -> dict:
         min_view_cosine=args.min_view_cosine,
         min_projected_scale=args.min_projected_scale,
         view_score_power=args.view_score_power,
-        min_samples=args.min_samples)
+        min_samples=args.min_samples, geometry_aware=args.geometry_aware,
+        occlusion_margin_px=args.occlusion_margin_px,
+        depth_edge_margin_px=args.depth_edge_margin_px,
+        depth_edge_tolerance=args.depth_edge_tolerance,
+        depth_edge_relative_tolerance=args.depth_edge_relative_tolerance,
+        dynamic_exclusion=args.dynamic_exclusion,
+        dynamic_mask_margin_px=args.dynamic_mask_margin_px,
+        calibration_sigma_multiplier=args.calibration_sigma_multiplier,
+        maximum_uncertainty_margin_px=args.max_uncertainty_margin_px,
+        return_diagnostics=args.geometry_aware)
+    if args.geometry_aware:
+        rgb, seen, diagnostics = result
+    else:
+        rgb, seen = result
+        diagnostics = None
     output = pcio.write_ply(args.out, xyz, rgb)
     report = {
         'input': str(args.input), 'output': str(output),
@@ -92,6 +117,8 @@ def run(args: argparse.Namespace) -> dict:
         'image_margin': int(args.image_margin),
         'vignette_gain_limit': float(args.vignette_gain_limit),
         'min_samples': int(args.min_samples),
+        'geometry_aware': bool(args.geometry_aware),
+        'fusion_diagnostics': diagnostics,
     }
     if args.report:
         path = Path(args.report)

--- a/tools/colored_map/recolor_pointcloud.py
+++ b/tools/colored_map/recolor_pointcloud.py
@@ -71,11 +71,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument('--min-projected-scale', type=float, default=0.0)
     parser.add_argument('--view-score-power', type=float, default=1.0)
     parser.add_argument('--geometry-aware', action='store_true')
-    parser.add_argument('--occlusion-margin-px', type=int, default=2)
-    parser.add_argument('--depth-edge-margin-px', type=int, default=2)
-    parser.add_argument('--depth-edge-tolerance', type=float, default=0.15)
+    parser.add_argument('--occlusion-margin-px', type=int, default=0)
+    parser.add_argument('--depth-edge-margin-px', type=int, default=0)
+    parser.add_argument('--depth-edge-tolerance', type=float, default=1.0)
     parser.add_argument('--depth-edge-relative-tolerance', type=float,
-                        default=0.02)
+                        default=0.10)
     parser.add_argument('--dynamic-exclusion', action='store_true')
     parser.add_argument('--dynamic-mask-margin-px', type=int, default=2)
     parser.add_argument('--calibration-sigma-multiplier', type=float,

--- a/tools/gaussian_splatting/geometry_aware_fusion.py
+++ b/tools/gaussian_splatting/geometry_aware_fusion.py
@@ -1,0 +1,13 @@
+# Deprecated location: canonical module is tools/colored_map/geometry_aware_fusion.py.
+import importlib.util as _ilu
+import sys as _sys
+from pathlib import Path as _Path
+
+_target = (_Path(__file__).resolve().parents[1] / 'colored_map' /
+           'geometry_aware_fusion.py')
+_spec = _ilu.spec_from_file_location('_colored_map_geometry_aware_fusion', _target)
+_mod = _ilu.module_from_spec(_spec)
+_sys.modules[_spec.name] = _mod
+_spec.loader.exec_module(_mod)
+_sys.modules[__name__] = _mod
+globals().update(_mod.__dict__)

--- a/tools/gaussian_splatting/train_gsplat.py
+++ b/tools/gaussian_splatting/train_gsplat.py
@@ -37,9 +37,10 @@ def load_transforms(path: str | Path) -> dict:
     (resolved), ``viewmats`` (list of 4x4 world->camera, OpenCV/gsplat
     convention), and ``groups`` (per-frame int index from the optional ``bag``
     frame key; all zeros when absent — used by per-group pose refinement when
-    merging multi-session captures). The stored ``transform_matrix`` is OpenGL
-    c2w, so we undo the ``ROS_OPTICAL_TO_OPENGL`` flip and invert to get the
-    OpenCV w2c gsplat wants.
+    merging multi-session captures). Optional timestamps, dynamic-mask paths,
+    and root spatiotemporal-calibration metadata are retained for geometry-aware
+    RGB fusion. The stored ``transform_matrix`` is OpenGL c2w, so we undo the
+    ``ROS_OPTICAL_TO_OPENGL`` flip and invert to get the OpenCV w2c gsplat wants.
     """
     path = Path(path)
     doc = json.loads(path.read_text())
@@ -49,6 +50,8 @@ def load_transforms(path: str | Path) -> dict:
     image_paths: list[Path] = []
     viewmats: list[np.ndarray] = []
     groups: list[int] = []
+    timestamps: list[float] = []
+    dynamic_mask_paths: list[Optional[Path]] = []
     group_ids: dict = {}
     for fr in doc['frames']:
         c2w_gl = np.asarray(fr['transform_matrix'], dtype=float)
@@ -56,6 +59,10 @@ def load_transforms(path: str | Path) -> dict:
         viewmats.append(np.linalg.inv(c2w_cv))
         image_paths.append((path.parent / fr['file_path']).resolve())
         groups.append(group_ids.setdefault(fr.get('bag', ''), len(group_ids)))
+        timestamps.append(float(fr.get('timestamp', np.nan)))
+        mask_path = fr.get('dynamic_mask_path')
+        dynamic_mask_paths.append(
+            (path.parent / mask_path).resolve() if mask_path else None)
     return {
         'K': K,
         'width': int(doc['w']),
@@ -63,6 +70,10 @@ def load_transforms(path: str | Path) -> dict:
         'image_paths': image_paths,
         'viewmats': viewmats,
         'groups': groups,
+        'timestamps': np.asarray(timestamps, dtype=np.float64),
+        'dynamic_mask_paths': dynamic_mask_paths,
+        'spatiotemporal_calibration':
+            doc.get('spatiotemporal_calibration'),
     }
 
 


### PR DESCRIPTION
## What changed

- add deterministic point-stride screening for paired recolouring A/B trials
- split same-pixel z-buffer rejects from additional silhouette-margin rejects
- make unvalidated silhouette and depth-edge margins default to zero across builder, pipeline, and recolour CLI
- document Construction Seq1 subset and full-density candidates, including rejected configurations
- retain dynamic-mask and calibration-uncertainty paths as independent opt-in guards

## Why

The initial 2 px boundary guard reduced full-density coverage from 0.7476 to 0.3519 and worsened held-out and planar quality. Parameter screening found configurations that improved held-out colour fidelity, but full-density planar roughness still failed the existing profile. The quality threshold was deliberately not relaxed to promote the feature.

## Real-data result

- K3 reference: coverage 0.7476, held-out median/inlier20 41.17/0.2863, planar roughness 7.23/23.89
- corrected-pose baseline O: 0.7408, 40.23/0.2928, 7.72/22.65
- best edge candidate N: 0.7712, 39.94/0.3007, 8.67/28.02

N improved coverage and held-out fidelity but failed the existing planar gate, so boundary margins remain default-off.

## Validation

- focused geometry/pipeline suite: 133 passed, 4 skipped
- ament_flake8: changed Python files clean
- git diff --check: clean
- full-density evaluations used all 4,840,318 points and 260 corrected camera poses

Stacked on #380.