### PR TITLE
Finish coloured-map release documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,10 @@ The pipeline registers LiDAR scans with the corrected trajectory, then projects
 synchronized camera pixels onto that geometry. This RTK-SLAM Construction Hall
 1 result follows the full estimated 60 m walking loop.
 
-![Camera-coloured SLAM point-cloud map and its estimated trajectory](lidarslam/images/map_flythrough_rtkslam.webp)
+![Camera-coloured SLAM point-cloud map and its estimated trajectory](lidarslam/images/map_flythrough_rtkslam.webp) ([MP4](lidarslam/images/map_flythrough_rtkslam.mp4) · [GIF](lidarslam/images/map_flythrough_rtkslam.gif))
 
-The sequence is from the RTK-SLAM dataset (CC-BY 4.0). Its total-station
-checkpoints are also used by the [accuracy gate](#accuracy).
+K3 has 4.84 M points, 74.76% colour coverage, and 11/11 profile checks passing; its cinematic render improves frame occupancy from 78.82% to 82.13% and flicker p90 from 0.00800 to 0.00668. See the [release-readiness record](docs/research/colored-map-release-readiness-2026-07.md) for provenance, rejected candidates, performance, and limits.
+The sequence is from RTK-SLAM (CC-BY 4.0); its total-station checkpoints also drive the [accuracy gate](#accuracy).
 
 If graph optimization outputs sparse keyframes, the coloured-map pipeline can
 propagate their corrections onto the dense SLAM pose stream automatically:
@@ -127,8 +127,8 @@ python3 tools/colored_map/colored_map_pipeline.py \
   --extrinsic configs/gaussian_splatting/<lidar_camera_extrinsic>.yaml
 ```
 
-The pipeline caches `dense_corrected_trajectory.tum` and rebuilds stale
-downstream artifacts; use `--force-trajectory` for an explicit refresh. Moving rigs can add `--refine-spatiotemporal-calibration`; see the [held-out-gated design and RTK-SLAM result](docs/research/colored-map-spatiotemporal-calibration-2026-07.md).
+The pipeline caches `dense_corrected_trajectory.tum` and rebuilds stale downstream artifacts; use `--force-trajectory` for an explicit refresh.
+Moving rigs can add `--refine-spatiotemporal-calibration`; see the [held-out-gated design and RTK-SLAM result](docs/research/colored-map-spatiotemporal-calibration-2026-07.md).
 
 ### Cross-repository SLAM benchmark
 

--- a/docs/releases/v0.5.0.md
+++ b/docs/releases/v0.5.0.md
@@ -44,13 +44,19 @@ Opt-in `deterministic_loop_scheduling` (default off) replaces latest-only
 wall-clock loop-candidate scheduling with a deterministic catch-up over
 unqueried submaps. Off by default; byte-identical behaviour when off.
 
-### Photoreal map deliverables
+### Camera-coloured map deliverables
 
-The README hero GIF rides the full 60 m RTK-SLAM Construction Hall loop
-through the camera-colored point-cloud map (occlusion-aware robust
-colorization), rendered with the in-repo flythrough tool. The optional 3DGS
-pipeline (gsplat, Apache-2.0) is documented end-to-end in
-`docs/3dgs-map-tutorial.md`.
+The README WebP rides the full 60 m RTK-SLAM Construction Hall loop through a
+4.84 M-point camera-coloured map, with MP4 and GIF fallbacks. The selected K3
+map has 74.76% colour coverage and passes its 11-item report-only alignment,
+held-out colour, coverage, chroma, and roughness profile. Rejected
+geometry-boundary candidates remain opt-in with zero default margins; the
+release does not weaken the existing planar-quality thresholds. The complete
+provenance, performance results, and promotion limits are recorded in
+`docs/research/colored-map-release-readiness-2026-07.md`.
+
+The optional 3DGS pipeline (gsplat, Apache-2.0) remains documented end-to-end
+in `docs/3dgs-map-tutorial.md`.
 
 ### Binary release prep (rosdistro)
 

--- a/docs/research/colored-map-release-readiness-2026-07.md
+++ b/docs/research/colored-map-release-readiness-2026-07.md
@@ -1,0 +1,91 @@
+# Camera-coloured map release readiness (2026-07)
+
+## Decision
+
+The camera-coloured map work is ready to ship as an opt-in, quality-gated
+pipeline. The selected public example remains the K3 Construction Seq1 map.
+Spatiotemporal calibration, dynamic masks, calibration-uncertainty propagation,
+and dataset-specific geometry margins are available without changing legacy
+defaults. Geometry boundary margins are not promoted for Construction Seq1.
+
+This distinction matters: the architecture and diagnostics are production
+ready, but a new guard is enabled by default only after paired full-density
+validation passes the existing quality profile. The release does not exchange
+surface consistency for a better aggregate colour score.
+
+## Selected map and media
+
+The K3 map contains 4,840,318 points. Of those, 3,618,693 receive camera colour
+for coverage 0.747615. It uses overlap RGB balancing, view confidence, a
+120-pixel image margin, vignette gain limit 2.5, and at least three camera
+observations. The report-only Construction Seq1 profile has 11 checks and no
+violations:
+
+- held-out RGB L2 median 41.17 (limit 42.0) and inlier-20 fraction 0.2863
+  (minimum 0.28);
+- global roughness median/p90 5.43/20.67 (limits 6.0/22.0);
+- planar roughness median/p90 7.23/23.89 (limits 7.6/25.0);
+- chroma retention 1.0016 and appearance coverage 0.7476.
+
+The README animation is rendered from K3 with the CPU surface-splat and
+cinematic-camera path. Against the previous README animation, occupied-pixel
+fraction improves from 0.78820 to 0.82135 and temporal-flicker p90 falls from
+0.00800 to 0.00668. Five points across the encoded loop were visually checked.
+
+| asset | dimensions | rate | frames | duration |
+| --- | ---: | ---: | ---: | ---: |
+| `map_flythrough_rtkslam.mp4` | 600x450 | 30 fps | 240 | 8 s |
+| `map_flythrough_rtkslam.gif` | 480x360 | 10 fps | 80 | 8 s |
+| `map_flythrough_rtkslam.webp` | 600x450 | 15 fps | 120 | 8 s |
+
+WebP is the README primary; MP4 and GIF are linked fallbacks. The source
+sequence is RTK-SLAM Construction Hall 1, distributed under CC-BY 4.0.
+
+## Architecture and promotion evidence
+
+1. The 7DoF spatiotemporal calibration recomposes camera poses from the dense
+   trajectory and accepts a correction only when training and held-out edge
+   loss improve, bounds and observability pass, and covariance is valid. The
+   Seq1 smoke improved training/held-out mean loss by 9.20%/7.85%.
+2. Geometry-aware fusion applies z-buffer silhouette, depth-edge, dynamic-mask,
+   and uncertainty-aware guards before robust colour selection. Diagnostics
+   retain separate rejection causes.
+3. Full-density candidate N improved coverage and held-out colour relative to
+   its corrected-pose baseline O, but worsened planar roughness to 8.67/28.02.
+   It was rejected against the unchanged 7.6/25.0 limits. Boundary margins
+   therefore remain zero by default.
+4. Edge-aware sampling no longer materializes an `Mx4x3` corner stack. The
+   one-million-coordinate kernel is 63.0% faster with 11.6% lower process RSS;
+   a paired 484k-point/260-image screen is 25.0% faster with an identical
+   report and byte-identical PLY SHA-256.
+
+Detailed evidence:
+
+- [spatiotemporal calibration](colored-map-spatiotemporal-calibration-2026-07.md)
+- [geometry-aware fusion and paired A/B](colored-map-geometry-aware-fusion-2026-07.md)
+- [performance and output equivalence](colored-map-fusion-performance-2026-07.md)
+
+## Compatibility and safe defaults
+
+All new correction and rejection behavior is opt-in. Without the corresponding
+flags, pipeline staging, output selection, sampling behavior, and public CLI
+defaults remain compatible. The geometry path requires a one-pixel z-buffer;
+dynamic exclusion requires a complete, dimension-checked mask set; uncertainty
+propagation requires an accepted calibration with valid seven-parameter
+uncertainty and strictly increasing timestamps.
+
+The following are not release claims:
+
+- automatic semantic segmentation (the core consumes external PNG masks);
+- universal geometry-margin values across cameras, rigs, or datasets;
+- independent Seq2 or cross-rig calibration promotion;
+- a completed world-map quality result from the camera-only realtime bag,
+  which did not contain a finished map topic.
+
+## Verification
+
+- focused coloured-map Python suite: 134 passed, 4 skipped;
+- ament flake8: passed;
+- paired output-equivalence benchmark: passed;
+- GitHub CI: Humble, Jazzy, docs/release metadata, release readiness, and the
+  negative threshold guard passed on run `29662475090`.

--- a/tools/colored_map/COLORING_HANDOFF.md
+++ b/tools/colored_map/COLORING_HANDOFF.md
@@ -320,3 +320,12 @@ bilinear用cornerからin-place min/maxを更新する実装へ置換した。ra
 270,092→238,664 KiB。Construction Seq1の同一48.4万点/260画像screenでは
 130.53s→97.91s（25.0%短縮）、coverage/report同一、PLY SHA-256も同一だった。
 詳細は`docs/research/colored-map-fusion-performance-2026-07.md`。
+
+## 17. 追記 (2026-07-19): release finish
+
+READMEへK3の4.84 M点、coverage 74.76%、11項目profile、動画のoccupied pixel / flicker
+改善を明記し、WebPにMP4/GIF fallbackを追加した。公開判断は
+`docs/research/colored-map-release-readiness-2026-07.md`へ集約。K3動画を5時点で
+目視し、MP4は600x450 / 30 fps / 240 frames / 8秒、GIFは480x360 / 10 fps /
+80 frames / 8秒を確認した。geometry boundary guardを既定化せず、既存planar gateを
+維持する制約もREADME、release note、release recordで一致させた。

--- a/tools/colored_map/README.md
+++ b/tools/colored_map/README.md
@@ -67,6 +67,11 @@ silhouette/depth-edge marginはConstruction Seq1の全量候補が既存planar q
 gateを通らなかったため既定0。dataset固有のpaired A/Bと既存profileを通すまで
 明示的に有効化しないこと。
 
+edge-aware samplingは4 cornerの巨大な一時stackを作らず、同じcornerからRGBの
+min/maxをin-place更新する。旧式との完全一致testに加え、Construction Seq1の
+paired screenでPLY SHA-256とreportが一致し、wall timeを25.0%短縮した。詳細は
+[`colored-map-fusion-performance-2026-07.md`](../../docs/research/colored-map-fusion-performance-2026-07.md)。
+
 README動画の再現設定は `render_map_flythrough.py --device cpu
 --soft-edge-px 1 --surface-splat --surface-aspect-limit 2.5
 --surface-normal-voxel 0.12 --camera-preset cinematic --render-voxel 0.03
@@ -77,6 +82,7 @@ README動画の再現設定は `render_map_flythrough.py --device cpu
 
 - [`COLORING_HANDOFF.md`](COLORING_HANDOFF.md) — 着色品質枝 (2026-07-18)
 - [`BIM_HANDOFF.md`](BIM_HANDOFF.md) — Scan-to-BIM 枝 (2026-07-11)
+- [`colored-map-release-readiness-2026-07.md`](../../docs/research/colored-map-release-readiness-2026-07.md) — 公開判定と制約
 
 チュートリアル: [`docs/3dgs-map-tutorial.md`](../../docs/3dgs-map-tutorial.md)
 (フライスルー生成)、[`docs/workflows.md`](../../docs/workflows.md)。


### PR DESCRIPTION
## What changed

- add a single release-readiness record for camera-coloured map evidence, safe defaults, rejected candidates, and known limits
- annotate the README K3 animation with MP4/GIF fallbacks and concise quality/media metrics
- align the v0.5.0 release note and coloured-map documentation with the validated K3 result
- record the final publication state in the colouring handoff

## Why

The implementation and experimental evidence were spread across calibration, fusion, A/B, performance, and handoff documents. The public entrypoint needed a compact claim with one detailed provenance page, including clear non-claims and the reason geometry boundary margins remain disabled by default.

## Impact

Users can trace the 4.84 M-point K3 example, its 74.76% colour coverage, all 11 profile checks, rendering improvements, performance results, and compatibility constraints from the README. No runtime behavior, media bytes, or defaults change in this PR.

## Checks

- docs entrypoint suite: 6 passed
- README length gate: 220 lines
- `git diff --check`: passed
- MP4/GIF codec, dimensions, frame count, and duration inspected
- five encoded MP4 loop positions visually inspected
- parent implementation CI run `29662475090`: Humble, Jazzy, docs, release readiness, and negative threshold guard passed
