### PR TITLE
Add coloured-map calibration diagnostics and rejection gates

### DIFF
--- a/docs/research/colored-map-spatiotemporal-calibration-2026-07.md
+++ b/docs/research/colored-map-spatiotemporal-calibration-2026-07.md
@@ -119,6 +119,25 @@ views. The ten worst views had 36.5% to 54.2% unmatched depth edges, despite a
 (-0.027, -0.126) px and direction coherence was 0.032. The overlays show broad,
 scene-dependent residuals on shelves, ceilings, and object boundaries rather
 than one consistent translation. This rules out treating K4 as a simple static
-extrinsic nudge: the next calibration iteration must first suppress unsupported
-depth edges and then test timing, motion distortion, and trajectory-conditioned
-residuals independently.
+extrinsic nudge. Timing, motion distortion, and trajectory-conditioned residuals
+must therefore be tested independently.
+
+### Surface-supported edge ablation
+
+The evaluator also provides an opt-in same-surface support filter. A projected
+depth-edge pixel is retained only when nearby finite depths agree within an
+absolute and range-relative tolerance. Reports always include the raw edge
+count and retained fraction so filtering cannot improve a score merely by
+discarding difficult observations. Calibration additionally supports a minimum
+retained-fraction rejection gate; the pipeline uses 25% when this filter is
+enabled.
+
+The full-density K4 `radius=2, min_neighbors=4` ablation retained 51.42% of raw
+edges. Median residual improved only from 7.759 to 7.234 px, 2 px inliers from
+22.31% to 23.12%, and out-of-range residuals from 34.96% to 32.79%; p90 remained
+saturated at 13 px. With the production 300,000-point calibration subsample,
+only 7.62% survived. Its apparently lower 4.59 px median is selection bias and
+fails the 25% retention gate. This filter is useful for visual diagnosis but is
+not a K5 calibration candidate. The next objective needs correspondence support
+that remains meaningful under sparse geometry rather than image-plane density
+alone.

--- a/docs/research/colored-map-spatiotemporal-calibration-2026-07.md
+++ b/docs/research/colored-map-spatiotemporal-calibration-2026-07.md
@@ -90,3 +90,35 @@ multi-scale curvature and undefined-correlation handling, stratified splitting,
 continuous-time pose recomposition, static-motion degeneracy, independent
 held-out rejection, pipeline staging, cache reuse, and unchanged opt-in command
 composition.
+
+## K5 residual diagnostics
+
+An aggregate edge-distance score can hide whether a poor map is caused by one
+constant camera correction or by view-dependent timing and pose errors. The
+alignment evaluator therefore has an optional diagnostic output:
+
+```bash
+python3 scripts/evaluate_lidar_camera_alignment.py \
+  --pointcloud coloured.ply --transforms posed/transforms.json \
+  --out alignment.json --diagnostics-dir alignment_diagnostics \
+  --worst-views 10
+```
+
+Each selected view records the median signed x/y displacement from projected
+LiDAR depth edges to their nearest strong image edges. The diagnostic directory
+contains JSON, the worst-view overlays, and a contact sheet. Image edges are
+green; LiDAR edges progress from cyan through yellow to red as residual grows,
+and unmatched edges are magenta. A stable signed direction across views points
+to a static extrinsic error. Large changes between views instead point to clock,
+motion distortion, rolling shutter, or trajectory error. These images are
+diagnostic evidence, not a replacement for independent held-out acceptance.
+
+The first full-resolution K4 audit used all 4,906,133 geometry points and 26
+views. The ten worst views had 36.5% to 54.2% unmatched depth edges, despite a
+12 px search radius. Across all matched edges, the weighted direction was only
+(-0.027, -0.126) px and direction coherence was 0.032. The overlays show broad,
+scene-dependent residuals on shelves, ceilings, and object boundaries rather
+than one consistent translation. This rules out treating K4 as a simple static
+extrinsic nudge: the next calibration iteration must first suppress unsupported
+depth edges and then test timing, motion distortion, and trajectory-conditioned
+residuals independently.

--- a/docs/research/colored-map-spatiotemporal-calibration-2026-07.md
+++ b/docs/research/colored-map-spatiotemporal-calibration-2026-07.md
@@ -166,3 +166,24 @@ rejected a stationary point outside the local neighbourhood. No corrected pose
 was adopted. This establishes density-independent evidence and safe rejection,
 but does not yet improve K4 colour registration; fixed nearest-image-edge
 distance remains too weak and ambiguous in the cluttered warehouse.
+
+### Per-pixel orientation-aware correspondence
+
+Fixed contours can optionally carry the unit normal of their originating depth
+discontinuity. `--orientation-max-angle-deg` then requires the unoriented depth
+normal and image-gradient normal to agree as well as satisfying pixel distance.
+Angle-rejected contours remain saturated residuals rather than disappearing
+from the population. The option is default-off and requires fixed contours.
+
+The 30-degree production smoke retained all 260,000 fixed contour points but
+left 61.24% without a valid match. Training loss improved only 1.09% and
+held-out loss 0.52%, both worse than distance-only contours. The solution also
+reached search bounds and failed observability because of insufficient and
+unstable curvature, an unobservable time/translation pair, an out-of-local
+stationary point, and ill-conditioning. It was rejected and original poses were
+exported.
+
+Pixel normals from a sparse depth raster are not stable enough around shelves,
+corners, and thin structures. The next candidate should group contour pixels
+into supported line segments and estimate one robust tangent per segment,
+rather than loosening this per-pixel gate until it becomes distance-only again.

--- a/docs/research/colored-map-spatiotemporal-calibration-2026-07.md
+++ b/docs/research/colored-map-spatiotemporal-calibration-2026-07.md
@@ -141,3 +141,28 @@ fails the 25% retention gate. This filter is useful for visual diagnosis but is
 not a K5 calibration candidate. The next objective needs correspondence support
 that remains meaningful under sparse geometry rather than image-plane density
 alone.
+
+### Fixed full-density 3D contours
+
+The next candidate extracts visible depth-edge winner IDs from the complete
+4.91 M-point geometry before applying `--max-points`. Each view retains a
+deterministically image-distributed cap of those world-space points. During
+7DoF search the same 3D points are reprojected for every candidate, so neither
+the 300,000-point calibration subsample nor candidate-dependent edge detection
+can change the objective's population. Pipeline support is opt-in through
+`--calibration-fixed-contours` and `--alignment-fixed-contours`.
+
+Image-associated contour selection is diagnostic-only. An ablation selecting
+points initially within 12 px of an image edge made zero correction the exact
+optimum: both training and held-out loss changed by 0%. The CLI now rejects
+that mode during optimization. Production calibration requires geometry-only
+selection (`--contour-association-distance 0`).
+
+A geometry-only smoke used 13 stratified views and 20,000 fixed contour points
+per view. All 260,000 points survived the 300,000-point calibration condition.
+The candidate reduced training loss by 2.25%, but held-out loss by only 0.76%
+(7.3723 to 7.3160 px), below the required 2%. The observability audit also
+rejected a stationary point outside the local neighbourhood. No corrected pose
+was adopted. This establishes density-independent evidence and safe rejection,
+but does not yet improve K4 colour registration; fixed nearest-image-edge
+distance remains too weak and ambiguous in the cluttered warehouse.

--- a/graph_based_slam/test/test_colored_map_pipeline.py
+++ b/graph_based_slam/test/test_colored_map_pipeline.py
@@ -454,6 +454,7 @@ def test_fixed_contour_options_reach_calibration_and_alignment(tmp_path):
         tmp_path, '--refine-spatiotemporal-calibration',
         '--calibration-fixed-contours',
         '--calibration-contour-max-points-per-view', '12000',
+        '--calibration-orientation-max-angle-deg', '25',
         '--quality-profile', str(tmp_path / 'profile.yaml'),
         '--alignment-fixed-contours',
         '--alignment-contour-association-distance', '30')
@@ -463,6 +464,8 @@ def test_fixed_contour_options_reach_calibration_and_alignment(tmp_path):
     assert '--fixed-contours' in calibration
     assert calibration[
         calibration.index('--contour-max-points-per-view') + 1] == '12000'
+    assert calibration[
+        calibration.index('--orientation-max-angle-deg') + 1] == '25.0'
     assert '--fixed-contours' in alignment
     assert alignment[
         alignment.index('--contour-association-distance') + 1] == '30'

--- a/graph_based_slam/test/test_colored_map_pipeline.py
+++ b/graph_based_slam/test/test_colored_map_pipeline.py
@@ -420,6 +420,16 @@ def test_quality_profile_allows_appearance_and_colour_only(tmp_path):
     assert '--appearance-report' in gate
 
 
+def test_quality_profile_can_emit_alignment_residual_diagnostics(tmp_path):
+    args = _args(
+        tmp_path, '--quality-profile', str(tmp_path / 'profile.yaml'),
+        '--alignment-diagnostics', '--alignment-diagnostic-worst-views', '6')
+    alignment = dict(cmp.build_commands(args))['camera-LiDAR alignment']
+    diagnostics = alignment[alignment.index('--diagnostics-dir') + 1]
+    assert diagnostics.endswith('out/lidar_camera_alignment_diagnostics')
+    assert alignment[alignment.index('--worst-views') + 1] == '6'
+
+
 def test_vignette_and_confidence_options_reach_map_builder(tmp_path):
     commands = cmp.build_commands(_args(
         tmp_path, '--color-image-margin', '140', '--color-min-samples', '3',

--- a/graph_based_slam/test/test_colored_map_pipeline.py
+++ b/graph_based_slam/test/test_colored_map_pipeline.py
@@ -430,6 +430,25 @@ def test_quality_profile_can_emit_alignment_residual_diagnostics(tmp_path):
     assert alignment[alignment.index('--worst-views') + 1] == '6'
 
 
+def test_depth_support_options_reach_calibration_and_alignment(tmp_path):
+    args = _args(
+        tmp_path, '--refine-spatiotemporal-calibration',
+        '--calibration-depth-support-radius', '2',
+        '--calibration-depth-support-min-neighbors', '5',
+        '--quality-profile', str(tmp_path / 'profile.yaml'),
+        '--alignment-depth-support-radius', '3',
+        '--alignment-depth-support-min-neighbors', '7')
+    commands = dict(cmp.build_commands(args))
+    calibration = commands['spatiotemporal calibration']
+    alignment = commands['camera-LiDAR alignment']
+    assert calibration[calibration.index('--depth-support-radius') + 1] == '2'
+    assert calibration[calibration.index('--depth-support-min-neighbors') + 1] == '5'
+    assert calibration[
+        calibration.index('--minimum-supported-edge-fraction') + 1] == '0.25'
+    assert alignment[alignment.index('--depth-support-radius') + 1] == '3'
+    assert alignment[alignment.index('--depth-support-min-neighbors') + 1] == '7'
+
+
 def test_vignette_and_confidence_options_reach_map_builder(tmp_path):
     commands = cmp.build_commands(_args(
         tmp_path, '--color-image-margin', '140', '--color-min-samples', '3',

--- a/graph_based_slam/test/test_colored_map_pipeline.py
+++ b/graph_based_slam/test/test_colored_map_pipeline.py
@@ -449,6 +449,25 @@ def test_depth_support_options_reach_calibration_and_alignment(tmp_path):
     assert alignment[alignment.index('--depth-support-min-neighbors') + 1] == '7'
 
 
+def test_fixed_contour_options_reach_calibration_and_alignment(tmp_path):
+    args = _args(
+        tmp_path, '--refine-spatiotemporal-calibration',
+        '--calibration-fixed-contours',
+        '--calibration-contour-max-points-per-view', '12000',
+        '--quality-profile', str(tmp_path / 'profile.yaml'),
+        '--alignment-fixed-contours',
+        '--alignment-contour-association-distance', '30')
+    commands = dict(cmp.build_commands(args))
+    calibration = commands['spatiotemporal calibration']
+    alignment = commands['camera-LiDAR alignment']
+    assert '--fixed-contours' in calibration
+    assert calibration[
+        calibration.index('--contour-max-points-per-view') + 1] == '12000'
+    assert '--fixed-contours' in alignment
+    assert alignment[
+        alignment.index('--contour-association-distance') + 1] == '30'
+
+
 def test_vignette_and_confidence_options_reach_map_builder(tmp_path):
     commands = cmp.build_commands(_args(
         tmp_path, '--color-image-margin', '140', '--color-min-samples', '3',

--- a/graph_based_slam/test/test_lidar_camera_alignment.py
+++ b/graph_based_slam/test/test_lidar_camera_alignment.py
@@ -72,6 +72,20 @@ def test_nearest_edge_distances_reports_alignment_and_shift():
         lca.nearest_edge_distances(query, query, max_distance=6), 0.0)
 
 
+def test_nearest_edge_correspondences_reports_signed_direction_and_saturation():
+    query = np.zeros((12, 12), dtype=bool)
+    target = np.zeros_like(query)
+    query[4, 4] = True
+    query[10, 10] = True
+    target[2, 7] = True
+    result = lca.nearest_edge_correspondences(query, target, max_distance=4)
+    np.testing.assert_allclose(result['distance_px'][0], np.hypot(-2, 3))
+    assert result['dy_px'][0] == -2
+    assert result['dx_px'][0] == 3
+    assert result['distance_px'][1] == 5
+    assert np.isnan(result['dy_px'][1]) and np.isnan(result['dx_px'][1])
+
+
 def test_projected_depth_keeps_nearest_point():
     points = np.array([[0.0, 0.0, 2.0], [0.0, 0.0, 5.0]])
     K = np.array([[10.0, 0.0, 5.0], [0.0, 10.0, 5.0], [0.0, 0.0, 1.0]])
@@ -91,12 +105,49 @@ def test_score_view_handles_no_depth_edges():
 
 def test_score_view_reports_search_range_saturation(monkeypatch):
     monkeypatch.setattr(
-        lca, 'nearest_edge_distances',
-        lambda *args, **kwargs: np.array([0.0, 13.0], dtype=np.float32))
+        lca, 'nearest_edge_correspondences',
+        lambda *args, **kwargs: {
+            'distance_px': np.array([0.0, 13.0], dtype=np.float32),
+            'dx_px': np.array([0.0, np.nan], dtype=np.float32),
+            'dy_px': np.array([0.0, np.nan], dtype=np.float32)})
     result = lca.score_view(
         np.array([[0.0, 0.0, 2.0]]), np.eye(4), np.eye(3),
         np.zeros((10, 10, 3), dtype=np.uint8), max_distance=12)
     assert result['out_of_range_fraction'] == 0.5
+    assert result['matched_edge_points'] == 1
+
+
+def test_write_residual_diagnostics_ranks_worst_view_and_writes_pngs(
+        tmp_path, monkeypatch):
+    overlays = []
+
+    def render(*args, **kwargs):
+        value = len(overlays) + 1
+        overlays.append(value)
+        return np.full((8, 10, 3), value, dtype=np.uint8)
+
+    monkeypatch.setattr(lca, 'render_residual_overlay', render)
+    per_view = [
+        {'view_index': 0, 'edge_points': 10, 'matched_edge_points': 8,
+         'median_px': 2.0, 'p90_px': 4.0, 'inlier_2px': 0.5,
+         'out_of_range_fraction': 0.1, 'median_dx_px': 1.0,
+         'median_dy_px': 0.0, 'mean_dx_px': 1.0, 'mean_dy_px': 0.0,
+         'direction_coherence': 0.5},
+        {'view_index': 1, 'edge_points': 10, 'matched_edge_points': 5,
+         'median_px': 8.0, 'p90_px': 13.0, 'inlier_2px': 0.1,
+         'out_of_range_fraction': 0.5, 'median_dx_px': -2.0,
+         'median_dy_px': 3.0, 'mean_dx_px': -2.0, 'mean_dy_px': 3.0,
+         'direction_coherence': 0.8},
+    ]
+    result = lca.write_residual_diagnostics(
+        tmp_path, np.zeros((0, 3)), np.asarray([np.eye(4), np.eye(4)]),
+        np.eye(3), [0, 1], [np.zeros((8, 10, 3), np.uint8)] * 2,
+        per_view, worst_views=1, edge_percentile=95.0, max_distance=12)
+    assert result['worst_views'][0]['view_index'] == 1
+    assert (tmp_path / 'worst_01_view_00001.png').is_file()
+    assert (tmp_path / 'worst_views_contact_sheet.png').is_file()
+    assert json.loads((tmp_path / 'diagnostics.json').read_text())[
+        'direction_summary']['weighted_mean_dx_px'] == -2 / 13
 
 
 def test_correction_matrix_applies_translation_and_rotation():

--- a/graph_based_slam/test/test_lidar_camera_alignment.py
+++ b/graph_based_slam/test/test_lidar_camera_alignment.py
@@ -61,6 +61,25 @@ def test_depth_edges_detects_supported_depth_step():
     assert edges.sum() == 2
 
 
+def test_surface_supported_edges_keep_surfaces_and_reject_isolated_pair():
+    depth = np.full((12, 12), np.inf, dtype=np.float32)
+    depth[2:10, 2:6] = 2.0
+    depth[2:10, 6:10] = 4.0
+    depth[0, 0:2] = [2.0, 4.0]
+    edges, raw_count = lca.supported_depth_edges(depth, {
+        'radius': 1, 'min_neighbors': 2, 'absolute': 0.1, 'relative': 0.0,
+    })
+    assert raw_count == 18
+    assert edges[:, 5:7].sum() == 16
+    assert not edges[0, :2].any()
+
+
+def test_surface_support_rejects_impossible_neighbour_count():
+    with np.testing.assert_raises_regex(ValueError, 'exceed'):
+        lca.surface_support_mask(
+            np.ones((4, 4), np.float32), radius=1, min_neighbors=9)
+
+
 def test_nearest_edge_distances_reports_alignment_and_shift():
     query = np.zeros((20, 20), dtype=bool)
     target = np.zeros_like(query)
@@ -351,3 +370,10 @@ def test_calibration_acceptance_requires_heldout_improvement_and_support():
         {'edge_points': 10, 'loss': 10.0}, improved, before, improved,
         minimum_edge_points=50, minimum_heldout_improvement=0.1)
     assert not accepted and reason == 'insufficient_edge_support'
+    filtered = {'edge_points': 100, 'loss': 10.0,
+                'supported_edge_fraction': 0.08}
+    accepted, reason = lca.calibration_acceptance(
+        filtered, improved, filtered, improved,
+        minimum_edge_points=50, minimum_heldout_improvement=0.1,
+        minimum_supported_edge_fraction=0.25)
+    assert not accepted and reason == 'insufficient_supported_edge_fraction'

--- a/graph_based_slam/test/test_lidar_camera_alignment.py
+++ b/graph_based_slam/test/test_lidar_camera_alignment.py
@@ -61,6 +61,16 @@ def test_depth_edges_detects_supported_depth_step():
     assert edges.sum() == 2
 
 
+def test_depth_edge_normal_field_reports_horizontal_step_normal():
+    depth = np.full((8, 8), np.inf, np.float32)
+    depth[3, 2:6] = [2.0, 2.0, 4.0, 4.0]
+    edges, nx, ny = lca.depth_edge_normal_field(
+        depth, absolute=0.25, relative=0.0)
+    assert edges[3, 3] and edges[3, 4]
+    np.testing.assert_allclose(nx[3, 3:5], 1.0)
+    np.testing.assert_allclose(ny[3, 3:5], 0.0)
+
+
 def test_surface_supported_edges_keep_surfaces_and_reject_isolated_pair():
     depth = np.full((12, 12), np.inf, dtype=np.float32)
     depth[2:10, 2:6] = 2.0
@@ -105,6 +115,28 @@ def test_nearest_edge_correspondences_reports_signed_direction_and_saturation():
     assert np.isnan(result['dy_px'][1]) and np.isnan(result['dx_px'][1])
 
 
+def test_oriented_correspondence_rejects_perpendicular_edge():
+    query = np.zeros((12, 12), bool)
+    target = np.zeros_like(query)
+    query[6, 4] = True
+    target[6, 6] = True
+    qnx = np.zeros((12, 12), np.float32)
+    qny = np.zeros_like(qnx)
+    tnx = np.zeros_like(qnx)
+    tny = np.zeros_like(qnx)
+    qnx[6, 4] = 1.0
+    tny[6, 6] = 1.0
+    rejected = lca.nearest_oriented_edge_correspondences(
+        query, target, qnx, qny, tnx, tny,
+        max_distance=4, max_angle_deg=20.0)
+    assert rejected['distance_px'][0] == 5.0
+    tnx[6, 6], tny[6, 6] = 1.0, 0.0
+    accepted = lca.nearest_oriented_edge_correspondences(
+        query, target, qnx, qny, tnx, tny,
+        max_distance=4, max_angle_deg=20.0)
+    assert accepted['distance_px'][0] == 2.0
+
+
 def test_projected_depth_keeps_nearest_point():
     points = np.array([[0.0, 0.0, 2.0], [0.0, 0.0, 5.0]])
     K = np.array([[10.0, 0.0, 5.0], [0.0, 10.0, 5.0], [0.0, 0.0, 1.0]])
@@ -137,7 +169,8 @@ def test_extract_fixed_contours_uses_full_density_edges_and_caps_points():
         np.asarray(points), np.asarray([np.eye(4)]), K, [image],
         edge_percentile=50.0, association_distance=2,
         max_points_per_view=5)
-    assert banks[0].shape == (5, 3)
+    assert banks[0].shape == (5, 5)
+    np.testing.assert_allclose(np.linalg.norm(banks[0][:, 3:5], axis=1), 1.0)
     assert report['views'][0]['raw_depth_edge_pixels'] == 16
     assert report['views'][0]['image_associated_edge_points_before_cap'] > 5
     assert report['total_fixed_contour_points'] == 5

--- a/graph_based_slam/test/test_lidar_camera_alignment.py
+++ b/graph_based_slam/test/test_lidar_camera_alignment.py
@@ -112,6 +112,37 @@ def test_projected_depth_keeps_nearest_point():
     assert depth[5, 5] == 2.0
 
 
+def test_projected_depth_and_ids_keeps_nearest_source_id():
+    points = np.array([[0.0, 0.0, 5.0], [0.0, 0.0, 2.0]])
+    K = np.array([[10.0, 0.0, 5.0], [0.0, 10.0, 5.0], [0.0, 0.0, 1.0]])
+    depth, point_ids = lca.projected_depth_and_ids(
+        points, np.eye(4), K, 10, 10)
+    assert depth[5, 5] == 2.0
+    assert point_ids[5, 5] == 1
+    assert point_ids[0, 0] == -1
+
+
+def test_extract_fixed_contours_uses_full_density_edges_and_caps_points():
+    width = height = 12
+    K = np.array([[10.0, 0.0, 6.0], [0.0, 10.0, 6.0], [0.0, 0.0, 1.0]])
+    points = []
+    for v in range(2, 10):
+        for u in range(2, 10):
+            z = 2.0 if u < 6 else 4.0
+            points.append([(u - 6.0) * z / 10.0,
+                           (v - 6.0) * z / 10.0, z])
+    image = np.zeros((height, width, 3), np.uint8)
+    image[:, 6:] = 255
+    banks, report = lca.extract_fixed_contours(
+        np.asarray(points), np.asarray([np.eye(4)]), K, [image],
+        edge_percentile=50.0, association_distance=2,
+        max_points_per_view=5)
+    assert banks[0].shape == (5, 3)
+    assert report['views'][0]['raw_depth_edge_pixels'] == 16
+    assert report['views'][0]['image_associated_edge_points_before_cap'] > 5
+    assert report['total_fixed_contour_points'] == 5
+
+
 def test_score_view_handles_no_depth_edges():
     points = np.array([[0.0, 0.0, 2.0]])
     K = np.array([[10.0, 0.0, 5.0], [0.0, 10.0, 5.0], [0.0, 0.0, 1.0]])
@@ -120,6 +151,28 @@ def test_score_view_handles_no_depth_edges():
     assert result['edge_points'] == 0
     assert result['median_px'] is None
     assert result['out_of_range_fraction'] is None
+
+
+def test_alignment_objective_uses_fixed_contours_without_dense_points():
+    image = np.zeros((12, 12, 3), np.uint8)
+    image[:, 6:] = 255
+    K = np.array([[10.0, 0.0, 6.0], [0.0, 10.0, 6.0], [0.0, 0.0, 1.0]])
+    contours = [np.array([[0.0, 0.0, 2.0]])]
+    loss, metrics = lca.alignment_objective(
+        np.zeros((0, 3)), np.asarray([np.eye(4)]), K, [image],
+        np.zeros(6), edge_percentile=50.0,
+        contour_points_by_view=contours)
+    assert np.isfinite(loss)
+    assert metrics['edge_points'] == 1
+    assert metrics['raw_edge_points'] == 1
+
+
+def test_alignment_objective_rejects_mismatched_contour_banks():
+    with np.testing.assert_raises_regex(ValueError, 'bank count'):
+        lca.alignment_objective(
+            np.zeros((0, 3)), np.asarray([np.eye(4)]), np.eye(3),
+            [np.zeros((4, 4), np.uint8)], np.zeros(6),
+            contour_points_by_view=[])
 
 
 def test_score_view_reports_search_range_saturation(monkeypatch):

--- a/scripts/evaluate_lidar_camera_alignment.py
+++ b/scripts/evaluate_lidar_camera_alignment.py
@@ -221,14 +221,135 @@ def projected_depth(points: np.ndarray, viewmat: np.ndarray, K: np.ndarray,
     return image
 
 
+def projected_depth_and_ids(points: np.ndarray, viewmat: np.ndarray,
+                            K: np.ndarray, width: int,
+                            height: int) -> tuple[np.ndarray, np.ndarray]:
+    """Project nearest depth and deterministic source point ID per pixel."""
+    points = np.asarray(points, dtype=np.float64)
+    camera = points @ viewmat[:3, :3].T + viewmat[:3, 3]
+    depth = camera[:, 2]
+    with np.errstate(divide='ignore', invalid='ignore'):
+        u = np.nan_to_num(K[0, 0] * camera[:, 0] / depth + K[0, 2], nan=-1.0,
+                          posinf=-1.0, neginf=-1.0)
+        v = np.nan_to_num(K[1, 1] * camera[:, 1] / depth + K[1, 2], nan=-1.0,
+                          posinf=-1.0, neginf=-1.0)
+    ui = np.round(u).astype(np.int64)
+    vi = np.round(v).astype(np.int64)
+    inside = ((depth > 1e-6) & (ui >= 0) & (ui < width) &
+              (vi >= 0) & (vi < height))
+    depth_image = np.full(height * width, np.inf, dtype=np.float64)
+    missing_id = np.iinfo(np.int64).max
+    id_image = np.full(height * width, missing_id, dtype=np.int64)
+    if not np.any(inside):
+        id_image.fill(-1)
+        return (depth_image.reshape(height, width).astype(np.float32),
+                id_image.reshape(height, width))
+    ids = np.flatnonzero(inside)
+    pixels = vi[inside] * width + ui[inside]
+    np.minimum.at(depth_image, pixels, depth[inside])
+    winners = depth[inside] == depth_image[pixels]
+    np.minimum.at(id_image, pixels[winners], ids[winners])
+    id_image[id_image == missing_id] = -1
+    return (depth_image.reshape(height, width).astype(np.float32),
+            id_image.reshape(height, width))
+
+
+def projected_point_mask(points: np.ndarray, viewmat: np.ndarray, K: np.ndarray,
+                         width: int, height: int) -> np.ndarray:
+    """Project fixed 3D contour points into a deterministic binary mask."""
+    points = np.asarray(points, dtype=np.float64)
+    mask = np.zeros((height, width), dtype=bool)
+    if points.size == 0:
+        return mask
+    camera = points @ viewmat[:3, :3].T + viewmat[:3, 3]
+    depth = camera[:, 2]
+    with np.errstate(divide='ignore', invalid='ignore'):
+        u = np.nan_to_num(K[0, 0] * camera[:, 0] / depth + K[0, 2], nan=-1.0,
+                          posinf=-1.0, neginf=-1.0)
+        v = np.nan_to_num(K[1, 1] * camera[:, 1] / depth + K[1, 2], nan=-1.0,
+                          posinf=-1.0, neginf=-1.0)
+    ui = np.round(u).astype(np.int64)
+    vi = np.round(v).astype(np.int64)
+    inside = ((depth > 1e-6) & (ui >= 0) & (ui < width) &
+              (vi >= 0) & (vi < height))
+    mask[vi[inside], ui[inside]] = True
+    return mask
+
+
+def extract_fixed_contours(points: np.ndarray, viewmats: np.ndarray,
+                           K: np.ndarray, images: list[np.ndarray], *,
+                           edge_percentile: float = 95.0,
+                           association_distance: int = 0,
+                           max_points_per_view: int = 50000,
+                           depth_support: dict | None = None
+                           ) -> tuple[list[np.ndarray], dict]:
+    """Freeze full-density visible depth edges as per-view 3D point banks."""
+    banks = []
+    per_view = []
+    for ordinal, (viewmat, image) in enumerate(zip(viewmats, images)):
+        height, width = image.shape[:2]
+        depth, point_ids = projected_depth_and_ids(
+            points, viewmat, K, width, height)
+        lidar_edges, raw_edges = supported_depth_edges(depth, depth_support)
+        edge_ids = point_ids[lidar_edges]
+        valid_ids = edge_ids >= 0
+        edge_ids = edge_ids[valid_ids]
+        query = np.zeros_like(lidar_edges)
+        query[lidar_edges] = valid_ids
+        if association_distance > 0:
+            distances = nearest_edge_distances(
+                query, image_edges(image, edge_percentile),
+                association_distance)
+            associated = distances <= association_distance
+        else:
+            associated = np.ones(len(edge_ids), dtype=bool)
+        selected_ids = edge_ids[associated]
+        # Preserve row-major image order before deterministic thinning so the
+        # cap remains spatially distributed instead of following PLY point ID.
+        _, first_occurrence = np.unique(selected_ids, return_index=True)
+        selected_ids = selected_ids[np.sort(first_occurrence)]
+        before_cap = len(selected_ids)
+        if len(selected_ids) > max_points_per_view:
+            indices = np.linspace(
+                0, len(selected_ids) - 1, max_points_per_view,
+                dtype=np.int64)
+            selected_ids = selected_ids[indices]
+        banks.append(np.asarray(points[selected_ids], dtype=np.float64))
+        per_view.append({
+            'ordinal': ordinal,
+            'raw_depth_edge_pixels': raw_edges,
+            'supported_depth_edge_pixels': int(np.sum(lidar_edges)),
+            'candidate_edge_points_before_cap': before_cap,
+            'image_associated_edge_points_before_cap': (
+                before_cap if association_distance > 0 else None),
+            'fixed_contour_points': len(selected_ids),
+            'association_fraction': float(
+                np.mean(associated) if associated.size else 0.0),
+        })
+    return banks, {
+        'association_distance_px': association_distance,
+        'image_association_enabled': association_distance > 0,
+        'max_points_per_view': max_points_per_view,
+        'depth_support': depth_support,
+        'views': per_view,
+        'total_fixed_contour_points': int(sum(len(bank) for bank in banks)),
+    }
+
+
 def score_view(points: np.ndarray, viewmat: np.ndarray, K: np.ndarray,
                image: np.ndarray, *, edge_percentile: float = 95.0,
                max_distance: int = 12,
-               depth_support: dict | None = None) -> dict:
+               depth_support: dict | None = None,
+               contour_points: np.ndarray | None = None) -> dict:
     """Score one camera view and return pixel-distance alignment metrics."""
     height, width = image.shape[:2]
-    lidar_edges, raw_edge_points = supported_depth_edges(
-        projected_depth(points, viewmat, K, width, height), depth_support)
+    if contour_points is None:
+        lidar_edges, raw_edge_points = supported_depth_edges(
+            projected_depth(points, viewmat, K, width, height), depth_support)
+    else:
+        lidar_edges = projected_point_mask(
+            contour_points, viewmat, K, width, height)
+        raw_edge_points = len(contour_points)
     correspondences = nearest_edge_correspondences(
         lidar_edges, image_edges(image, edge_percentile), max_distance)
     distances = correspondences['distance_px']
@@ -269,7 +390,9 @@ def render_residual_overlay(points: np.ndarray, viewmat: np.ndarray,
                             K: np.ndarray, image: np.ndarray, *,
                             edge_percentile: float = 95.0,
                             max_distance: int = 12,
-                            depth_support: dict | None = None) -> np.ndarray:
+                            depth_support: dict | None = None,
+                            contour_points: np.ndarray | None = None
+                            ) -> np.ndarray:
     """Overlay image edges and colour-coded LiDAR edge residuals."""
     source = np.asarray(image)
     if source.ndim == 2:
@@ -280,8 +403,12 @@ def render_residual_overlay(points: np.ndarray, viewmat: np.ndarray,
     output = np.clip(source.astype(np.float32) * 0.55, 0, 255).astype(np.uint8)
     height, width = source.shape[:2]
     camera_edges = image_edges(source, edge_percentile)
-    lidar_edges, _ = supported_depth_edges(
-        projected_depth(points, viewmat, K, width, height), depth_support)
+    if contour_points is None:
+        lidar_edges, _ = supported_depth_edges(
+            projected_depth(points, viewmat, K, width, height), depth_support)
+    else:
+        lidar_edges = projected_point_mask(
+            contour_points, viewmat, K, width, height)
     residuals = nearest_edge_correspondences(
         lidar_edges, camera_edges, max_distance)
 
@@ -311,13 +438,17 @@ def write_residual_diagnostics(directory: Path, points: np.ndarray,
                                per_view: list[dict], *, worst_views: int,
                                edge_percentile: float,
                                max_distance: int,
-                               depth_support: dict | None = None) -> dict:
+                               depth_support: dict | None = None,
+                               contour_points_by_view: list[np.ndarray] | None = None
+                               ) -> dict:
     """Write deterministic worst-view overlays and a compact contact sheet."""
     import imageio.v3 as iio
 
     directory = Path(directory)
     directory.mkdir(parents=True, exist_ok=True)
     image_by_index = dict(zip(selected, images))
+    contour_by_index = (dict(zip(selected, contour_points_by_view))
+                        if contour_points_by_view is not None else {})
     valid = [item for item in per_view if item['edge_points'] > 0]
     ranked = sorted(
         valid,
@@ -331,7 +462,8 @@ def write_residual_diagnostics(directory: Path, points: np.ndarray,
         overlay = render_residual_overlay(
             points, viewmats[index], K, image_by_index[index],
             edge_percentile=edge_percentile, max_distance=max_distance,
-            depth_support=depth_support)
+            depth_support=depth_support,
+            contour_points=contour_by_index.get(index))
         filename = f'worst_{rank:02d}_view_{index:05d}.png'
         path = directory / filename
         iio.imwrite(path, overlay)
@@ -381,6 +513,7 @@ def write_residual_diagnostics(directory: Path, points: np.ndarray,
                          'unmatched_lidar_edges': 'magenta'},
               'ranking': 'out_of_range_fraction,p90_px,median_px',
               'depth_support': depth_support,
+              'fixed_contours': contour_points_by_view is not None,
               'direction_summary': direction,
               'contact_sheet': contact_name, 'worst_views': entries}
     (directory / 'diagnostics.json').write_text(json.dumps(result, indent=2) + '\n')
@@ -408,18 +541,30 @@ def alignment_objective(points: np.ndarray, viewmats: np.ndarray,
                         max_distance: int = 12,
                         reference_edge_points: int | None = None,
                         image_edge_masks: list[np.ndarray] | None = None,
-                        depth_support: dict | None = None
+                        depth_support: dict | None = None,
+                        contour_points_by_view: list[np.ndarray] | None = None
                         ) -> tuple[float, dict]:
     """Return coverage-guarded mean edge distance for one SE(3) correction."""
+    if (contour_points_by_view is not None and
+            len(contour_points_by_view) != len(images)):
+        raise ValueError('fixed contour bank count must match image count')
     delta = correction_matrix(parameters)
     chunks = []
     targets = (image_edge_masks if image_edge_masks is not None else
                [image_edges(image, edge_percentile) for image in images])
     raw_edge_points = 0
-    for viewmat, image, target in zip(viewmats, images, targets):
+    contours = (contour_points_by_view if contour_points_by_view is not None
+                else [None] * len(images))
+    for viewmat, image, target, contour_points in zip(
+            viewmats, images, targets, contours):
         height, width = image.shape[:2]
-        lidar_edges, raw_count = supported_depth_edges(projected_depth(
-            points, delta @ viewmat, K, width, height), depth_support)
+        if contour_points is None:
+            lidar_edges, raw_count = supported_depth_edges(projected_depth(
+                points, delta @ viewmat, K, width, height), depth_support)
+        else:
+            lidar_edges = projected_point_mask(
+                contour_points, delta @ viewmat, K, width, height)
+            raw_count = len(contour_points)
         raw_edge_points += raw_count
         chunks.append(nearest_edge_distances(lidar_edges, target, max_distance))
     values = np.concatenate([item for item in chunks if item.size]) \
@@ -449,14 +594,16 @@ def optimize_correction(points: np.ndarray, viewmats: np.ndarray, K: np.ndarray,
                         rotation_step_deg: float = 0.2,
                         edge_percentile: float = 95.0,
                         max_distance: int = 12,
-                        depth_support: dict | None = None
+                        depth_support: dict | None = None,
+                        contour_points_by_view: list[np.ndarray] | None = None
                         ) -> tuple[np.ndarray, dict, dict]:
     """Coordinate-search a camera-frame correction, coarse to fine."""
     parameters = np.zeros(6, dtype=np.float64)
     base_loss, before = alignment_objective(
         points, viewmats, K, images, parameters,
         edge_percentile=edge_percentile, max_distance=max_distance,
-        depth_support=depth_support)
+        depth_support=depth_support,
+        contour_points_by_view=contour_points_by_view)
     best_loss = base_loss
     reference = before['edge_points']
     edge_masks = [image_edges(image, edge_percentile) for image in images]
@@ -473,7 +620,8 @@ def optimize_correction(points: np.ndarray, viewmats: np.ndarray, K: np.ndarray,
                     max_distance=max_distance,
                     reference_edge_points=reference,
                     image_edge_masks=edge_masks,
-                    depth_support=depth_support)
+                    depth_support=depth_support,
+                    contour_points_by_view=contour_points_by_view)
                 if loss < best_loss:
                     parameters, best_loss = candidate, loss
         steps *= 0.5
@@ -481,7 +629,8 @@ def optimize_correction(points: np.ndarray, viewmats: np.ndarray, K: np.ndarray,
         points, viewmats, K, images, parameters,
         edge_percentile=edge_percentile, max_distance=max_distance,
         reference_edge_points=reference, image_edge_masks=edge_masks,
-        depth_support=depth_support)
+        depth_support=depth_support,
+        contour_points_by_view=contour_points_by_view)
     before['loss'] = base_loss
     after['loss'] = best_loss
     return parameters, before, after
@@ -567,7 +716,9 @@ def spatiotemporal_objective(
         edge_percentile: float = 95.0, max_distance: int = 12,
         reference_edge_points: int | None = None,
         image_edge_masks: list[np.ndarray] | None = None,
-        depth_support: dict | None = None) -> tuple[float, dict]:
+        depth_support: dict | None = None,
+        contour_points_by_view: list[np.ndarray] | None = None
+        ) -> tuple[float, dict]:
     """Evaluate a continuous-time pose recomposition against image edges."""
     try:
         viewmats = recompose_viewmats(
@@ -579,7 +730,8 @@ def spatiotemporal_objective(
         points, viewmats, K, images, np.zeros(6),
         edge_percentile=edge_percentile, max_distance=max_distance,
         reference_edge_points=reference_edge_points,
-        image_edge_masks=image_edge_masks, depth_support=depth_support)
+        image_edge_masks=image_edge_masks, depth_support=depth_support,
+        contour_points_by_view=contour_points_by_view)
 
 
 def optimize_spatiotemporal(
@@ -591,13 +743,16 @@ def optimize_spatiotemporal(
         max_translation: float = 0.1, max_rotation_deg: float = 2.0,
         edge_percentile: float = 95.0,
         max_distance: int = 12,
-        depth_support: dict | None = None) -> tuple[np.ndarray, dict, dict]:
+        depth_support: dict | None = None,
+        contour_points_by_view: list[np.ndarray] | None = None
+        ) -> tuple[np.ndarray, dict, dict]:
     """Bounded deterministic coordinate search over dt plus a local SE(3)."""
     parameters = np.zeros(7, dtype=np.float64)
     base_loss, before = spatiotemporal_objective(
         points, samples, stamps, body_T_camera, K, images, parameters,
         edge_percentile=edge_percentile, max_distance=max_distance,
-        depth_support=depth_support)
+        depth_support=depth_support,
+        contour_points_by_view=contour_points_by_view)
     reference = before['edge_points']
     edge_masks = [image_edges(image, edge_percentile) for image in images]
     best_loss = base_loss
@@ -621,7 +776,8 @@ def optimize_spatiotemporal(
                         max_distance=max_distance,
                         reference_edge_points=reference,
                         image_edge_masks=edge_masks,
-                        depth_support=depth_support)
+                        depth_support=depth_support,
+                        contour_points_by_view=contour_points_by_view)
                     if loss + 1e-12 < best_loss:
                         parameters, best_loss = candidate, loss
                         changed = True
@@ -630,7 +786,8 @@ def optimize_spatiotemporal(
         points, samples, stamps, body_T_camera, K, images, parameters,
         edge_percentile=edge_percentile, max_distance=max_distance,
         reference_edge_points=reference, image_edge_masks=edge_masks,
-        depth_support=depth_support)
+        depth_support=depth_support,
+        contour_points_by_view=contour_points_by_view)
     before['loss'] = base_loss
     after['loss'] = best_loss
     return parameters, before, after
@@ -649,7 +806,8 @@ def optimize_spatiotemporal_production(
         maximum_time_translation_correlation: float = 0.98,
         edge_percentile: float = 95.0,
         max_distance: int = 12,
-        depth_support: dict | None = None
+        depth_support: dict | None = None,
+        contour_points_by_view: list[np.ndarray] | None = None
         ) -> tuple[np.ndarray, dict, dict, dict]:
     """Optimize a pyramid and audit local identifiability before adoption."""
     if (not scales or any(not 0.0 < scale <= 1.0 for scale in scales) or
@@ -678,7 +836,8 @@ def optimize_spatiotemporal_production(
             points, samples, stamps, body_T_camera, level_K, level_images,
             reference_parameters, edge_percentile=edge_percentile,
             max_distance=max(2, int(round(max_distance * scale))),
-            image_edge_masks=edge_masks, depth_support=depth_support)
+            image_edge_masks=edge_masks, depth_support=depth_support,
+            contour_points_by_view=contour_points_by_view)
         reference_edges = reference_metrics['edge_points']
 
         def objective(candidate):
@@ -687,14 +846,16 @@ def optimize_spatiotemporal_production(
                 candidate, edge_percentile=edge_percentile,
                 max_distance=max(2, int(round(max_distance * scale))),
                 reference_edge_points=reference_edges,
-                image_edge_masks=edge_masks, depth_support=depth_support)
+                image_edge_masks=edge_masks, depth_support=depth_support,
+                contour_points_by_view=contour_points_by_view)
             return loss
         return objective
 
     base_loss, before = spatiotemporal_objective(
         points, samples, stamps, body_T_camera, K, images, parameters,
         edge_percentile=edge_percentile, max_distance=max_distance,
-        depth_support=depth_support)
+        depth_support=depth_support,
+        contour_points_by_view=contour_points_by_view)
     before['loss'] = base_loss
     for scale in scales:
         objective = level_objective(scale, np.zeros(7))
@@ -731,7 +892,8 @@ def optimize_spatiotemporal_production(
         points, samples, stamps, body_T_camera, K, images, parameters,
         edge_percentile=edge_percentile, max_distance=max_distance,
         reference_edge_points=before['edge_points'],
-        depth_support=depth_support)
+        depth_support=depth_support,
+        contour_points_by_view=contour_points_by_view)
     after['loss'] = final_loss
     audit_objective = level_objective(observability_scale, parameters)
     observability = stc.finite_difference_observability(
@@ -742,6 +904,7 @@ def optimize_spatiotemporal_production(
     report = {
         'mode': 'multi_resolution_production',
         'depth_support': depth_support,
+        'fixed_contours': contour_points_by_view is not None,
         'pyramid_scales': list(scales),
         'levels': levels,
         'initial_bounds_dt_s_xyz_m_rpy_rad': initial_bounds.tolist(),
@@ -875,6 +1038,14 @@ def main() -> int:
     parser.add_argument('--depth-support-absolute', type=float, default=0.10,
                         help='metre tolerance for same-surface support')
     parser.add_argument('--depth-support-relative', type=float, default=0.01)
+    parser.add_argument('--fixed-contours', action='store_true',
+                        help='extract full-density 3D depth contours once and '
+                             'reuse them throughout calibration')
+    parser.add_argument('--contour-association-distance', type=int, default=0,
+                        help='initial image-edge association radius; 0 keeps '
+                             'geometry-only contours and avoids pose bias')
+    parser.add_argument('--contour-max-points-per-view', type=int, default=50000)
+    parser.add_argument('--contour-min-points-per-view', type=int, default=500)
     parser.add_argument('--diagnostics-dir', type=Path,
                         help='write worst-view residual overlays and summary')
     parser.add_argument('--worst-views', type=int, default=10,
@@ -938,6 +1109,11 @@ def main() -> int:
             args.depth_support_min_neighbors < 1 or
             args.depth_support_absolute < 0.0 or
             args.depth_support_relative < 0.0 or
+            (args.contour_association_distance != 0 and
+             args.contour_association_distance < args.max_distance) or
+            args.contour_max_points_per_view < 1 or
+            args.contour_min_points_per_view < 1 or
+            args.contour_min_points_per_view > args.contour_max_points_per_view or
             not 0.0 <= args.minimum_supported_edge_fraction <= 1.0 or
             not 0.0 <= args.minimum_heldout_improvement < 1.0):
         raise SystemExit('stride, distance, rounds, and search steps must be > 0')
@@ -946,6 +1122,10 @@ def main() -> int:
     if args.production_calibration and not args.optimize_spatiotemporal:
         raise SystemExit('--production-calibration requires '
                          '--optimize-spatiotemporal')
+    if ((args.optimize_spatiotemporal or args.optimize_extrinsic) and
+            args.fixed_contours and args.contour_association_distance > 0):
+        raise SystemExit('image-associated fixed contours are diagnostic-only; '
+                         'calibration requires geometry-only association 0')
     try:
         pyramid_scales = tuple(float(item) for item in
                                args.pyramid_scales.split(','))
@@ -969,7 +1149,8 @@ def main() -> int:
             'relative': args.depth_support_relative,
         }
     import imageio.v3 as iio
-    points, _ = pcio.read_ply_xyz(args.pointcloud)
+    full_points, _ = pcio.read_ply_xyz(args.pointcloud)
+    points = full_points
     if args.max_points and len(points) > args.max_points:
         indices = np.linspace(
             0, len(points) - 1, args.max_points, dtype=np.int64)
@@ -979,6 +1160,25 @@ def main() -> int:
     selected = list(range(0, len(viewmats), args.view_stride))
     images = [np.asarray(iio.imread(dataset['image_paths'][index]))
               for index in selected]
+    contour_points_by_view = None
+    contour_report = None
+    if args.fixed_contours:
+        contour_points_by_view, contour_report = extract_fixed_contours(
+            full_points, viewmats[selected], dataset['K'], images,
+            edge_percentile=args.edge_percentile,
+            association_distance=args.contour_association_distance,
+            max_points_per_view=args.contour_max_points_per_view,
+            depth_support=depth_support)
+        insufficient = [
+            selected[ordinal]
+            for ordinal, bank in enumerate(contour_points_by_view)
+            if len(bank) < args.contour_min_points_per_view]
+        if insufficient:
+            raise SystemExit(
+                'fixed contour extraction has insufficient points in views: ' +
+                ','.join(str(index) for index in insufficient))
+    contour_by_index = (dict(zip(selected, contour_points_by_view))
+                        if contour_points_by_view is not None else {})
     optimization = None
     delta = np.eye(4)
     effective_viewmats = viewmats.copy()
@@ -1017,6 +1217,10 @@ def main() -> int:
         image_by_index = dict(zip(selected, images))
         train_images = [image_by_index[index] for index in train]
         heldout_images = [image_by_index[index] for index in heldout]
+        train_contours = ([contour_by_index[index] for index in train]
+                          if contour_points_by_view is not None else None)
+        heldout_contours = ([contour_by_index[index] for index in heldout]
+                            if contour_points_by_view is not None else None)
         production_report = None
         if args.production_calibration:
             (parameters, train_before, train_after,
@@ -1039,7 +1243,8 @@ def main() -> int:
                     args.maximum_time_translation_correlation),
                 edge_percentile=args.edge_percentile,
                 max_distance=args.max_distance,
-                depth_support=depth_support)
+                depth_support=depth_support,
+                contour_points_by_view=train_contours)
         else:
             parameters, train_before, train_after = optimize_spatiotemporal(
                 points, samples, stamps[train], body_T_camera, dataset['K'],
@@ -1052,19 +1257,22 @@ def main() -> int:
                 max_rotation_deg=args.max_rotation_deg,
                 edge_percentile=args.edge_percentile,
                 max_distance=args.max_distance,
-                depth_support=depth_support)
+                depth_support=depth_support,
+                contour_points_by_view=train_contours)
         zero = np.zeros(7)
         heldout_before_loss, heldout_before = spatiotemporal_objective(
             points, samples, stamps[heldout], body_T_camera, dataset['K'],
             heldout_images, zero, edge_percentile=args.edge_percentile,
-            max_distance=args.max_distance, depth_support=depth_support)
+            max_distance=args.max_distance, depth_support=depth_support,
+            contour_points_by_view=heldout_contours)
         heldout_after_loss, heldout_after = spatiotemporal_objective(
             points, samples, stamps[heldout], body_T_camera, dataset['K'],
             heldout_images, parameters,
             edge_percentile=args.edge_percentile,
             max_distance=args.max_distance,
             reference_edge_points=heldout_before['edge_points'],
-            depth_support=depth_support)
+            depth_support=depth_support,
+            contour_points_by_view=heldout_contours)
         heldout_before['loss'], heldout_after['loss'] = (
             heldout_before_loss, heldout_after_loss)
         accepted, rejection_reason = calibration_acceptance(
@@ -1073,6 +1281,8 @@ def main() -> int:
             minimum_heldout_improvement=args.minimum_heldout_improvement,
             minimum_supported_edge_fraction=(
                 args.minimum_supported_edge_fraction))
+        rejection_reasons = ([rejection_reason]
+                             if rejection_reason is not None else [])
         parameter_bounds = np.array([
             args.max_time_offset, args.max_translation,
             args.max_translation, args.max_translation,
@@ -1090,10 +1300,12 @@ def main() -> int:
             boundary_axes = production_report['boundary_axes']
             if boundary_axes:
                 accepted = False
-                rejection_reason = 'search_boundary_reached'
+                rejection_reasons.append('search_boundary_reached')
             if not production_report['observability']['observable']:
                 accepted = False
-                rejection_reason = 'calibration_not_observable'
+                rejection_reasons.append('calibration_not_observable')
+        rejection_reason = (rejection_reasons[-1]
+                            if rejection_reasons else None)
         if accepted:
             effective_viewmats = recompose_viewmats(
                 samples, stamps, body_T_camera, parameters)
@@ -1116,6 +1328,7 @@ def main() -> int:
             'train': {'before': train_before, 'after': train_after},
             'heldout': {'before': heldout_before, 'after': heldout_after},
             'rejection_reason': rejection_reason,
+            'rejection_reasons': rejection_reasons,
         }
     elif args.optimize_extrinsic:
         parameters, before, after = optimize_correction(
@@ -1125,7 +1338,8 @@ def main() -> int:
             rotation_step_deg=args.rotation_step_deg,
             edge_percentile=args.edge_percentile,
             max_distance=args.max_distance,
-            depth_support=depth_support)
+            depth_support=depth_support,
+            contour_points_by_view=contour_points_by_view)
         delta = correction_matrix(parameters)
         effective_viewmats = np.asarray(
             [delta @ viewmat for viewmat in viewmats])
@@ -1136,11 +1350,13 @@ def main() -> int:
             'before': before, 'after': after,
         }
     per_view = []
-    for index, image in zip(selected, images):
+    for ordinal, (index, image) in enumerate(zip(selected, images)):
         score = score_view(
             points, effective_viewmats[index], dataset['K'], image,
             edge_percentile=args.edge_percentile,
-            max_distance=args.max_distance, depth_support=depth_support)
+            max_distance=args.max_distance, depth_support=depth_support,
+            contour_points=(contour_points_by_view[ordinal]
+                            if contour_points_by_view is not None else None))
         score['view_index'] = index
         per_view.append(score)
     valid = [item for item in per_view if item['edge_points'] > 0]
@@ -1150,8 +1366,10 @@ def main() -> int:
     report = {'pointcloud': str(args.pointcloud.resolve()),
               'transforms': str(args.transforms.resolve()),
               'points_scored': len(points),
+              'full_density_points': len(full_points),
               'views_scored': len(valid), 'edge_points': int(weights.sum()),
-              'depth_support': depth_support}
+              'depth_support': depth_support,
+              'fixed_contours': contour_report}
     raw_edges = sum(item['raw_edge_points'] for item in valid)
     report['raw_edge_points'] = raw_edges
     report['supported_edge_fraction'] = float(
@@ -1182,7 +1400,8 @@ def main() -> int:
             args.diagnostics_dir, points, effective_viewmats, dataset['K'],
             selected, images, per_view, worst_views=args.worst_views,
             edge_percentile=args.edge_percentile,
-            max_distance=args.max_distance, depth_support=depth_support)
+            max_distance=args.max_distance, depth_support=depth_support,
+            contour_points_by_view=contour_points_by_view)
         report['diagnostics']['directory'] = str(args.diagnostics_dir.resolve())
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(json.dumps(report, indent=2) + '\n')

--- a/scripts/evaluate_lidar_camera_alignment.py
+++ b/scripts/evaluate_lidar_camera_alignment.py
@@ -124,6 +124,43 @@ def nearest_edge_distances(query: np.ndarray, target: np.ndarray,
     return distances
 
 
+def nearest_edge_correspondences(query: np.ndarray, target: np.ndarray,
+                                 max_distance: int = 12) -> dict:
+    """Return bounded nearest-edge distances and signed target offsets.
+
+    ``dx_px`` and ``dy_px`` point from each LiDAR depth-edge pixel to the
+    matched image-edge pixel. Unmatched pixels retain the historical
+    ``max_distance + 1`` distance and have null-direction sentinels encoded as
+    NaN. The deterministic offset ordering makes diagnostics reproducible.
+    """
+    query_y, query_x = np.nonzero(query)
+    if query_y.size == 0:
+        empty = np.zeros(0, dtype=np.float32)
+        return {'query_y': query_y, 'query_x': query_x,
+                'distance_px': empty, 'dy_px': empty, 'dx_px': empty}
+    distances = np.full(query_y.size, float(max_distance + 1), dtype=np.float32)
+    match_dy = np.full(query_y.size, np.nan, dtype=np.float32)
+    match_dx = np.full(query_y.size, np.nan, dtype=np.float32)
+    height, width = target.shape
+    offsets = [(dy, dx) for dy in range(-max_distance, max_distance + 1)
+               for dx in range(-max_distance, max_distance + 1)
+               if dy * dy + dx * dx <= max_distance * max_distance]
+    offsets.sort(key=lambda item: item[0] * item[0] + item[1] * item[1])
+    for dy, dx in offsets:
+        distance = float(np.hypot(dy, dx))
+        pending = distances > distance
+        y = query_y + dy
+        x = query_x + dx
+        inside = pending & (y >= 0) & (y < height) & (x >= 0) & (x < width)
+        hit = np.zeros(query_y.size, dtype=bool)
+        hit[inside] = target[y[inside], x[inside]]
+        distances[hit] = distance
+        match_dy[hit] = dy
+        match_dx[hit] = dx
+    return {'query_y': query_y, 'query_x': query_x,
+            'distance_px': distances, 'dy_px': match_dy, 'dx_px': match_dx}
+
+
 def projected_depth(points: np.ndarray, viewmat: np.ndarray, K: np.ndarray,
                     width: int, height: int) -> np.ndarray:
     """Project one view into an image containing sparse nearest depths."""
@@ -140,16 +177,152 @@ def score_view(points: np.ndarray, viewmat: np.ndarray, K: np.ndarray,
     """Score one camera view and return pixel-distance alignment metrics."""
     height, width = image.shape[:2]
     lidar_edges = depth_edges(projected_depth(points, viewmat, K, width, height))
-    distances = nearest_edge_distances(
+    correspondences = nearest_edge_correspondences(
         lidar_edges, image_edges(image, edge_percentile), max_distance)
+    distances = correspondences['distance_px']
     if distances.size == 0:
         return {'edge_points': 0, 'median_px': None, 'p90_px': None,
-                'inlier_2px': None, 'out_of_range_fraction': None}
+                'inlier_2px': None, 'out_of_range_fraction': None,
+                'matched_edge_points': 0, 'median_dx_px': None,
+                'median_dy_px': None, 'mean_dx_px': None,
+                'mean_dy_px': None, 'direction_coherence': None}
+    matched = np.isfinite(correspondences['dx_px'])
+    dx = correspondences['dx_px'][matched]
+    dy = correspondences['dy_px'][matched]
+    mean_dx = float(np.mean(dx)) if np.any(matched) else None
+    mean_dy = float(np.mean(dy)) if np.any(matched) else None
+    mean_radius = float(np.mean(np.hypot(dx, dy))) if np.any(matched) else None
     return {'edge_points': int(distances.size),
             'median_px': float(np.median(distances)),
             'p90_px': float(np.percentile(distances, 90)),
             'inlier_2px': float(np.mean(distances <= 2.0)),
-            'out_of_range_fraction': float(np.mean(distances > max_distance))}
+            'out_of_range_fraction': float(np.mean(distances > max_distance)),
+            'matched_edge_points': int(np.sum(matched)),
+            'median_dx_px': (float(np.median(correspondences['dx_px'][matched]))
+                             if np.any(matched) else None),
+            'median_dy_px': (float(np.median(correspondences['dy_px'][matched]))
+                             if np.any(matched) else None),
+            'mean_dx_px': mean_dx, 'mean_dy_px': mean_dy,
+            'direction_coherence': (float(np.hypot(mean_dx, mean_dy) /
+                                          max(mean_radius, 1e-12))
+                                    if mean_radius is not None else None)}
+
+
+def render_residual_overlay(points: np.ndarray, viewmat: np.ndarray,
+                            K: np.ndarray, image: np.ndarray, *,
+                            edge_percentile: float = 95.0,
+                            max_distance: int = 12) -> np.ndarray:
+    """Overlay image edges and colour-coded LiDAR edge residuals."""
+    source = np.asarray(image)
+    if source.ndim == 2:
+        source = np.repeat(source[:, :, None], 3, axis=2)
+    source = source[:, :, :3]
+    if source.dtype != np.uint8:
+        source = np.clip(source, 0, 255).astype(np.uint8)
+    output = np.clip(source.astype(np.float32) * 0.55, 0, 255).astype(np.uint8)
+    height, width = source.shape[:2]
+    camera_edges = image_edges(source, edge_percentile)
+    lidar_edges = depth_edges(projected_depth(points, viewmat, K, width, height))
+    residuals = nearest_edge_correspondences(
+        lidar_edges, camera_edges, max_distance)
+
+    # Camera edges are green. LiDAR edges run cyan -> yellow -> red as the
+    # residual grows; saturated/unmatched edges are magenta.
+    output[camera_edges] = [40, 220, 40]
+    if residuals['distance_px'].size:
+        ratio = np.minimum(residuals['distance_px'], max_distance) / max_distance
+        colours = np.stack([
+            255.0 * ratio,
+            255.0 * (1.0 - np.abs(2.0 * ratio - 1.0)),
+            255.0 * (1.0 - ratio),
+        ], axis=1).astype(np.uint8)
+        unmatched = residuals['distance_px'] > max_distance
+        colours[unmatched] = [255, 0, 255]
+        y, x = residuals['query_y'], residuals['query_x']
+        for dy, dx in ((0, 0), (-1, 0), (1, 0), (0, -1), (0, 1)):
+            yy, xx = y + dy, x + dx
+            inside = (yy >= 0) & (yy < height) & (xx >= 0) & (xx < width)
+            output[yy[inside], xx[inside]] = colours[inside]
+    return output
+
+
+def write_residual_diagnostics(directory: Path, points: np.ndarray,
+                               viewmats: np.ndarray, K: np.ndarray,
+                               selected: list[int], images: list[np.ndarray],
+                               per_view: list[dict], *, worst_views: int,
+                               edge_percentile: float,
+                               max_distance: int) -> dict:
+    """Write deterministic worst-view overlays and a compact contact sheet."""
+    import imageio.v3 as iio
+
+    directory = Path(directory)
+    directory.mkdir(parents=True, exist_ok=True)
+    image_by_index = dict(zip(selected, images))
+    valid = [item for item in per_view if item['edge_points'] > 0]
+    ranked = sorted(
+        valid,
+        key=lambda item: (item['out_of_range_fraction'], item['p90_px'],
+                          item['median_px'], -item['view_index']),
+        reverse=True)[:worst_views]
+    tiles = []
+    entries = []
+    for rank, metrics in enumerate(ranked, 1):
+        index = metrics['view_index']
+        overlay = render_residual_overlay(
+            points, viewmats[index], K, image_by_index[index],
+            edge_percentile=edge_percentile, max_distance=max_distance)
+        filename = f'worst_{rank:02d}_view_{index:05d}.png'
+        path = directory / filename
+        iio.imwrite(path, overlay)
+        tile_width = min(400, overlay.shape[1])
+        step = max(1, int(np.ceil(overlay.shape[1] / tile_width)))
+        tiles.append(overlay[::step, ::step])
+        entries.append({'rank': rank, 'view_index': index,
+                        'overlay': filename, **metrics})
+
+    contact_name = None
+    if tiles:
+        columns = min(2, len(tiles))
+        tile_height = max(tile.shape[0] for tile in tiles)
+        tile_width = max(tile.shape[1] for tile in tiles)
+        rows = (len(tiles) + columns - 1) // columns
+        contact = np.zeros((rows * tile_height, columns * tile_width, 3),
+                           dtype=np.uint8)
+        for ordinal, tile in enumerate(tiles):
+            row, column = divmod(ordinal, columns)
+            contact[row * tile_height:row * tile_height + tile.shape[0],
+                    column * tile_width:column * tile_width + tile.shape[1]] = tile
+        contact_name = 'worst_views_contact_sheet.png'
+        iio.imwrite(directory / contact_name, contact)
+
+    matched = [item for item in valid if item['mean_dx_px'] is not None]
+    direction = None
+    if matched:
+        weights = np.asarray([item['matched_edge_points'] for item in matched],
+                             dtype=float)
+        direction = {
+            'weighted_mean_dx_px': float(np.average(
+                [item['mean_dx_px'] for item in matched], weights=weights)),
+            'weighted_mean_dy_px': float(np.average(
+                [item['mean_dy_px'] for item in matched], weights=weights)),
+            'view_mean_dx_std_px': float(np.std(
+                [item['mean_dx_px'] for item in matched])),
+            'view_mean_dy_std_px': float(np.std(
+                [item['mean_dy_px'] for item in matched])),
+            'weighted_direction_coherence': float(np.average(
+                [item['direction_coherence'] for item in matched],
+                weights=weights)),
+        }
+    result = {'legend': {'camera_edges': 'green',
+                         'aligned_lidar_edges': 'cyan',
+                         'mid_residual_lidar_edges': 'yellow',
+                         'max_residual_lidar_edges': 'red',
+                         'unmatched_lidar_edges': 'magenta'},
+              'ranking': 'out_of_range_fraction,p90_px,median_px',
+              'direction_summary': direction,
+              'contact_sheet': contact_name, 'worst_views': entries}
+    (directory / 'diagnostics.json').write_text(json.dumps(result, indent=2) + '\n')
+    return result
 
 
 def correction_matrix(parameters: np.ndarray) -> np.ndarray:
@@ -602,6 +775,10 @@ def main() -> int:
                         help='retain this percentile of nonzero image gradients; '
                              '95 focuses the metric on structural edges')
     parser.add_argument('--max-distance', type=int, default=12)
+    parser.add_argument('--diagnostics-dir', type=Path,
+                        help='write worst-view residual overlays and summary')
+    parser.add_argument('--worst-views', type=int, default=10,
+                        help='number of residual overlays to write')
     optimization_mode = parser.add_mutually_exclusive_group()
     optimization_mode.add_argument('--optimize-extrinsic', action='store_true')
     optimization_mode.add_argument('--optimize-spatiotemporal', action='store_true')
@@ -652,6 +829,7 @@ def main() -> int:
             args.minimum_curvature <= 0.0 or args.maximum_condition <= 1.0 or
             not 0.0 <= args.maximum_time_translation_correlation < 1.0 or
             args.minimum_edge_points < 1 or args.max_points < 0 or
+            args.worst_views < 1 or
             not 0.0 <= args.minimum_heldout_improvement < 1.0):
         raise SystemExit('stride, distance, rounds, and search steps must be > 0')
     if args.optimize_spatiotemporal and args.trajectory is None:
@@ -865,6 +1043,13 @@ def main() -> int:
     elif args.corrected_transforms_out is not None:
         raise SystemExit('--corrected-transforms-out requires an optimization mode')
     report['per_view'] = per_view
+    if args.diagnostics_dir is not None:
+        report['diagnostics'] = write_residual_diagnostics(
+            args.diagnostics_dir, points, effective_viewmats, dataset['K'],
+            selected, images, per_view, worst_views=args.worst_views,
+            edge_percentile=args.edge_percentile,
+            max_distance=args.max_distance)
+        report['diagnostics']['directory'] = str(args.diagnostics_dir.resolve())
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(json.dumps(report, indent=2) + '\n')
     print(json.dumps({key: value for key, value in report.items()

--- a/scripts/evaluate_lidar_camera_alignment.py
+++ b/scripts/evaluate_lidar_camera_alignment.py
@@ -54,8 +54,9 @@ import spatiotemporal_calibration as stc  # noqa: E402
 import train_gsplat as tg  # noqa: E402
 
 
-def image_edges(image: np.ndarray, percentile: float = 95.0) -> np.ndarray:
-    """Return a strong grayscale-gradient edge mask without OpenCV/SciPy."""
+def image_edge_field(image: np.ndarray, percentile: float = 95.0
+                     ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return strong edges and unit image-gradient normal components."""
     array = np.asarray(image, dtype=np.float32)
     if array.ndim == 3:
         array = array[:, :, :3] @ np.array([0.299, 0.587, 0.114])
@@ -65,13 +66,22 @@ def image_edges(image: np.ndarray, percentile: float = 95.0) -> np.ndarray:
         raise ValueError('percentile must be between 0 and 100')
     gx = np.zeros_like(array)
     gy = np.zeros_like(array)
-    gx[:, 1:-1] = np.abs(array[:, 2:] - array[:, :-2])
-    gy[1:-1, :] = np.abs(array[2:, :] - array[:-2, :])
+    gx[:, 1:-1] = array[:, 2:] - array[:, :-2]
+    gy[1:-1, :] = array[2:, :] - array[:-2, :]
     magnitude = np.hypot(gx, gy)
     nonzero = magnitude[magnitude > 0.0]
     if nonzero.size == 0:
-        return np.zeros(array.shape, dtype=bool)
-    return magnitude >= np.percentile(nonzero, percentile)
+        empty = np.zeros(array.shape, dtype=np.float32)
+        return np.zeros(array.shape, dtype=bool), empty, empty
+    edges = magnitude >= np.percentile(nonzero, percentile)
+    denominator = np.maximum(magnitude, 1e-12)
+    return (edges, (gx / denominator).astype(np.float32),
+            (gy / denominator).astype(np.float32))
+
+
+def image_edges(image: np.ndarray, percentile: float = 95.0) -> np.ndarray:
+    """Return a strong grayscale-gradient edge mask without OpenCV/SciPy."""
+    return image_edge_field(image, percentile)[0]
 
 
 def depth_edges(depth: np.ndarray, absolute: float = 0.25,
@@ -98,6 +108,39 @@ def depth_edges(depth: np.ndarray, absolute: float = 0.25,
     edges[:-1, :] |= vertical
     edges[1:, :] |= vertical
     return edges
+
+
+def depth_edge_normal_field(depth: np.ndarray, absolute: float = 0.25,
+                            relative: float = 0.02
+                            ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return depth edges and unsigned discontinuity-normal components."""
+    values = np.asarray(depth, dtype=np.float32)
+    valid = np.isfinite(values) & (values > 0.0)
+    nx = np.zeros(values.shape, dtype=np.float32)
+    ny = np.zeros(values.shape, dtype=np.float32)
+    with np.errstate(invalid='ignore'):
+        horizontal = (valid[:, :-1] & valid[:, 1:] &
+                      (np.abs(values[:, :-1] - values[:, 1:]) >
+                       absolute + relative * np.minimum(
+                           values[:, :-1], values[:, 1:])))
+        vertical = (valid[:-1, :] & valid[1:, :] &
+                    (np.abs(values[:-1, :] - values[1:, :]) >
+                     absolute + relative * np.minimum(
+                         values[:-1, :], values[1:, :])))
+    with np.errstate(invalid='ignore'):
+        horizontal_sign = np.where(
+            horizontal, np.sign(values[:, 1:] - values[:, :-1]), 0.0)
+        vertical_sign = np.where(
+            vertical, np.sign(values[1:, :] - values[:-1, :]), 0.0)
+    nx[:, :-1] += horizontal_sign
+    nx[:, 1:] += horizontal_sign
+    ny[:-1, :] += vertical_sign
+    ny[1:, :] += vertical_sign
+    magnitude = np.hypot(nx, ny)
+    supported = magnitude > 0.0
+    nx[supported] /= magnitude[supported]
+    ny[supported] /= magnitude[supported]
+    return supported, nx, ny
 
 
 def surface_support_mask(depth: np.ndarray, *, radius: int = 2,
@@ -211,6 +254,48 @@ def nearest_edge_correspondences(query: np.ndarray, target: np.ndarray,
             'distance_px': distances, 'dy_px': match_dy, 'dx_px': match_dx}
 
 
+def nearest_oriented_edge_correspondences(
+        query: np.ndarray, target: np.ndarray,
+        query_nx: np.ndarray, query_ny: np.ndarray,
+        target_nx: np.ndarray, target_ny: np.ndarray, *,
+        max_distance: int = 12, max_angle_deg: float = 30.0) -> dict:
+    """Match nearest edges whose unoriented normal axes agree."""
+    query_y, query_x = np.nonzero(query)
+    if query_y.size == 0:
+        empty = np.zeros(0, dtype=np.float32)
+        return {'query_y': query_y, 'query_x': query_x,
+                'distance_px': empty, 'dy_px': empty, 'dx_px': empty}
+    distances = np.full(query_y.size, float(max_distance + 1), dtype=np.float32)
+    match_dy = np.full(query_y.size, np.nan, dtype=np.float32)
+    match_dx = np.full(query_y.size, np.nan, dtype=np.float32)
+    qnx, qny = query_nx[query_y, query_x], query_ny[query_y, query_x]
+    valid_query_normal = np.hypot(qnx, qny) > 0.5
+    cosine_limit = float(np.cos(np.deg2rad(max_angle_deg)))
+    height, width = target.shape
+    offsets = [(dy, dx) for dy in range(-max_distance, max_distance + 1)
+               for dx in range(-max_distance, max_distance + 1)
+               if dy * dy + dx * dx <= max_distance * max_distance]
+    offsets.sort(key=lambda item: item[0] * item[0] + item[1] * item[1])
+    for dy, dx in offsets:
+        distance = float(np.hypot(dy, dx))
+        pending = (distances > distance) & valid_query_normal
+        y, x = query_y + dy, query_x + dx
+        inside = pending & (y >= 0) & (y < height) & (x >= 0) & (x < width)
+        hit = np.zeros(query_y.size, dtype=bool)
+        if np.any(inside):
+            indices = np.flatnonzero(inside)
+            edge_hit = target[y[indices], x[indices]]
+            dot = np.abs(
+                qnx[indices] * target_nx[y[indices], x[indices]] +
+                qny[indices] * target_ny[y[indices], x[indices]])
+            hit[indices] = edge_hit & (dot >= cosine_limit)
+        distances[hit] = distance
+        match_dy[hit] = dy
+        match_dx[hit] = dx
+    return {'query_y': query_y, 'query_x': query_x,
+            'distance_px': distances, 'dy_px': match_dy, 'dx_px': match_dx}
+
+
 def projected_depth(points: np.ndarray, viewmat: np.ndarray, K: np.ndarray,
                     width: int, height: int) -> np.ndarray:
     """Project one view into an image containing sparse nearest depths."""
@@ -257,10 +342,20 @@ def projected_depth_and_ids(points: np.ndarray, viewmat: np.ndarray,
 def projected_point_mask(points: np.ndarray, viewmat: np.ndarray, K: np.ndarray,
                          width: int, height: int) -> np.ndarray:
     """Project fixed 3D contour points into a deterministic binary mask."""
-    points = np.asarray(points, dtype=np.float64)
+    return projected_contour_field(points, viewmat, K, width, height)[0]
+
+
+def projected_contour_field(contours: np.ndarray, viewmat: np.ndarray,
+                            K: np.ndarray, width: int, height: int
+                            ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Project fixed xyz+normal contours into a mask and normal field."""
+    contours = np.asarray(contours, dtype=np.float64)
     mask = np.zeros((height, width), dtype=bool)
-    if points.size == 0:
-        return mask
+    normal_x = np.zeros((height, width), dtype=np.float32)
+    normal_y = np.zeros((height, width), dtype=np.float32)
+    if contours.size == 0:
+        return mask, normal_x, normal_y
+    points = contours[:, :3]
     camera = points @ viewmat[:3, :3].T + viewmat[:3, 3]
     depth = camera[:, 2]
     with np.errstate(divide='ignore', invalid='ignore'):
@@ -273,7 +368,16 @@ def projected_point_mask(points: np.ndarray, viewmat: np.ndarray, K: np.ndarray,
     inside = ((depth > 1e-6) & (ui >= 0) & (ui < width) &
               (vi >= 0) & (vi < height))
     mask[vi[inside], ui[inside]] = True
-    return mask
+    if contours.shape[1] >= 5:
+        pixels = vi[inside] * width + ui[inside]
+        flat_x, flat_y = normal_x.reshape(-1), normal_y.reshape(-1)
+        np.add.at(flat_x, pixels, contours[inside, 3].astype(np.float32))
+        np.add.at(flat_y, pixels, contours[inside, 4].astype(np.float32))
+        magnitude = np.hypot(normal_x, normal_y)
+        valid = magnitude > 1e-6
+        normal_x[valid] /= magnitude[valid]
+        normal_y[valid] /= magnitude[valid]
+    return mask, normal_x, normal_y
 
 
 def extract_fixed_contours(points: np.ndarray, viewmats: np.ndarray,
@@ -291,9 +395,13 @@ def extract_fixed_contours(points: np.ndarray, viewmats: np.ndarray,
         depth, point_ids = projected_depth_and_ids(
             points, viewmat, K, width, height)
         lidar_edges, raw_edges = supported_depth_edges(depth, depth_support)
+        _, depth_nx, depth_ny = depth_edge_normal_field(depth)
         edge_ids = point_ids[lidar_edges]
+        edge_normals = np.stack(
+            [depth_nx[lidar_edges], depth_ny[lidar_edges]], axis=1)
         valid_ids = edge_ids >= 0
         edge_ids = edge_ids[valid_ids]
+        edge_normals = edge_normals[valid_ids]
         query = np.zeros_like(lidar_edges)
         query[lidar_edges] = valid_ids
         if association_distance > 0:
@@ -304,17 +412,23 @@ def extract_fixed_contours(points: np.ndarray, viewmats: np.ndarray,
         else:
             associated = np.ones(len(edge_ids), dtype=bool)
         selected_ids = edge_ids[associated]
+        selected_normals = edge_normals[associated]
         # Preserve row-major image order before deterministic thinning so the
         # cap remains spatially distributed instead of following PLY point ID.
         _, first_occurrence = np.unique(selected_ids, return_index=True)
-        selected_ids = selected_ids[np.sort(first_occurrence)]
+        first_occurrence = np.sort(first_occurrence)
+        selected_ids = selected_ids[first_occurrence]
+        selected_normals = selected_normals[first_occurrence]
         before_cap = len(selected_ids)
         if len(selected_ids) > max_points_per_view:
             indices = np.linspace(
                 0, len(selected_ids) - 1, max_points_per_view,
                 dtype=np.int64)
             selected_ids = selected_ids[indices]
-        banks.append(np.asarray(points[selected_ids], dtype=np.float64))
+            selected_normals = selected_normals[indices]
+        banks.append(np.column_stack([
+            np.asarray(points[selected_ids], dtype=np.float64),
+            selected_normals.astype(np.float64)]))
         per_view.append({
             'ordinal': ordinal,
             'raw_depth_edge_pixels': raw_edges,
@@ -340,18 +454,29 @@ def score_view(points: np.ndarray, viewmat: np.ndarray, K: np.ndarray,
                image: np.ndarray, *, edge_percentile: float = 95.0,
                max_distance: int = 12,
                depth_support: dict | None = None,
-               contour_points: np.ndarray | None = None) -> dict:
+               contour_points: np.ndarray | None = None,
+               orientation_max_angle_deg: float = 0.0) -> dict:
     """Score one camera view and return pixel-distance alignment metrics."""
     height, width = image.shape[:2]
     if contour_points is None:
+        depth = projected_depth(points, viewmat, K, width, height)
         lidar_edges, raw_edge_points = supported_depth_edges(
-            projected_depth(points, viewmat, K, width, height), depth_support)
+            depth, depth_support)
+        _, query_nx, query_ny = depth_edge_normal_field(depth)
     else:
-        lidar_edges = projected_point_mask(
+        lidar_edges, query_nx, query_ny = projected_contour_field(
             contour_points, viewmat, K, width, height)
         raw_edge_points = len(contour_points)
-    correspondences = nearest_edge_correspondences(
-        lidar_edges, image_edges(image, edge_percentile), max_distance)
+    image_edge_mask, target_nx, target_ny = image_edge_field(
+        image, edge_percentile)
+    if orientation_max_angle_deg > 0.0:
+        correspondences = nearest_oriented_edge_correspondences(
+            lidar_edges, image_edge_mask, query_nx, query_ny,
+            target_nx, target_ny, max_distance=max_distance,
+            max_angle_deg=orientation_max_angle_deg)
+    else:
+        correspondences = nearest_edge_correspondences(
+            lidar_edges, image_edge_mask, max_distance)
     distances = correspondences['distance_px']
     if distances.size == 0:
         return {'edge_points': 0, 'raw_edge_points': raw_edge_points,
@@ -383,7 +508,8 @@ def score_view(points: np.ndarray, viewmat: np.ndarray, K: np.ndarray,
             'mean_dx_px': mean_dx, 'mean_dy_px': mean_dy,
             'direction_coherence': (float(np.hypot(mean_dx, mean_dy) /
                                           max(mean_radius, 1e-12))
-                                    if mean_radius is not None else None)}
+                                    if mean_radius is not None else None),
+            'orientation_max_angle_deg': orientation_max_angle_deg}
 
 
 def render_residual_overlay(points: np.ndarray, viewmat: np.ndarray,
@@ -391,7 +517,8 @@ def render_residual_overlay(points: np.ndarray, viewmat: np.ndarray,
                             edge_percentile: float = 95.0,
                             max_distance: int = 12,
                             depth_support: dict | None = None,
-                            contour_points: np.ndarray | None = None
+                            contour_points: np.ndarray | None = None,
+                            orientation_max_angle_deg: float = 0.0
                             ) -> np.ndarray:
     """Overlay image edges and colour-coded LiDAR edge residuals."""
     source = np.asarray(image)
@@ -402,15 +529,23 @@ def render_residual_overlay(points: np.ndarray, viewmat: np.ndarray,
         source = np.clip(source, 0, 255).astype(np.uint8)
     output = np.clip(source.astype(np.float32) * 0.55, 0, 255).astype(np.uint8)
     height, width = source.shape[:2]
-    camera_edges = image_edges(source, edge_percentile)
+    camera_edges, target_nx, target_ny = image_edge_field(
+        source, edge_percentile)
     if contour_points is None:
-        lidar_edges, _ = supported_depth_edges(
-            projected_depth(points, viewmat, K, width, height), depth_support)
+        depth = projected_depth(points, viewmat, K, width, height)
+        lidar_edges, _ = supported_depth_edges(depth, depth_support)
+        _, query_nx, query_ny = depth_edge_normal_field(depth)
     else:
-        lidar_edges = projected_point_mask(
+        lidar_edges, query_nx, query_ny = projected_contour_field(
             contour_points, viewmat, K, width, height)
-    residuals = nearest_edge_correspondences(
-        lidar_edges, camera_edges, max_distance)
+    if orientation_max_angle_deg > 0.0:
+        residuals = nearest_oriented_edge_correspondences(
+            lidar_edges, camera_edges, query_nx, query_ny,
+            target_nx, target_ny, max_distance=max_distance,
+            max_angle_deg=orientation_max_angle_deg)
+    else:
+        residuals = nearest_edge_correspondences(
+            lidar_edges, camera_edges, max_distance)
 
     # Camera edges are green. LiDAR edges run cyan -> yellow -> red as the
     # residual grows; saturated/unmatched edges are magenta.
@@ -439,7 +574,8 @@ def write_residual_diagnostics(directory: Path, points: np.ndarray,
                                edge_percentile: float,
                                max_distance: int,
                                depth_support: dict | None = None,
-                               contour_points_by_view: list[np.ndarray] | None = None
+                               contour_points_by_view: list[np.ndarray] | None = None,
+                               orientation_max_angle_deg: float = 0.0
                                ) -> dict:
     """Write deterministic worst-view overlays and a compact contact sheet."""
     import imageio.v3 as iio
@@ -463,7 +599,8 @@ def write_residual_diagnostics(directory: Path, points: np.ndarray,
             points, viewmats[index], K, image_by_index[index],
             edge_percentile=edge_percentile, max_distance=max_distance,
             depth_support=depth_support,
-            contour_points=contour_by_index.get(index))
+            contour_points=contour_by_index.get(index),
+            orientation_max_angle_deg=orientation_max_angle_deg)
         filename = f'worst_{rank:02d}_view_{index:05d}.png'
         path = directory / filename
         iio.imwrite(path, overlay)
@@ -514,6 +651,7 @@ def write_residual_diagnostics(directory: Path, points: np.ndarray,
               'ranking': 'out_of_range_fraction,p90_px,median_px',
               'depth_support': depth_support,
               'fixed_contours': contour_points_by_view is not None,
+              'orientation_max_angle_deg': orientation_max_angle_deg,
               'direction_summary': direction,
               'contact_sheet': contact_name, 'worst_views': entries}
     (directory / 'diagnostics.json').write_text(json.dumps(result, indent=2) + '\n')
@@ -542,7 +680,8 @@ def alignment_objective(points: np.ndarray, viewmats: np.ndarray,
                         reference_edge_points: int | None = None,
                         image_edge_masks: list[np.ndarray] | None = None,
                         depth_support: dict | None = None,
-                        contour_points_by_view: list[np.ndarray] | None = None
+                        contour_points_by_view: list[np.ndarray] | None = None,
+                        orientation_max_angle_deg: float = 0.0
                         ) -> tuple[float, dict]:
     """Return coverage-guarded mean edge distance for one SE(3) correction."""
     if (contour_points_by_view is not None and
@@ -551,7 +690,9 @@ def alignment_objective(points: np.ndarray, viewmats: np.ndarray,
     delta = correction_matrix(parameters)
     chunks = []
     targets = (image_edge_masks if image_edge_masks is not None else
-               [image_edges(image, edge_percentile) for image in images])
+               [(image_edge_field(image, edge_percentile)
+                 if orientation_max_angle_deg > 0.0 else
+                 image_edges(image, edge_percentile)) for image in images])
     raw_edge_points = 0
     contours = (contour_points_by_view if contour_points_by_view is not None
                 else [None] * len(images))
@@ -559,14 +700,25 @@ def alignment_objective(points: np.ndarray, viewmats: np.ndarray,
             viewmats, images, targets, contours):
         height, width = image.shape[:2]
         if contour_points is None:
-            lidar_edges, raw_count = supported_depth_edges(projected_depth(
-                points, delta @ viewmat, K, width, height), depth_support)
+            depth = projected_depth(
+                points, delta @ viewmat, K, width, height)
+            lidar_edges, raw_count = supported_depth_edges(
+                depth, depth_support)
+            _, query_nx, query_ny = depth_edge_normal_field(depth)
         else:
-            lidar_edges = projected_point_mask(
+            lidar_edges, query_nx, query_ny = projected_contour_field(
                 contour_points, delta @ viewmat, K, width, height)
             raw_count = len(contour_points)
         raw_edge_points += raw_count
-        chunks.append(nearest_edge_distances(lidar_edges, target, max_distance))
+        if orientation_max_angle_deg > 0.0:
+            target_mask, target_nx, target_ny = target
+            chunks.append(nearest_oriented_edge_correspondences(
+                lidar_edges, target_mask, query_nx, query_ny,
+                target_nx, target_ny, max_distance=max_distance,
+                max_angle_deg=orientation_max_angle_deg)['distance_px'])
+        else:
+            chunks.append(nearest_edge_distances(
+                lidar_edges, target, max_distance))
     values = np.concatenate([item for item in chunks if item.size]) \
         if any(item.size for item in chunks) else np.zeros(0, np.float32)
     if not values.size:
@@ -595,7 +747,8 @@ def optimize_correction(points: np.ndarray, viewmats: np.ndarray, K: np.ndarray,
                         edge_percentile: float = 95.0,
                         max_distance: int = 12,
                         depth_support: dict | None = None,
-                        contour_points_by_view: list[np.ndarray] | None = None
+                        contour_points_by_view: list[np.ndarray] | None = None,
+                        orientation_max_angle_deg: float = 0.0
                         ) -> tuple[np.ndarray, dict, dict]:
     """Coordinate-search a camera-frame correction, coarse to fine."""
     parameters = np.zeros(6, dtype=np.float64)
@@ -603,10 +756,13 @@ def optimize_correction(points: np.ndarray, viewmats: np.ndarray, K: np.ndarray,
         points, viewmats, K, images, parameters,
         edge_percentile=edge_percentile, max_distance=max_distance,
         depth_support=depth_support,
-        contour_points_by_view=contour_points_by_view)
+        contour_points_by_view=contour_points_by_view,
+        orientation_max_angle_deg=orientation_max_angle_deg)
     best_loss = base_loss
     reference = before['edge_points']
-    edge_masks = [image_edges(image, edge_percentile) for image in images]
+    edge_masks = [(image_edge_field(image, edge_percentile)
+                   if orientation_max_angle_deg > 0.0 else
+                   image_edges(image, edge_percentile)) for image in images]
     steps = np.array([translation_step] * 3 +
                      [np.deg2rad(rotation_step_deg)] * 3)
     for _ in range(rounds):
@@ -621,7 +777,8 @@ def optimize_correction(points: np.ndarray, viewmats: np.ndarray, K: np.ndarray,
                     reference_edge_points=reference,
                     image_edge_masks=edge_masks,
                     depth_support=depth_support,
-                    contour_points_by_view=contour_points_by_view)
+                    contour_points_by_view=contour_points_by_view,
+                    orientation_max_angle_deg=orientation_max_angle_deg)
                 if loss < best_loss:
                     parameters, best_loss = candidate, loss
         steps *= 0.5
@@ -630,7 +787,8 @@ def optimize_correction(points: np.ndarray, viewmats: np.ndarray, K: np.ndarray,
         edge_percentile=edge_percentile, max_distance=max_distance,
         reference_edge_points=reference, image_edge_masks=edge_masks,
         depth_support=depth_support,
-        contour_points_by_view=contour_points_by_view)
+        contour_points_by_view=contour_points_by_view,
+        orientation_max_angle_deg=orientation_max_angle_deg)
     before['loss'] = base_loss
     after['loss'] = best_loss
     return parameters, before, after
@@ -717,7 +875,8 @@ def spatiotemporal_objective(
         reference_edge_points: int | None = None,
         image_edge_masks: list[np.ndarray] | None = None,
         depth_support: dict | None = None,
-        contour_points_by_view: list[np.ndarray] | None = None
+        contour_points_by_view: list[np.ndarray] | None = None,
+        orientation_max_angle_deg: float = 0.0
         ) -> tuple[float, dict]:
     """Evaluate a continuous-time pose recomposition against image edges."""
     try:
@@ -731,7 +890,8 @@ def spatiotemporal_objective(
         edge_percentile=edge_percentile, max_distance=max_distance,
         reference_edge_points=reference_edge_points,
         image_edge_masks=image_edge_masks, depth_support=depth_support,
-        contour_points_by_view=contour_points_by_view)
+        contour_points_by_view=contour_points_by_view,
+        orientation_max_angle_deg=orientation_max_angle_deg)
 
 
 def optimize_spatiotemporal(
@@ -744,7 +904,8 @@ def optimize_spatiotemporal(
         edge_percentile: float = 95.0,
         max_distance: int = 12,
         depth_support: dict | None = None,
-        contour_points_by_view: list[np.ndarray] | None = None
+        contour_points_by_view: list[np.ndarray] | None = None,
+        orientation_max_angle_deg: float = 0.0
         ) -> tuple[np.ndarray, dict, dict]:
     """Bounded deterministic coordinate search over dt plus a local SE(3)."""
     parameters = np.zeros(7, dtype=np.float64)
@@ -752,9 +913,12 @@ def optimize_spatiotemporal(
         points, samples, stamps, body_T_camera, K, images, parameters,
         edge_percentile=edge_percentile, max_distance=max_distance,
         depth_support=depth_support,
-        contour_points_by_view=contour_points_by_view)
+        contour_points_by_view=contour_points_by_view,
+        orientation_max_angle_deg=orientation_max_angle_deg)
     reference = before['edge_points']
-    edge_masks = [image_edges(image, edge_percentile) for image in images]
+    edge_masks = [(image_edge_field(image, edge_percentile)
+                   if orientation_max_angle_deg > 0.0 else
+                   image_edges(image, edge_percentile)) for image in images]
     best_loss = base_loss
     steps = np.array([time_step] + [translation_step] * 3 +
                      [np.deg2rad(rotation_step_deg)] * 3)
@@ -777,7 +941,8 @@ def optimize_spatiotemporal(
                         reference_edge_points=reference,
                         image_edge_masks=edge_masks,
                         depth_support=depth_support,
-                        contour_points_by_view=contour_points_by_view)
+                        contour_points_by_view=contour_points_by_view,
+                        orientation_max_angle_deg=orientation_max_angle_deg)
                     if loss + 1e-12 < best_loss:
                         parameters, best_loss = candidate, loss
                         changed = True
@@ -787,7 +952,8 @@ def optimize_spatiotemporal(
         edge_percentile=edge_percentile, max_distance=max_distance,
         reference_edge_points=reference, image_edge_masks=edge_masks,
         depth_support=depth_support,
-        contour_points_by_view=contour_points_by_view)
+        contour_points_by_view=contour_points_by_view,
+        orientation_max_angle_deg=orientation_max_angle_deg)
     before['loss'] = base_loss
     after['loss'] = best_loss
     return parameters, before, after
@@ -807,7 +973,8 @@ def optimize_spatiotemporal_production(
         edge_percentile: float = 95.0,
         max_distance: int = 12,
         depth_support: dict | None = None,
-        contour_points_by_view: list[np.ndarray] | None = None
+        contour_points_by_view: list[np.ndarray] | None = None,
+        orientation_max_angle_deg: float = 0.0
         ) -> tuple[np.ndarray, dict, dict, dict]:
     """Optimize a pyramid and audit local identifiability before adoption."""
     if (not scales or any(not 0.0 < scale <= 1.0 for scale in scales) or
@@ -828,7 +995,9 @@ def optimize_spatiotemporal_production(
         level_images = [stc.downsample_nearest(image, scale)
                         for image in images]
         level_K = stc.scale_intrinsics(K, scale)
-        edge_masks = [image_edges(image, edge_percentile)
+        edge_masks = [(image_edge_field(image, edge_percentile)
+                       if orientation_max_angle_deg > 0.0 else
+                       image_edges(image, edge_percentile))
                       for image in level_images]
         reference_parameters = (parameters if reference_parameters is None
                                 else reference_parameters)
@@ -837,7 +1006,8 @@ def optimize_spatiotemporal_production(
             reference_parameters, edge_percentile=edge_percentile,
             max_distance=max(2, int(round(max_distance * scale))),
             image_edge_masks=edge_masks, depth_support=depth_support,
-            contour_points_by_view=contour_points_by_view)
+            contour_points_by_view=contour_points_by_view,
+            orientation_max_angle_deg=orientation_max_angle_deg)
         reference_edges = reference_metrics['edge_points']
 
         def objective(candidate):
@@ -847,7 +1017,8 @@ def optimize_spatiotemporal_production(
                 max_distance=max(2, int(round(max_distance * scale))),
                 reference_edge_points=reference_edges,
                 image_edge_masks=edge_masks, depth_support=depth_support,
-                contour_points_by_view=contour_points_by_view)
+                contour_points_by_view=contour_points_by_view,
+                orientation_max_angle_deg=orientation_max_angle_deg)
             return loss
         return objective
 
@@ -855,7 +1026,8 @@ def optimize_spatiotemporal_production(
         points, samples, stamps, body_T_camera, K, images, parameters,
         edge_percentile=edge_percentile, max_distance=max_distance,
         depth_support=depth_support,
-        contour_points_by_view=contour_points_by_view)
+        contour_points_by_view=contour_points_by_view,
+        orientation_max_angle_deg=orientation_max_angle_deg)
     before['loss'] = base_loss
     for scale in scales:
         objective = level_objective(scale, np.zeros(7))
@@ -893,7 +1065,8 @@ def optimize_spatiotemporal_production(
         edge_percentile=edge_percentile, max_distance=max_distance,
         reference_edge_points=before['edge_points'],
         depth_support=depth_support,
-        contour_points_by_view=contour_points_by_view)
+        contour_points_by_view=contour_points_by_view,
+        orientation_max_angle_deg=orientation_max_angle_deg)
     after['loss'] = final_loss
     audit_objective = level_objective(observability_scale, parameters)
     observability = stc.finite_difference_observability(
@@ -905,6 +1078,7 @@ def optimize_spatiotemporal_production(
         'mode': 'multi_resolution_production',
         'depth_support': depth_support,
         'fixed_contours': contour_points_by_view is not None,
+        'orientation_max_angle_deg': orientation_max_angle_deg,
         'pyramid_scales': list(scales),
         'levels': levels,
         'initial_bounds_dt_s_xyz_m_rpy_rad': initial_bounds.tolist(),
@@ -1046,6 +1220,9 @@ def main() -> int:
                              'geometry-only contours and avoids pose bias')
     parser.add_argument('--contour-max-points-per-view', type=int, default=50000)
     parser.add_argument('--contour-min-points-per-view', type=int, default=500)
+    parser.add_argument('--orientation-max-angle-deg', type=float, default=0.0,
+                        help='maximum normal-axis disagreement for contour '
+                             'matching; 0 disables orientation gating')
     parser.add_argument('--diagnostics-dir', type=Path,
                         help='write worst-view residual overlays and summary')
     parser.add_argument('--worst-views', type=int, default=10,
@@ -1114,6 +1291,7 @@ def main() -> int:
             args.contour_max_points_per_view < 1 or
             args.contour_min_points_per_view < 1 or
             args.contour_min_points_per_view > args.contour_max_points_per_view or
+            not 0.0 <= args.orientation_max_angle_deg <= 90.0 or
             not 0.0 <= args.minimum_supported_edge_fraction <= 1.0 or
             not 0.0 <= args.minimum_heldout_improvement < 1.0):
         raise SystemExit('stride, distance, rounds, and search steps must be > 0')
@@ -1126,6 +1304,9 @@ def main() -> int:
             args.fixed_contours and args.contour_association_distance > 0):
         raise SystemExit('image-associated fixed contours are diagnostic-only; '
                          'calibration requires geometry-only association 0')
+    if args.orientation_max_angle_deg > 0.0 and not args.fixed_contours:
+        raise SystemExit('--orientation-max-angle-deg requires '
+                         '--fixed-contours')
     try:
         pyramid_scales = tuple(float(item) for item in
                                args.pyramid_scales.split(','))
@@ -1244,7 +1425,8 @@ def main() -> int:
                 edge_percentile=args.edge_percentile,
                 max_distance=args.max_distance,
                 depth_support=depth_support,
-                contour_points_by_view=train_contours)
+                contour_points_by_view=train_contours,
+                orientation_max_angle_deg=args.orientation_max_angle_deg)
         else:
             parameters, train_before, train_after = optimize_spatiotemporal(
                 points, samples, stamps[train], body_T_camera, dataset['K'],
@@ -1258,13 +1440,15 @@ def main() -> int:
                 edge_percentile=args.edge_percentile,
                 max_distance=args.max_distance,
                 depth_support=depth_support,
-                contour_points_by_view=train_contours)
+                contour_points_by_view=train_contours,
+                orientation_max_angle_deg=args.orientation_max_angle_deg)
         zero = np.zeros(7)
         heldout_before_loss, heldout_before = spatiotemporal_objective(
             points, samples, stamps[heldout], body_T_camera, dataset['K'],
             heldout_images, zero, edge_percentile=args.edge_percentile,
             max_distance=args.max_distance, depth_support=depth_support,
-            contour_points_by_view=heldout_contours)
+            contour_points_by_view=heldout_contours,
+            orientation_max_angle_deg=args.orientation_max_angle_deg)
         heldout_after_loss, heldout_after = spatiotemporal_objective(
             points, samples, stamps[heldout], body_T_camera, dataset['K'],
             heldout_images, parameters,
@@ -1272,7 +1456,8 @@ def main() -> int:
             max_distance=args.max_distance,
             reference_edge_points=heldout_before['edge_points'],
             depth_support=depth_support,
-            contour_points_by_view=heldout_contours)
+            contour_points_by_view=heldout_contours,
+            orientation_max_angle_deg=args.orientation_max_angle_deg)
         heldout_before['loss'], heldout_after['loss'] = (
             heldout_before_loss, heldout_after_loss)
         accepted, rejection_reason = calibration_acceptance(
@@ -1339,7 +1524,8 @@ def main() -> int:
             edge_percentile=args.edge_percentile,
             max_distance=args.max_distance,
             depth_support=depth_support,
-            contour_points_by_view=contour_points_by_view)
+            contour_points_by_view=contour_points_by_view,
+            orientation_max_angle_deg=args.orientation_max_angle_deg)
         delta = correction_matrix(parameters)
         effective_viewmats = np.asarray(
             [delta @ viewmat for viewmat in viewmats])
@@ -1356,7 +1542,8 @@ def main() -> int:
             edge_percentile=args.edge_percentile,
             max_distance=args.max_distance, depth_support=depth_support,
             contour_points=(contour_points_by_view[ordinal]
-                            if contour_points_by_view is not None else None))
+                            if contour_points_by_view is not None else None),
+            orientation_max_angle_deg=args.orientation_max_angle_deg)
         score['view_index'] = index
         per_view.append(score)
     valid = [item for item in per_view if item['edge_points'] > 0]
@@ -1369,7 +1556,8 @@ def main() -> int:
               'full_density_points': len(full_points),
               'views_scored': len(valid), 'edge_points': int(weights.sum()),
               'depth_support': depth_support,
-              'fixed_contours': contour_report}
+              'fixed_contours': contour_report,
+              'orientation_max_angle_deg': args.orientation_max_angle_deg}
     raw_edges = sum(item['raw_edge_points'] for item in valid)
     report['raw_edge_points'] = raw_edges
     report['supported_edge_fraction'] = float(
@@ -1401,7 +1589,8 @@ def main() -> int:
             selected, images, per_view, worst_views=args.worst_views,
             edge_percentile=args.edge_percentile,
             max_distance=args.max_distance, depth_support=depth_support,
-            contour_points_by_view=contour_points_by_view)
+            contour_points_by_view=contour_points_by_view,
+            orientation_max_angle_deg=args.orientation_max_angle_deg)
         report['diagnostics']['directory'] = str(args.diagnostics_dir.resolve())
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(json.dumps(report, indent=2) + '\n')

--- a/scripts/evaluate_lidar_camera_alignment.py
+++ b/scripts/evaluate_lidar_camera_alignment.py
@@ -578,7 +578,7 @@ def write_residual_diagnostics(directory: Path, points: np.ndarray,
                                orientation_max_angle_deg: float = 0.0
                                ) -> dict:
     """Write deterministic worst-view overlays and a compact contact sheet."""
-    import imageio.v3 as iio
+    import imageio as iio
 
     directory = Path(directory)
     directory.mkdir(parents=True, exist_ok=True)
@@ -1329,7 +1329,7 @@ def main() -> int:
             'absolute': args.depth_support_absolute,
             'relative': args.depth_support_relative,
         }
-    import imageio.v3 as iio
+    import imageio as iio
     full_points, _ = pcio.read_ply_xyz(args.pointcloud)
     points = full_points
     if args.max_points and len(points) > args.max_points:

--- a/scripts/evaluate_lidar_camera_alignment.py
+++ b/scripts/evaluate_lidar_camera_alignment.py
@@ -100,6 +100,56 @@ def depth_edges(depth: np.ndarray, absolute: float = 0.25,
     return edges
 
 
+def surface_support_mask(depth: np.ndarray, *, radius: int = 2,
+                         min_neighbors: int = 4, absolute: float = 0.10,
+                         relative: float = 0.01) -> np.ndarray:
+    """Return depth pixels supported by nearby samples on the same surface."""
+    values = np.asarray(depth, dtype=np.float32)
+    if values.ndim != 2:
+        raise ValueError(f'depth must be HxW, got {values.shape}')
+    if radius < 1 or min_neighbors < 1:
+        raise ValueError('surface support radius and neighbours must be positive')
+    if min_neighbors > (2 * radius + 1) ** 2 - 1:
+        raise ValueError('surface support neighbours exceed the search window')
+    if absolute < 0.0 or relative < 0.0:
+        raise ValueError('surface support tolerances must be non-negative')
+    valid = np.isfinite(values) & (values > 0.0)
+    counts = np.zeros(values.shape, dtype=np.uint16)
+    height, width = values.shape
+    for dy in range(-radius, radius + 1):
+        for dx in range(-radius, radius + 1):
+            if dy == 0 and dx == 0:
+                continue
+            target_y = slice(max(0, -dy), min(height, height - dy))
+            target_x = slice(max(0, -dx), min(width, width - dx))
+            neighbour_y = slice(max(0, dy), min(height, height + dy))
+            neighbour_x = slice(max(0, dx), min(width, width + dx))
+            centre = values[target_y, target_x]
+            neighbour = values[neighbour_y, neighbour_x]
+            pair_valid = (valid[target_y, target_x] &
+                          valid[neighbour_y, neighbour_x])
+            with np.errstate(invalid='ignore'):
+                close = pair_valid & (
+                    np.abs(centre - neighbour) <=
+                    absolute + relative * np.minimum(centre, neighbour))
+            counts[target_y, target_x] += close
+    return valid & (counts >= min_neighbors)
+
+
+def supported_depth_edges(depth: np.ndarray,
+                          support: dict | None = None) -> tuple[np.ndarray, int]:
+    """Return raw or same-surface-supported edges plus the raw edge count."""
+    raw = depth_edges(depth)
+    raw_count = int(np.sum(raw))
+    if support is None or support.get('radius', 0) == 0:
+        return raw, raw_count
+    mask = surface_support_mask(
+        depth, radius=support['radius'],
+        min_neighbors=support['min_neighbors'],
+        absolute=support['absolute'], relative=support['relative'])
+    return raw & mask, raw_count
+
+
 def nearest_edge_distances(query: np.ndarray, target: np.ndarray,
                            max_distance: int = 12) -> np.ndarray:
     """Find target-edge distance for query pixels with a bounded local search."""
@@ -173,15 +223,19 @@ def projected_depth(points: np.ndarray, viewmat: np.ndarray, K: np.ndarray,
 
 def score_view(points: np.ndarray, viewmat: np.ndarray, K: np.ndarray,
                image: np.ndarray, *, edge_percentile: float = 95.0,
-               max_distance: int = 12) -> dict:
+               max_distance: int = 12,
+               depth_support: dict | None = None) -> dict:
     """Score one camera view and return pixel-distance alignment metrics."""
     height, width = image.shape[:2]
-    lidar_edges = depth_edges(projected_depth(points, viewmat, K, width, height))
+    lidar_edges, raw_edge_points = supported_depth_edges(
+        projected_depth(points, viewmat, K, width, height), depth_support)
     correspondences = nearest_edge_correspondences(
         lidar_edges, image_edges(image, edge_percentile), max_distance)
     distances = correspondences['distance_px']
     if distances.size == 0:
-        return {'edge_points': 0, 'median_px': None, 'p90_px': None,
+        return {'edge_points': 0, 'raw_edge_points': raw_edge_points,
+                'supported_edge_fraction': 0.0, 'median_px': None,
+                'p90_px': None,
                 'inlier_2px': None, 'out_of_range_fraction': None,
                 'matched_edge_points': 0, 'median_dx_px': None,
                 'median_dy_px': None, 'mean_dx_px': None,
@@ -193,6 +247,9 @@ def score_view(points: np.ndarray, viewmat: np.ndarray, K: np.ndarray,
     mean_dy = float(np.mean(dy)) if np.any(matched) else None
     mean_radius = float(np.mean(np.hypot(dx, dy))) if np.any(matched) else None
     return {'edge_points': int(distances.size),
+            'raw_edge_points': raw_edge_points,
+            'supported_edge_fraction': float(
+                distances.size / max(raw_edge_points, 1)),
             'median_px': float(np.median(distances)),
             'p90_px': float(np.percentile(distances, 90)),
             'inlier_2px': float(np.mean(distances <= 2.0)),
@@ -211,7 +268,8 @@ def score_view(points: np.ndarray, viewmat: np.ndarray, K: np.ndarray,
 def render_residual_overlay(points: np.ndarray, viewmat: np.ndarray,
                             K: np.ndarray, image: np.ndarray, *,
                             edge_percentile: float = 95.0,
-                            max_distance: int = 12) -> np.ndarray:
+                            max_distance: int = 12,
+                            depth_support: dict | None = None) -> np.ndarray:
     """Overlay image edges and colour-coded LiDAR edge residuals."""
     source = np.asarray(image)
     if source.ndim == 2:
@@ -222,7 +280,8 @@ def render_residual_overlay(points: np.ndarray, viewmat: np.ndarray,
     output = np.clip(source.astype(np.float32) * 0.55, 0, 255).astype(np.uint8)
     height, width = source.shape[:2]
     camera_edges = image_edges(source, edge_percentile)
-    lidar_edges = depth_edges(projected_depth(points, viewmat, K, width, height))
+    lidar_edges, _ = supported_depth_edges(
+        projected_depth(points, viewmat, K, width, height), depth_support)
     residuals = nearest_edge_correspondences(
         lidar_edges, camera_edges, max_distance)
 
@@ -251,7 +310,8 @@ def write_residual_diagnostics(directory: Path, points: np.ndarray,
                                selected: list[int], images: list[np.ndarray],
                                per_view: list[dict], *, worst_views: int,
                                edge_percentile: float,
-                               max_distance: int) -> dict:
+                               max_distance: int,
+                               depth_support: dict | None = None) -> dict:
     """Write deterministic worst-view overlays and a compact contact sheet."""
     import imageio.v3 as iio
 
@@ -270,7 +330,8 @@ def write_residual_diagnostics(directory: Path, points: np.ndarray,
         index = metrics['view_index']
         overlay = render_residual_overlay(
             points, viewmats[index], K, image_by_index[index],
-            edge_percentile=edge_percentile, max_distance=max_distance)
+            edge_percentile=edge_percentile, max_distance=max_distance,
+            depth_support=depth_support)
         filename = f'worst_{rank:02d}_view_{index:05d}.png'
         path = directory / filename
         iio.imwrite(path, overlay)
@@ -319,6 +380,7 @@ def write_residual_diagnostics(directory: Path, points: np.ndarray,
                          'max_residual_lidar_edges': 'red',
                          'unmatched_lidar_edges': 'magenta'},
               'ranking': 'out_of_range_fraction,p90_px,median_px',
+              'depth_support': depth_support,
               'direction_summary': direction,
               'contact_sheet': contact_name, 'worst_views': entries}
     (directory / 'diagnostics.json').write_text(json.dumps(result, indent=2) + '\n')
@@ -345,22 +407,28 @@ def alignment_objective(points: np.ndarray, viewmats: np.ndarray,
                         parameters: np.ndarray, *, edge_percentile: float = 95.0,
                         max_distance: int = 12,
                         reference_edge_points: int | None = None,
-                        image_edge_masks: list[np.ndarray] | None = None
+                        image_edge_masks: list[np.ndarray] | None = None,
+                        depth_support: dict | None = None
                         ) -> tuple[float, dict]:
     """Return coverage-guarded mean edge distance for one SE(3) correction."""
     delta = correction_matrix(parameters)
     chunks = []
     targets = (image_edge_masks if image_edge_masks is not None else
                [image_edges(image, edge_percentile) for image in images])
+    raw_edge_points = 0
     for viewmat, image, target in zip(viewmats, images, targets):
         height, width = image.shape[:2]
-        lidar_edges = depth_edges(projected_depth(
-            points, delta @ viewmat, K, width, height))
+        lidar_edges, raw_count = supported_depth_edges(projected_depth(
+            points, delta @ viewmat, K, width, height), depth_support)
+        raw_edge_points += raw_count
         chunks.append(nearest_edge_distances(lidar_edges, target, max_distance))
     values = np.concatenate([item for item in chunks if item.size]) \
         if any(item.size for item in chunks) else np.zeros(0, np.float32)
     if not values.size:
-        return float('inf'), {'edge_points': 0, 'mean_px': None}
+        return float('inf'), {'edge_points': 0,
+                              'raw_edge_points': raw_edge_points,
+                              'supported_edge_fraction': 0.0,
+                              'mean_px': None}
     edge_points = int(values.size)
     reference = edge_points if reference_edge_points is None else reference_edge_points
     coverage = edge_points / max(reference, 1)
@@ -369,7 +437,10 @@ def alignment_objective(points: np.ndarray, viewmats: np.ndarray,
     return loss, {'edge_points': edge_points, 'mean_px': float(np.mean(values)),
                   'median_px': float(np.median(values)),
                   'out_of_range_fraction': float(np.mean(values > max_distance)),
-                  'coverage': coverage}
+                  'coverage': coverage,
+                  'raw_edge_points': raw_edge_points,
+                  'supported_edge_fraction': float(
+                      edge_points / max(raw_edge_points, 1))}
 
 
 def optimize_correction(points: np.ndarray, viewmats: np.ndarray, K: np.ndarray,
@@ -377,12 +448,15 @@ def optimize_correction(points: np.ndarray, viewmats: np.ndarray, K: np.ndarray,
                         translation_step: float = 0.02,
                         rotation_step_deg: float = 0.2,
                         edge_percentile: float = 95.0,
-                        max_distance: int = 12) -> tuple[np.ndarray, dict, dict]:
+                        max_distance: int = 12,
+                        depth_support: dict | None = None
+                        ) -> tuple[np.ndarray, dict, dict]:
     """Coordinate-search a camera-frame correction, coarse to fine."""
     parameters = np.zeros(6, dtype=np.float64)
     base_loss, before = alignment_objective(
         points, viewmats, K, images, parameters,
-        edge_percentile=edge_percentile, max_distance=max_distance)
+        edge_percentile=edge_percentile, max_distance=max_distance,
+        depth_support=depth_support)
     best_loss = base_loss
     reference = before['edge_points']
     edge_masks = [image_edges(image, edge_percentile) for image in images]
@@ -398,14 +472,16 @@ def optimize_correction(points: np.ndarray, viewmats: np.ndarray, K: np.ndarray,
                     edge_percentile=edge_percentile,
                     max_distance=max_distance,
                     reference_edge_points=reference,
-                    image_edge_masks=edge_masks)
+                    image_edge_masks=edge_masks,
+                    depth_support=depth_support)
                 if loss < best_loss:
                     parameters, best_loss = candidate, loss
         steps *= 0.5
     _, after = alignment_objective(
         points, viewmats, K, images, parameters,
         edge_percentile=edge_percentile, max_distance=max_distance,
-        reference_edge_points=reference, image_edge_masks=edge_masks)
+        reference_edge_points=reference, image_edge_masks=edge_masks,
+        depth_support=depth_support)
     before['loss'] = base_loss
     after['loss'] = best_loss
     return parameters, before, after
@@ -490,7 +566,8 @@ def spatiotemporal_objective(
         images: list[np.ndarray], parameters: np.ndarray, *,
         edge_percentile: float = 95.0, max_distance: int = 12,
         reference_edge_points: int | None = None,
-        image_edge_masks: list[np.ndarray] | None = None) -> tuple[float, dict]:
+        image_edge_masks: list[np.ndarray] | None = None,
+        depth_support: dict | None = None) -> tuple[float, dict]:
     """Evaluate a continuous-time pose recomposition against image edges."""
     try:
         viewmats = recompose_viewmats(
@@ -502,7 +579,7 @@ def spatiotemporal_objective(
         points, viewmats, K, images, np.zeros(6),
         edge_percentile=edge_percentile, max_distance=max_distance,
         reference_edge_points=reference_edge_points,
-        image_edge_masks=image_edge_masks)
+        image_edge_masks=image_edge_masks, depth_support=depth_support)
 
 
 def optimize_spatiotemporal(
@@ -513,12 +590,14 @@ def optimize_spatiotemporal(
         rotation_step_deg: float = 0.2, max_time_offset: float = 0.1,
         max_translation: float = 0.1, max_rotation_deg: float = 2.0,
         edge_percentile: float = 95.0,
-        max_distance: int = 12) -> tuple[np.ndarray, dict, dict]:
+        max_distance: int = 12,
+        depth_support: dict | None = None) -> tuple[np.ndarray, dict, dict]:
     """Bounded deterministic coordinate search over dt plus a local SE(3)."""
     parameters = np.zeros(7, dtype=np.float64)
     base_loss, before = spatiotemporal_objective(
         points, samples, stamps, body_T_camera, K, images, parameters,
-        edge_percentile=edge_percentile, max_distance=max_distance)
+        edge_percentile=edge_percentile, max_distance=max_distance,
+        depth_support=depth_support)
     reference = before['edge_points']
     edge_masks = [image_edges(image, edge_percentile) for image in images]
     best_loss = base_loss
@@ -541,7 +620,8 @@ def optimize_spatiotemporal(
                         candidate, edge_percentile=edge_percentile,
                         max_distance=max_distance,
                         reference_edge_points=reference,
-                        image_edge_masks=edge_masks)
+                        image_edge_masks=edge_masks,
+                        depth_support=depth_support)
                     if loss + 1e-12 < best_loss:
                         parameters, best_loss = candidate, loss
                         changed = True
@@ -549,7 +629,8 @@ def optimize_spatiotemporal(
     _, after = spatiotemporal_objective(
         points, samples, stamps, body_T_camera, K, images, parameters,
         edge_percentile=edge_percentile, max_distance=max_distance,
-        reference_edge_points=reference, image_edge_masks=edge_masks)
+        reference_edge_points=reference, image_edge_masks=edge_masks,
+        depth_support=depth_support)
     before['loss'] = base_loss
     after['loss'] = best_loss
     return parameters, before, after
@@ -567,7 +648,9 @@ def optimize_spatiotemporal_production(
         minimum_curvature: float = 1e-6, maximum_condition: float = 1e6,
         maximum_time_translation_correlation: float = 0.98,
         edge_percentile: float = 95.0,
-        max_distance: int = 12) -> tuple[np.ndarray, dict, dict, dict]:
+        max_distance: int = 12,
+        depth_support: dict | None = None
+        ) -> tuple[np.ndarray, dict, dict, dict]:
     """Optimize a pyramid and audit local identifiability before adoption."""
     if (not scales or any(not 0.0 < scale <= 1.0 for scale in scales) or
             tuple(sorted(scales)) != scales):
@@ -595,7 +678,7 @@ def optimize_spatiotemporal_production(
             points, samples, stamps, body_T_camera, level_K, level_images,
             reference_parameters, edge_percentile=edge_percentile,
             max_distance=max(2, int(round(max_distance * scale))),
-            image_edge_masks=edge_masks)
+            image_edge_masks=edge_masks, depth_support=depth_support)
         reference_edges = reference_metrics['edge_points']
 
         def objective(candidate):
@@ -604,13 +687,14 @@ def optimize_spatiotemporal_production(
                 candidate, edge_percentile=edge_percentile,
                 max_distance=max(2, int(round(max_distance * scale))),
                 reference_edge_points=reference_edges,
-                image_edge_masks=edge_masks)
+                image_edge_masks=edge_masks, depth_support=depth_support)
             return loss
         return objective
 
     base_loss, before = spatiotemporal_objective(
         points, samples, stamps, body_T_camera, K, images, parameters,
-        edge_percentile=edge_percentile, max_distance=max_distance)
+        edge_percentile=edge_percentile, max_distance=max_distance,
+        depth_support=depth_support)
     before['loss'] = base_loss
     for scale in scales:
         objective = level_objective(scale, np.zeros(7))
@@ -646,7 +730,8 @@ def optimize_spatiotemporal_production(
     final_loss, after = spatiotemporal_objective(
         points, samples, stamps, body_T_camera, K, images, parameters,
         edge_percentile=edge_percentile, max_distance=max_distance,
-        reference_edge_points=before['edge_points'])
+        reference_edge_points=before['edge_points'],
+        depth_support=depth_support)
     after['loss'] = final_loss
     audit_objective = level_objective(observability_scale, parameters)
     observability = stc.finite_difference_observability(
@@ -656,6 +741,7 @@ def optimize_spatiotemporal_production(
         maximum_correlation=maximum_time_translation_correlation)
     report = {
         'mode': 'multi_resolution_production',
+        'depth_support': depth_support,
         'pyramid_scales': list(scales),
         'levels': levels,
         'initial_bounds_dt_s_xyz_m_rpy_rad': initial_bounds.tolist(),
@@ -674,13 +760,20 @@ def optimize_spatiotemporal_production(
 def calibration_acceptance(train_before: dict, train_after: dict,
                            heldout_before: dict, heldout_after: dict, *,
                            minimum_edge_points: int,
-                           minimum_heldout_improvement: float) -> tuple[bool, str | None]:
+                           minimum_heldout_improvement: float,
+                           minimum_supported_edge_fraction: float = 0.0
+                           ) -> tuple[bool, str | None]:
     """Apply the independent validation gate used before exporting poses."""
     enough_edges = (
         train_before['edge_points'] >= minimum_edge_points and
         heldout_before['edge_points'] >= minimum_edge_points)
     if not enough_edges:
         return False, 'insufficient_edge_support'
+    if (train_before.get('supported_edge_fraction', 1.0) <
+            minimum_supported_edge_fraction or
+            heldout_before.get('supported_edge_fraction', 1.0) <
+            minimum_supported_edge_fraction):
+        return False, 'insufficient_supported_edge_fraction'
     train_loss = train_after['loss']
     heldout_loss = heldout_after['loss']
     heldout_limit = heldout_before['loss'] * (
@@ -775,6 +868,13 @@ def main() -> int:
                         help='retain this percentile of nonzero image gradients; '
                              '95 focuses the metric on structural edges')
     parser.add_argument('--max-distance', type=int, default=12)
+    parser.add_argument('--depth-support-radius', type=int, default=0,
+                        help='require same-surface neighbours around each LiDAR '
+                             'edge pixel; 0 preserves the raw edge metric')
+    parser.add_argument('--depth-support-min-neighbors', type=int, default=4)
+    parser.add_argument('--depth-support-absolute', type=float, default=0.10,
+                        help='metre tolerance for same-surface support')
+    parser.add_argument('--depth-support-relative', type=float, default=0.01)
     parser.add_argument('--diagnostics-dir', type=Path,
                         help='write worst-view residual overlays and summary')
     parser.add_argument('--worst-views', type=int, default=10,
@@ -811,6 +911,10 @@ def main() -> int:
     parser.add_argument('--maximum-time-translation-correlation', type=float,
                         default=0.98)
     parser.add_argument('--minimum-edge-points', type=int, default=50)
+    parser.add_argument('--minimum-supported-edge-fraction', type=float,
+                        default=0.0,
+                        help='reject calibration when surface filtering keeps '
+                             'less than this raw-edge fraction')
     parser.add_argument('--minimum-heldout-improvement', type=float, default=0.0,
                         help='fractional held-out loss reduction required to '
                              'accept and export the correction')
@@ -830,6 +934,11 @@ def main() -> int:
             not 0.0 <= args.maximum_time_translation_correlation < 1.0 or
             args.minimum_edge_points < 1 or args.max_points < 0 or
             args.worst_views < 1 or
+            args.depth_support_radius < 0 or
+            args.depth_support_min_neighbors < 1 or
+            args.depth_support_absolute < 0.0 or
+            args.depth_support_relative < 0.0 or
+            not 0.0 <= args.minimum_supported_edge_fraction <= 1.0 or
             not 0.0 <= args.minimum_heldout_improvement < 1.0):
         raise SystemExit('stride, distance, rounds, and search steps must be > 0')
     if args.optimize_spatiotemporal and args.trajectory is None:
@@ -847,6 +956,18 @@ def main() -> int:
             not np.isclose(args.observability_scale, pyramid_scales[-1])):
         raise SystemExit('--observability-scale must match the finest '
                          '--pyramid-scales value')
+    if (args.depth_support_radius > 0 and
+            args.depth_support_min_neighbors >
+            (2 * args.depth_support_radius + 1) ** 2 - 1):
+        raise SystemExit('--depth-support-min-neighbors exceeds its window')
+    depth_support = None
+    if args.depth_support_radius > 0:
+        depth_support = {
+            'radius': args.depth_support_radius,
+            'min_neighbors': args.depth_support_min_neighbors,
+            'absolute': args.depth_support_absolute,
+            'relative': args.depth_support_relative,
+        }
     import imageio.v3 as iio
     points, _ = pcio.read_ply_xyz(args.pointcloud)
     if args.max_points and len(points) > args.max_points:
@@ -917,7 +1038,8 @@ def main() -> int:
                 maximum_time_translation_correlation=(
                     args.maximum_time_translation_correlation),
                 edge_percentile=args.edge_percentile,
-                max_distance=args.max_distance)
+                max_distance=args.max_distance,
+                depth_support=depth_support)
         else:
             parameters, train_before, train_after = optimize_spatiotemporal(
                 points, samples, stamps[train], body_T_camera, dataset['K'],
@@ -929,24 +1051,28 @@ def main() -> int:
                 max_translation=args.max_translation,
                 max_rotation_deg=args.max_rotation_deg,
                 edge_percentile=args.edge_percentile,
-                max_distance=args.max_distance)
+                max_distance=args.max_distance,
+                depth_support=depth_support)
         zero = np.zeros(7)
         heldout_before_loss, heldout_before = spatiotemporal_objective(
             points, samples, stamps[heldout], body_T_camera, dataset['K'],
             heldout_images, zero, edge_percentile=args.edge_percentile,
-            max_distance=args.max_distance)
+            max_distance=args.max_distance, depth_support=depth_support)
         heldout_after_loss, heldout_after = spatiotemporal_objective(
             points, samples, stamps[heldout], body_T_camera, dataset['K'],
             heldout_images, parameters,
             edge_percentile=args.edge_percentile,
             max_distance=args.max_distance,
-            reference_edge_points=heldout_before['edge_points'])
+            reference_edge_points=heldout_before['edge_points'],
+            depth_support=depth_support)
         heldout_before['loss'], heldout_after['loss'] = (
             heldout_before_loss, heldout_after_loss)
         accepted, rejection_reason = calibration_acceptance(
             train_before, train_after, heldout_before, heldout_after,
             minimum_edge_points=args.minimum_edge_points,
-            minimum_heldout_improvement=args.minimum_heldout_improvement)
+            minimum_heldout_improvement=args.minimum_heldout_improvement,
+            minimum_supported_edge_fraction=(
+                args.minimum_supported_edge_fraction))
         parameter_bounds = np.array([
             args.max_time_offset, args.max_translation,
             args.max_translation, args.max_translation,
@@ -982,6 +1108,8 @@ def main() -> int:
             'heldout_view_indices': heldout,
             'validation_split': split_report,
             'minimum_edge_points': args.minimum_edge_points,
+            'minimum_supported_edge_fraction':
+                args.minimum_supported_edge_fraction,
             'search_bounds_dt_s_xyz_m_rpy_deg': parameter_bounds.tolist(),
             'boundary_axes': boundary_axes,
             'production_calibration': production_report,
@@ -996,7 +1124,8 @@ def main() -> int:
             translation_step=args.translation_step,
             rotation_step_deg=args.rotation_step_deg,
             edge_percentile=args.edge_percentile,
-            max_distance=args.max_distance)
+            max_distance=args.max_distance,
+            depth_support=depth_support)
         delta = correction_matrix(parameters)
         effective_viewmats = np.asarray(
             [delta @ viewmat for viewmat in viewmats])
@@ -1011,7 +1140,7 @@ def main() -> int:
         score = score_view(
             points, effective_viewmats[index], dataset['K'], image,
             edge_percentile=args.edge_percentile,
-            max_distance=args.max_distance)
+            max_distance=args.max_distance, depth_support=depth_support)
         score['view_index'] = index
         per_view.append(score)
     valid = [item for item in per_view if item['edge_points'] > 0]
@@ -1021,7 +1150,12 @@ def main() -> int:
     report = {'pointcloud': str(args.pointcloud.resolve()),
               'transforms': str(args.transforms.resolve()),
               'points_scored': len(points),
-              'views_scored': len(valid), 'edge_points': int(weights.sum())}
+              'views_scored': len(valid), 'edge_points': int(weights.sum()),
+              'depth_support': depth_support}
+    raw_edges = sum(item['raw_edge_points'] for item in valid)
+    report['raw_edge_points'] = raw_edges
+    report['supported_edge_fraction'] = float(
+        weights.sum() / max(raw_edges, 1))
     for name in ('median_px', 'p90_px', 'inlier_2px',
                  'out_of_range_fraction'):
         report[f'weighted_{name}'] = float(np.average(
@@ -1048,7 +1182,7 @@ def main() -> int:
             args.diagnostics_dir, points, effective_viewmats, dataset['K'],
             selected, images, per_view, worst_views=args.worst_views,
             edge_percentile=args.edge_percentile,
-            max_distance=args.max_distance)
+            max_distance=args.max_distance, depth_support=depth_support)
         report['diagnostics']['directory'] = str(args.diagnostics_dir.resolve())
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(json.dumps(report, indent=2) + '\n')

--- a/tools/colored_map/COLORING_HANDOFF.md
+++ b/tools/colored_map/COLORING_HANDOFF.md
@@ -378,3 +378,11 @@ correspondence supportが必要。
 0.76%（7.3723→7.3160 px）のみ。stationary pointもlocal範囲外で可観測性FAILとなり
 不採用。密度非依存の証拠集合は完成したが、clutter環境のnearest image-edge目的が
 まだ曖昧で、K4のpose/README assetは更新していない。
+
+固定contourへdepth discontinuity normalを持たせ、画像gradient normalとの角度も見る
+`--orientation-max-angle-deg`をdefault-offで追加した。30度の13 view×20k smokeは
+全260k点を母集団に残したまま未対応61.24%、train改善1.09%、held-out改善0.52%。
+search boundaryへ到達し、曲率不足/不安定、time-translation pair非可観測、local外の
+stationary point、ill-conditionでもFAILしたため不採用。疎depth rasterのpixel normalは
+棚・角・細構造で不安定。次は角度を緩めるのでなく、contourを支持付きline segmentへ
+束ねてsegment tangentをrobust推定する。K4 pose/assetは引き続き未変更。

--- a/tools/colored_map/COLORING_HANDOFF.md
+++ b/tools/colored_map/COLORING_HANDOFF.md
@@ -349,3 +349,16 @@ held-out、global/planar roughnessがすべて改善したためREADME動画へ�
 same-pose provenance、K3 exact rebuild、双方向structure support、品質profile、同一8視点
 目視を採用根拠とする。詳細は
 `docs/research/colored-map-dynamic-cleaning-2026-07.md`。
+
+## 19. 追記 (2026-07-19): K5 residual diagnostics
+
+K4の11項目PASSが目視品質を代表していなかったため、camera-LiDAR alignmentへ
+signed x/y残差、対応率、方向coherence、ワーストview overlay、contact sheetを追加した。
+pipelineでは`--alignment-diagnostics`で品質評価と同時生成できる。通常動作は不変。
+
+K4の4,906,133点・26 view実測では、ワースト10 viewの12 px圏外率が
+36.5%〜54.2%、全体の方向coherenceは0.032だった。一定方向の外部較正ずれだけでは
+説明できず、棚・天井・物体境界にscene-dependentな未対応edgeが広がる。成果物は
+`benchmarks/rtkslam_seq1_colored_map_20260718/k5_diagnostics/`。次はunsupportedな
+LiDAR depth edgeを較正目的から除外した後、時刻・motion distortion・軌跡依存残差を
+別々に評価する。

--- a/tools/colored_map/COLORING_HANDOFF.md
+++ b/tools/colored_map/COLORING_HANDOFF.md
@@ -362,3 +362,10 @@ K4の4,906,133点・26 view実測では、ワースト10 viewの12 px圏外率�
 `benchmarks/rtkslam_seq1_colored_map_20260718/k5_diagnostics/`。次はunsupportedな
 LiDAR depth edgeを較正目的から除外した後、時刻・motion distortion・軌跡依存残差を
 別々に評価する。
+
+surface-supported edge gateもdefault-offで実装し、raw edge数と保持率、較正時の
+最小保持率gate（pipeline既定25%）を追加した。しかしK4全点のr2/n4は51.42%を保持して
+median 7.759→7.234 px、圏外率34.96→32.79%に留まり、p90は13 pxのまま。productionの
+30万点subsampleでは保持率7.62%まで崩れたため不採用。見かけのmedian 4.59 pxは
+selection biasであり、保持率gateが正しく拒否する。次は画像平面の点密度に依存しない
+correspondence supportが必要。

--- a/tools/colored_map/COLORING_HANDOFF.md
+++ b/tools/colored_map/COLORING_HANDOFF.md
@@ -369,3 +369,12 @@ median 7.759→7.234 px、圏外率34.96→32.79%に留まり、p90は13 pxの�
 30万点subsampleでは保持率7.62%まで崩れたため不採用。見かけのmedian 4.59 pxは
 selection biasであり、保持率gateが正しく拒否する。次は画像平面の点密度に依存しない
 correspondence supportが必要。
+
+続いて全密度4.91M点の初期z-buffer winnerからview別3D contour point IDを固定し、
+30万点subsampleや候補姿勢で評価集合が変わらない`--fixed-contours`を追加した。
+画像edgeから12 px以内を先に選ぶ方式は初期姿勢を最適値へlockし、train/held-outとも
+改善0%だったためoptimizationでは明示拒否する。geometry-only（association=0）の
+13 view×20k点smokeは260k点を100%保持し、train 2.25%改善に対しheld-outは
+0.76%（7.3723→7.3160 px）のみ。stationary pointもlocal範囲外で可観測性FAILとなり
+不採用。密度非依存の証拠集合は完成したが、clutter環境のnearest image-edge目的が
+まだ曖昧で、K4のpose/README assetは更新していない。

--- a/tools/colored_map/colored_map_pipeline.py
+++ b/tools/colored_map/colored_map_pipeline.py
@@ -360,7 +360,15 @@ def build_commands(args) -> list[tuple[str, list[str]]]:
                 str(args.calibration_depth_support_relative),
                 '--minimum-supported-edge-fraction',
                 str(args.calibration_minimum_supported_edge_fraction),
-            ] if args.calibration_depth_support_radius > 0 else [])))
+            ] if args.calibration_depth_support_radius > 0 else []) + ([
+                '--fixed-contours',
+                '--contour-association-distance',
+                str(args.calibration_contour_association_distance),
+                '--contour-max-points-per-view',
+                str(args.calibration_contour_max_points_per_view),
+                '--contour-min-points-per-view',
+                str(args.calibration_contour_min_points_per_view),
+            ] if args.calibration_fixed_contours else [])))
 
     if (rebuild_images or rebuild_masks or rebuild_calibration or
             args.force_map or
@@ -405,6 +413,16 @@ def build_commands(args) -> list[tuple[str, list[str]]]:
                     str(args.alignment_depth_support_absolute),
                     '--depth-support-relative',
                     str(args.alignment_depth_support_relative),
+                ])
+            if args.alignment_fixed_contours:
+                alignment_command.extend([
+                    '--fixed-contours',
+                    '--contour-association-distance',
+                    str(args.alignment_contour_association_distance),
+                    '--contour-max-points-per-view',
+                    str(args.alignment_contour_max_points_per_view),
+                    '--contour-min-points-per-view',
+                    str(args.alignment_contour_min_points_per_view),
                 ])
             commands.append(('camera-LiDAR alignment', alignment_command))
         if (rebuild_map or rebuild_images or args.force_quality or
@@ -518,6 +536,16 @@ def run_pipeline(args) -> dict:
             raise ValueError(f'invalid {prefix} depth support settings')
     if not 0.0 <= args.calibration_minimum_supported_edge_fraction <= 1.0:
         raise ValueError('invalid calibration minimum supported edge fraction')
+    for prefix, association, maximum, minimum in (
+            ('calibration', args.calibration_contour_association_distance,
+             args.calibration_contour_max_points_per_view,
+             args.calibration_contour_min_points_per_view),
+            ('alignment', args.alignment_contour_association_distance,
+             args.alignment_contour_max_points_per_view,
+             args.alignment_contour_min_points_per_view)):
+        if ((association != 0 and association < 12) or maximum < 1 or
+                minimum < 1 or minimum > maximum):
+            raise ValueError(f'invalid {prefix} fixed contour settings')
     if args.refine_spatiotemporal_calibration and (
             args.calibration_view_stride < 1 or
             args.calibration_max_points < 1 or
@@ -656,6 +684,13 @@ def build_parser() -> argparse.ArgumentParser:
                    default=0.01)
     p.add_argument('--calibration-minimum-supported-edge-fraction', type=float,
                    default=0.25)
+    p.add_argument('--calibration-fixed-contours', action='store_true')
+    p.add_argument('--calibration-contour-association-distance', type=int,
+                   default=0)
+    p.add_argument('--calibration-contour-max-points-per-view', type=int,
+                   default=50000)
+    p.add_argument('--calibration-contour-min-points-per-view', type=int,
+                   default=500)
     p.add_argument('--max-trajectory-gap', type=float, default=0.5,
                    help='reject sparse pose streams with a larger gap (s); '
                         'set <=0 to disable')
@@ -746,6 +781,13 @@ def build_parser() -> argparse.ArgumentParser:
                    default=0.10)
     p.add_argument('--alignment-depth-support-relative', type=float,
                    default=0.01)
+    p.add_argument('--alignment-fixed-contours', action='store_true')
+    p.add_argument('--alignment-contour-association-distance', type=int,
+                   default=0)
+    p.add_argument('--alignment-contour-max-points-per-view', type=int,
+                   default=50000)
+    p.add_argument('--alignment-contour-min-points-per-view', type=int,
+                   default=500)
     p.add_argument('--trajectory-report', type=Path,
                    help='metrics.json containing evo.ape.rmse for quality gate')
     p.add_argument('--geometry-report', type=Path,

--- a/tools/colored_map/colored_map_pipeline.py
+++ b/tools/colored_map/colored_map_pipeline.py
@@ -368,6 +368,8 @@ def build_commands(args) -> list[tuple[str, list[str]]]:
                 str(args.calibration_contour_max_points_per_view),
                 '--contour-min-points-per-view',
                 str(args.calibration_contour_min_points_per_view),
+                '--orientation-max-angle-deg',
+                str(args.calibration_orientation_max_angle_deg),
             ] if args.calibration_fixed_contours else [])))
 
     if (rebuild_images or rebuild_masks or rebuild_calibration or
@@ -423,6 +425,8 @@ def build_commands(args) -> list[tuple[str, list[str]]]:
                     str(args.alignment_contour_max_points_per_view),
                     '--contour-min-points-per-view',
                     str(args.alignment_contour_min_points_per_view),
+                    '--orientation-max-angle-deg',
+                    str(args.alignment_orientation_max_angle_deg),
                 ])
             commands.append(('camera-LiDAR alignment', alignment_command))
         if (rebuild_map or rebuild_images or args.force_quality or
@@ -546,6 +550,15 @@ def run_pipeline(args) -> dict:
         if ((association != 0 and association < 12) or maximum < 1 or
                 minimum < 1 or minimum > maximum):
             raise ValueError(f'invalid {prefix} fixed contour settings')
+    if (not 0.0 <= args.calibration_orientation_max_angle_deg <= 90.0 or
+            not 0.0 <= args.alignment_orientation_max_angle_deg <= 90.0):
+        raise ValueError('invalid contour orientation angle')
+    if (args.calibration_orientation_max_angle_deg > 0.0 and
+            not args.calibration_fixed_contours):
+        raise ValueError('calibration orientation gate requires fixed contours')
+    if (args.alignment_orientation_max_angle_deg > 0.0 and
+            not args.alignment_fixed_contours):
+        raise ValueError('alignment orientation gate requires fixed contours')
     if args.refine_spatiotemporal_calibration and (
             args.calibration_view_stride < 1 or
             args.calibration_max_points < 1 or
@@ -691,6 +704,8 @@ def build_parser() -> argparse.ArgumentParser:
                    default=50000)
     p.add_argument('--calibration-contour-min-points-per-view', type=int,
                    default=500)
+    p.add_argument('--calibration-orientation-max-angle-deg', type=float,
+                   default=0.0)
     p.add_argument('--max-trajectory-gap', type=float, default=0.5,
                    help='reject sparse pose streams with a larger gap (s); '
                         'set <=0 to disable')
@@ -788,6 +803,8 @@ def build_parser() -> argparse.ArgumentParser:
                    default=50000)
     p.add_argument('--alignment-contour-min-points-per-view', type=int,
                    default=500)
+    p.add_argument('--alignment-orientation-max-angle-deg', type=float,
+                   default=0.0)
     p.add_argument('--trajectory-report', type=Path,
                    help='metrics.json containing evo.ape.rmse for quality gate')
     p.add_argument('--geometry-report', type=Path,

--- a/tools/colored_map/colored_map_pipeline.py
+++ b/tools/colored_map/colored_map_pipeline.py
@@ -358,6 +358,7 @@ def build_commands(args) -> list[tuple[str, list[str]]]:
 
     if args.quality_profile is not None:
         alignment_report = out_dir / 'lidar_camera_alignment.json'
+        alignment_diagnostics = out_dir / 'lidar_camera_alignment_diagnostics'
         colour_report = out_dir / 'heldout_point_colors.json'
         appearance_report = out_dir / 'colored_map_appearance.json'
         quality_report = out_dir / 'colored_map_quality_gate.json'
@@ -367,15 +368,23 @@ def build_commands(args) -> list[tuple[str, list[str]]]:
             args.appearance_planar_roughness or
             profile_uses_planar_roughness(Path(args.quality_profile)))
         if (rebuild_map or rebuild_images or args.force_quality or
+                (args.alignment_diagnostics and not
+                 (alignment_diagnostics / 'diagnostics.json').is_file()) or
                 is_stale(alignment_report, [colored_map, transforms])):
-            commands.append(('camera-LiDAR alignment', [
+            alignment_command = [
                 sys.executable,
                 str(REPO_ROOT / 'scripts' /
                     'evaluate_lidar_camera_alignment.py'),
                 '--pointcloud', str(colored_map),
                 '--transforms', str(transforms),
                 '--out', str(alignment_report),
-            ]))
+            ]
+            if args.alignment_diagnostics:
+                alignment_command.extend([
+                    '--diagnostics-dir', str(alignment_diagnostics),
+                    '--worst-views', str(args.alignment_diagnostic_worst_views),
+                ])
+            commands.append(('camera-LiDAR alignment', alignment_command))
         if (rebuild_map or rebuild_images or args.force_quality or
                 is_stale(colour_report, [colored_map, transforms])):
             commands.append(('held-out colour', [
@@ -471,6 +480,8 @@ def run_pipeline(args) -> dict:
             args.dynamic_map_cleaner_free_votes_floor < 1 or
             args.dynamic_map_cleaner_void_min_scans < 1):
         raise ValueError('invalid dynamic map cleaner settings')
+    if args.alignment_diagnostic_worst_views < 1:
+        raise ValueError('--alignment-diagnostic-worst-views must be >= 1')
     if args.refine_spatiotemporal_calibration and (
             args.calibration_view_stride < 1 or
             args.calibration_max_points < 1 or
@@ -680,6 +691,9 @@ def build_parser() -> argparse.ArgumentParser:
                         'checks using this profile')
     p.add_argument('--appearance-planar-roughness', action='store_true',
                    help='include PCA-planar voxel roughness in appearance report')
+    p.add_argument('--alignment-diagnostics', action='store_true',
+                   help='write signed residual overlays for worst camera views')
+    p.add_argument('--alignment-diagnostic-worst-views', type=int, default=10)
     p.add_argument('--trajectory-report', type=Path,
                    help='metrics.json containing evo.ape.rmse for quality gate')
     p.add_argument('--geometry-report', type=Path,

--- a/tools/colored_map/colored_map_pipeline.py
+++ b/tools/colored_map/colored_map_pipeline.py
@@ -349,7 +349,18 @@ def build_commands(args) -> list[tuple[str, list[str]]]:
                 str(args.calibration_minimum_edge_points),
                 '--minimum-heldout-improvement',
                 str(args.calibration_minimum_heldout_improvement),
-            ]))
+            ] + ([
+                '--depth-support-radius',
+                str(args.calibration_depth_support_radius),
+                '--depth-support-min-neighbors',
+                str(args.calibration_depth_support_min_neighbors),
+                '--depth-support-absolute',
+                str(args.calibration_depth_support_absolute),
+                '--depth-support-relative',
+                str(args.calibration_depth_support_relative),
+                '--minimum-supported-edge-fraction',
+                str(args.calibration_minimum_supported_edge_fraction),
+            ] if args.calibration_depth_support_radius > 0 else [])))
 
     if (rebuild_images or rebuild_masks or rebuild_calibration or
             args.force_map or
@@ -383,6 +394,17 @@ def build_commands(args) -> list[tuple[str, list[str]]]:
                 alignment_command.extend([
                     '--diagnostics-dir', str(alignment_diagnostics),
                     '--worst-views', str(args.alignment_diagnostic_worst_views),
+                ])
+            if args.alignment_depth_support_radius > 0:
+                alignment_command.extend([
+                    '--depth-support-radius',
+                    str(args.alignment_depth_support_radius),
+                    '--depth-support-min-neighbors',
+                    str(args.alignment_depth_support_min_neighbors),
+                    '--depth-support-absolute',
+                    str(args.alignment_depth_support_absolute),
+                    '--depth-support-relative',
+                    str(args.alignment_depth_support_relative),
                 ])
             commands.append(('camera-LiDAR alignment', alignment_command))
         if (rebuild_map or rebuild_images or args.force_quality or
@@ -482,6 +504,20 @@ def run_pipeline(args) -> dict:
         raise ValueError('invalid dynamic map cleaner settings')
     if args.alignment_diagnostic_worst_views < 1:
         raise ValueError('--alignment-diagnostic-worst-views must be >= 1')
+    for prefix, radius, neighbours, absolute, relative in (
+            ('calibration', args.calibration_depth_support_radius,
+             args.calibration_depth_support_min_neighbors,
+             args.calibration_depth_support_absolute,
+             args.calibration_depth_support_relative),
+            ('alignment', args.alignment_depth_support_radius,
+             args.alignment_depth_support_min_neighbors,
+             args.alignment_depth_support_absolute,
+             args.alignment_depth_support_relative)):
+        if (radius < 0 or neighbours < 1 or absolute < 0.0 or relative < 0.0 or
+                (radius > 0 and neighbours > (2 * radius + 1) ** 2 - 1)):
+            raise ValueError(f'invalid {prefix} depth support settings')
+    if not 0.0 <= args.calibration_minimum_supported_edge_fraction <= 1.0:
+        raise ValueError('invalid calibration minimum supported edge fraction')
     if args.refine_spatiotemporal_calibration and (
             args.calibration_view_stride < 1 or
             args.calibration_max_points < 1 or
@@ -611,6 +647,15 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument('--calibration-minimum-edge-points', type=int, default=50)
     p.add_argument('--calibration-minimum-heldout-improvement', type=float,
                    default=0.0)
+    p.add_argument('--calibration-depth-support-radius', type=int, default=0)
+    p.add_argument('--calibration-depth-support-min-neighbors', type=int,
+                   default=4)
+    p.add_argument('--calibration-depth-support-absolute', type=float,
+                   default=0.10)
+    p.add_argument('--calibration-depth-support-relative', type=float,
+                   default=0.01)
+    p.add_argument('--calibration-minimum-supported-edge-fraction', type=float,
+                   default=0.25)
     p.add_argument('--max-trajectory-gap', type=float, default=0.5,
                    help='reject sparse pose streams with a larger gap (s); '
                         'set <=0 to disable')
@@ -694,6 +739,13 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument('--alignment-diagnostics', action='store_true',
                    help='write signed residual overlays for worst camera views')
     p.add_argument('--alignment-diagnostic-worst-views', type=int, default=10)
+    p.add_argument('--alignment-depth-support-radius', type=int, default=0)
+    p.add_argument('--alignment-depth-support-min-neighbors', type=int,
+                   default=4)
+    p.add_argument('--alignment-depth-support-absolute', type=float,
+                   default=0.10)
+    p.add_argument('--alignment-depth-support-relative', type=float,
+                   default=0.01)
     p.add_argument('--trajectory-report', type=Path,
                    help='metrics.json containing evo.ape.rmse for quality gate')
     p.add_argument('--geometry-report', type=Path,


### PR DESCRIPTION
## Summary

- add worst-view camera-LiDAR residual overlays, signed displacement diagnostics, and pipeline integration
- add surface-support retention accounting and hard rejection for sparse calibration evidence
- add full-density fixed 3D contour banks so calibration evidence is independent of the 300k-point subsample
- evaluate optional orientation-aware matching while preserving rejected candidates as diagnostics

## Why

The K4 coloured-map release gates passed even though the rendered map still showed severe colour bleeding. Aggregate thresholds hid scene-dependent residuals, and sparse image-plane support could make filtered candidates look artificially better.

This PR strengthens the evidence and rejection architecture. It does **not** promote a new K5 map, camera pose, or README asset.

## Results

- K4 worst views: 36.5–54.2% of depth edges had no image edge within 12 px
- surface-support candidate retained only 7.62% under the production 300k-point condition and is rejected
- geometry-only fixed contours retained all 260k smoke-test contour points, but held-out improvement was only 0.76%
- 30° orientation candidate improved held-out loss by only 0.52%, reached search bounds, and failed observability
- rejected calibration exports preserve the original poses

## Validation

- `python3 -m pytest -q graph_based_slam/test/test_lidar_camera_alignment.py graph_based_slam/test/test_colored_map_pipeline.py graph_based_slam/test/test_spatiotemporal_calibration.py`
- 76 passed
- Python bytecode compilation and `git diff --check` passed
