### PR TITLE
Pin RKO-LIO odom topic in the SLAM launch

### DIFF
--- a/lidarslam/launch/rko_lio_slam.launch.py
+++ b/lidarslam/launch/rko_lio_slam.launch.py
@@ -73,6 +73,10 @@ def create_rko_offline_node(context, *args, **kwargs):
         'initialization_phase': LaunchConfiguration('initialization_phase'),
         'skip_to_time': LaunchConfiguration('skip_to_time'),
         'publish_deskewed_scan': True,
+        # The upstream-integrated rko_lio defaults to "rko_lio/odom"; the
+        # graph backend below (and the record_backend_input tooling) expect
+        # the fork's historical "/rko_lio/odometry".
+        'odom_topic': '/rko_lio/odometry',
         'dump_results': LaunchConfiguration('dump_results'),
         'results_dir': LaunchConfiguration('results_dir'),
         'run_name': LaunchConfiguration('run_name'),

--- a/lidarslam/test/test_rko_lio_launch_config.py
+++ b/lidarslam/test/test_rko_lio_launch_config.py
@@ -210,3 +210,48 @@ def test_rko_launch_declares_gnss_topic_argument():
         kw for kw in gnss_topic_call.keywords if kw.arg == 'default_value'
     )
     assert _constant_string(default_kw.value) == '/gnss/fix'
+
+
+def test_offline_node_pins_odom_topic():
+    """The frontend must publish odometry on the fork's historical topic.
+
+    The upstream-integrated rko_lio renamed its default odometry topic from
+    "rko_lio/odometry" to "rko_lio/odom".  The graph backend's odom_input
+    remap (and the record_backend_input tooling) still expect
+    "/rko_lio/odometry", so the launch must pin odom_topic explicitly;
+    otherwise the backend silently receives no odometry and saves an empty
+    map.
+    """
+    module = _parse_launch_ast()
+    factory = _find_function(module, 'create_rko_offline_node')
+
+    found = False
+    for launch_dict in (n for n in ast.walk(factory) if isinstance(n, ast.Dict)):
+        for key, value in zip(launch_dict.keys, launch_dict.values):
+            if _constant_string(key) != 'odom_topic':
+                continue
+            assert _constant_string(value) == '/rko_lio/odometry'
+            found = True
+    assert found
+
+
+def test_graph_backend_odom_remap_matches_frontend_topic():
+    """The backend odom_input remap must target the pinned frontend topic."""
+    module = _parse_launch_ast()
+    factory = _find_function(module, 'create_graph_based_slam_node')
+
+    remap_pairs = []
+    for call in (n for n in ast.walk(factory) if isinstance(n, ast.Call)):
+        if not isinstance(call.func, ast.Name) or call.func.id != 'Node':
+            continue
+        remappings_kw = next(
+            (kw for kw in call.keywords if kw.arg == 'remappings'), None
+        )
+        if remappings_kw is None:
+            continue
+        remap_pairs.extend(
+            tuple(_constant_string(elt) for elt in pair.elts)
+            for pair in remappings_kw.value.elts
+            if isinstance(pair, ast.Tuple)
+        )
+    assert ('odom_input', '/rko_lio/odometry') in remap_pairs

--- a/lidarslam/test/test_rko_lio_launch_config.py
+++ b/lidarslam/test/test_rko_lio_launch_config.py
@@ -213,15 +213,13 @@ def test_rko_launch_declares_gnss_topic_argument():
 
 
 def test_offline_node_pins_odom_topic():
-    """The frontend must publish odometry on the fork's historical topic.
-
-    The upstream-integrated rko_lio renamed its default odometry topic from
-    "rko_lio/odometry" to "rko_lio/odom".  The graph backend's odom_input
-    remap (and the record_backend_input tooling) still expect
-    "/rko_lio/odometry", so the launch must pin odom_topic explicitly;
-    otherwise the backend silently receives no odometry and saves an empty
-    map.
-    """
+    """The frontend must publish odometry on the fork's historical topic."""
+    # The upstream-integrated rko_lio renamed its default odometry topic from
+    # "rko_lio/odometry" to "rko_lio/odom".  The graph backend's odom_input
+    # remap (and the record_backend_input tooling) still expect
+    # "/rko_lio/odometry", so the launch must pin odom_topic explicitly;
+    # otherwise the backend silently receives no odometry and saves an empty
+    # map.
     module = _parse_launch_ast()
     factory = _find_function(module, 'create_rko_offline_node')
 


### PR DESCRIPTION
## Summary

The upstream-master integration of the `rko_lio` submodule (fork PR #3) renamed its default odometry topic from `rko_lio/odometry` to `rko_lio/odom`. `rko_lio_slam.launch.py` still remaps the graph backend's `odom_input` to `/rko_lio/odometry`, so the backend silently received **no odometry, created zero submaps, and `map_save` wrote an empty map** (`/rko_lio/odometry`: Publisher count 0, Subscription count 3). The `record_backend_input.sh` / `run_backend_replay_variance.sh` tooling records the same topic and is equally affected.

This PR pins `odom_topic: /rko_lio/odometry` in the offline node parameters (keeping the fork's historical contract that all backend tooling expects) and adds two AST regression tests that keep the frontend topic and the backend remap in sync, so a future rename fails fast instead of silently producing an empty map.

## Reproduce

```bash
ros2 launch lidarslam rko_lio_slam.launch.py \
  main_param_dir:=$PWD/lidarslam/param/lidarslam_lidar_degeneracy.yaml \
  rko_param_file:=$PWD/lidarslam/param/rko_lio_lidar_degeneracy_radar_continuous_tunnel.ros.yaml \
  bag_path:=<lidar_degeneracy_datasets>/ros2_radar/tunnel \
  lidar_topic:=/os_cloud_node/points imu_topic:=/vectornav_node/uncomp_imu \
  save_dir:=<out> use_rviz:=false
# before: "Odom input" never logged, map_save writes an empty map
# after:  300 submaps / 504.5 m, map.pcd with 691k points
```

## Benchmark (NTNU LiDAR Degeneracy tunnel, true one-way distance ~500 m)

| stage | endpoint distance | note |
|---|---:|---|
| frontend odometry | 505.03 m (+1.0%) | matches the documented continuous-fusion result |
| backend optimized | 504.76 m (+0.95%) | 303 poses, zero loops (pass-through as intended) |

Map quality (`run_map_quality_check.sh`): 691k points, MME −1.481 nats, plane thickness RMS mean 0.0598 m / p95 0.1104 m, planar coverage 0.808. Artifacts under `benchmarks/lidar_degeneracy_datasets_v1/runs/tunnel_full_slam_map_v1`.

## Tests

- `python3 -m pytest lidarslam/test/test_rko_lio_launch_config.py -q` → 7 passed (2 new)
- `lidarslam/test/` suite: 79 passed, 2 pre-existing environment-dependent failures in `test_benchmark_summary_profiles.py` (also fail on clean `origin/develop`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHdmiymJbTKU8zvMB5ibtf