### PR TITLE
Optimize edge-aware colour sampling

### DIFF
--- a/docs/research/colored-map-fusion-performance-2026-07.md
+++ b/docs/research/colored-map-fusion-performance-2026-07.md
@@ -1,0 +1,56 @@
+# Camera-colour fusion performance (2026-07)
+
+## Profile
+
+Construction Seq1 full-density recolouring showed two useful operating points:
+
+- corrected-pose baseline O processed about 173.0 million accepted camera
+  samples in roughly 14 minutes;
+- guarded candidate N processed about 111.6 million in roughly 9 minutes.
+
+A one-view profile over all 4,840,318 points attributed about 46% of the robust
+projection call to edge-aware sub-pixel sampling. The implementation built an
+`Mx4x3` corner tensor solely to compute each query's local RGB range, after
+already gathering the same four corner arrays for bilinear interpolation.
+
+## Optimization
+
+The optimized sampler gathers the top two corners, initializes element-wise
+minimum and maximum arrays, then gathers the bottom pair and updates those
+arrays in place. Corner arrays are released as soon as their interpolation row
+is complete. This removes the `Mx4x3` stack and its `ptp` reduction while
+preserving the same bilinear arithmetic, edge threshold, nearest-pixel fallback,
+and tie behavior.
+
+A randomized reference test compares 1,000 sub-pixel queries against the old
+pairwise-corner formula exactly, including out-of-frame clamping and strong-edge
+fallback.
+
+## Results
+
+The fixed microbenchmark used one deterministic 1080x1440 RGB image, one
+million deterministic floating-point pixel coordinates, six edge-aware calls,
+and the same process environment.
+
+| implementation | median kernel | max RSS |
+| --- | ---: | ---: |
+| pairwise corner stack | 1.402 s | 270,092 KiB |
+| in-place min/max | 0.519 s | 238,664 KiB |
+
+Kernel time fell by 63.0% and process peak RSS by 11.6%.
+
+The paired end-to-end screen used every tenth point of the 4,840,318-point K3
+map, all 260 corrected camera poses, overlap RGB balance, view confidence,
+120-pixel image margin, vignette gain 2.5, and minimum three samples. Runs were
+serial on the same host.
+
+| implementation | wall time | max RSS | coverage |
+| --- | ---: | ---: | ---: |
+| pairwise corner stack | 130.53 s | 1,848,356 KiB | 0.777837 |
+| in-place min/max | 97.91 s | 1,848,584 KiB | 0.777837 |
+
+End-to-end time fell by 25.0%. Whole-process RSS was unchanged because point,
+normal, image, and bounded-sample arrays dominate outside the sampling kernel.
+Both reports matched after removing their output paths, and the two output PLY
+files had the identical SHA-256
+`f3edb9e62847961340bd37ee51bd4b59d3b6562a3c9eb500177a7c98dc0f502c`.

--- a/graph_based_slam/test/test_gaussian_splatting_pointcloud.py
+++ b/graph_based_slam/test/test_gaussian_splatting_pointcloud.py
@@ -499,6 +499,35 @@ def test_colorize_robust_edge_aware_keeps_smooth_bilinear_sampling():
     np.testing.assert_array_equal(rgb[0], [104, 104, 104])
 
 
+def test_edge_aware_sampling_matches_pairwise_corner_reference():
+    rng = np.random.default_rng(19)
+    image = rng.integers(0, 256, (23, 31, 3), dtype=np.uint8)
+    u = rng.uniform(-0.25, 30.25, 1000)
+    v = rng.uniform(-0.25, 22.25, 1000)
+    actual = pcio._sample_pixels(
+        image, u, v, 31, 23, 'edge-aware', 48.0)
+
+    source = image.astype(np.float32)
+    x0 = np.clip(np.floor(u).astype(np.int64), 0, 30)
+    y0 = np.clip(np.floor(v).astype(np.int64), 0, 22)
+    x1, y1 = np.minimum(x0 + 1, 30), np.minimum(y0 + 1, 22)
+    wx = np.clip(u - x0, 0.0, 1.0)[:, None].astype(np.float32)
+    wy = np.clip(v - y0, 0.0, 1.0)[:, None].astype(np.float32)
+    top = source[y0, x0] * (1.0 - wx) + source[y0, x1] * wx
+    bottom = source[y1, x0] * (1.0 - wx) + source[y1, x1] * wx
+    expected = top * (1.0 - wy) + bottom * wy
+    corners = np.stack([
+        source[y0, x0], source[y0, x1],
+        source[y1, x0], source[y1, x1],
+    ], axis=1)
+    use_nearest = np.ptp(corners, axis=1).max(axis=1) > 48.0
+    nearest_u = np.clip(np.round(u).astype(np.int64), 0, 30)
+    nearest_v = np.clip(np.round(v).astype(np.int64), 0, 22)
+    expected[use_nearest] = source[
+        nearest_v[use_nearest], nearest_u[use_nearest]]
+    np.testing.assert_array_equal(actual, expected)
+
+
 def test_colorize_robust_edge_aware_validates_threshold():
     vms, K, W, H = _cam()
     img = np.zeros((H, W, 3), dtype=np.uint8)

--- a/tools/colored_map/COLORING_HANDOFF.md
+++ b/tools/colored_map/COLORING_HANDOFF.md
@@ -311,3 +311,12 @@ transformsにもmask参照と来歴が保持される。動的除外時は部分
 実データ閾値の採用は次段階で行い、coverageだけでなくheld-out色誤差、appearance、
 各棄却理由、boundary cropを同時比較する。設計記録は
 `docs/research/colored-map-geometry-aware-fusion-2026-07.md`。
+
+## 16. 追記 (2026-07-19): edge-aware sampling性能
+
+`_sample_pixels(..., interp='edge-aware')`の4 corner stack + `np.ptp`を、
+bilinear用cornerからin-place min/maxを更新する実装へ置換した。random 1,000座標で
+旧式と完全一致。100万座標microbenchmarkはmedian 1.402s→0.519s、RSS
+270,092→238,664 KiB。Construction Seq1の同一48.4万点/260画像screenでは
+130.53s→97.91s（25.0%短縮）、coverage/report同一、PLY SHA-256も同一だった。
+詳細は`docs/research/colored-map-fusion-performance-2026-07.md`。

--- a/tools/colored_map/pointcloud_io.py
+++ b/tools/colored_map/pointcloud_io.py
@@ -305,13 +305,26 @@ def _sample_pixels(img: np.ndarray, uf: np.ndarray, vf: np.ndarray,
     y1 = np.minimum(y0 + 1, height - 1)
     wx = np.clip(uf - x0, 0.0, 1.0)[:, None].astype(np.float32)
     wy = np.clip(vf - y0, 0.0, 1.0)[:, None].astype(np.float32)
-    top = im[y0, x0] * (1.0 - wx) + im[y0, x1] * wx
-    bot = im[y1, x0] * (1.0 - wx) + im[y1, x1] * wx
+    p00, p10 = im[y0, x0], im[y0, x1]
+    if interp == 'edge-aware':
+        local_minimum = np.minimum(p00, p10)
+        local_maximum = np.maximum(p00, p10)
+    top = p00 * (1.0 - wx) + p10 * wx
+    del p00, p10
+    p01, p11 = im[y1, x0], im[y1, x1]
+    if interp == 'edge-aware':
+        np.minimum(local_minimum, p01, out=local_minimum)
+        np.minimum(local_minimum, p11, out=local_minimum)
+        np.maximum(local_maximum, p01, out=local_maximum)
+        np.maximum(local_maximum, p11, out=local_maximum)
+    bot = p01 * (1.0 - wx) + p11 * wx
+    del p01, p11
     bilinear = top * (1.0 - wy) + bot * wy
     if interp == 'bilinear':
         return bilinear
-    corners = np.stack([im[y0, x0], im[y0, x1], im[y1, x0], im[y1, x1]], axis=1)
-    local_range = np.ptp(corners, axis=1).max(axis=1)
+    # Avoid materialising Mx4x3 corners. At multi-million-point scale that
+    # temporary dominates edge-aware sampling memory and reduction time.
+    local_range = (local_maximum - local_minimum).max(axis=1)
     ui = np.clip(np.round(uf).astype(np.int64), 0, width - 1)
     vi = np.clip(np.round(vf).astype(np.int64), 0, height - 1)
     use_nearest = local_range > edge_threshold


### PR DESCRIPTION
## What changed

- replace the edge-aware sampler's `Mx4x3` corner stack and `np.ptp` reduction with incremental in-place min/max updates
- add a randomized exact-reference regression test for 1,000 sub-pixel samples
- document the focused microbenchmark and paired Construction Seq1 screen

## Why

Edge-aware sampling accounted for about 46% of a profiled robust projection call. The sampler gathered the four bilinear corners, then materialized them again as a large stacked tensor only to measure their local RGB range.

## Impact

- one-million-coordinate kernel median: 1.402 s to 0.519 s (63.0% faster)
- kernel-process max RSS: 270,092 KiB to 238,664 KiB (11.6% lower)
- paired 484k-point / 260-image screen: 130.53 s to 97.91 s (25.0% faster)
- coverage and reports are identical; output PLY SHA-256 is identical

The public behavior and defaults are unchanged.

## Checks

- focused Python suite: 134 passed, 4 skipped
- ament flake8: passed
- `git diff --check`: passed
- randomized old-formula equality test: exact array equality
- paired output SHA-256: `f3edb9e62847961340bd37ee51bd4b59d3b6562a3c9eb500177a7c98dc0f502c`
