### PR TITLE
Add radarless tunnel IMU preset

### DIFF
--- a/docs/degeneracy-guide.md
+++ b/docs/degeneracy-guide.md
@@ -16,7 +16,7 @@ exp07 negative-result check). Read that page for the full methodology.
 
 | Symptom | Root cause | Preset | Sensors needed |
 | --- | --- | --- | --- |
-| Trajectory reach is much shorter than the true traveled distance in a long, straight, self-similar corridor/tunnel | Single-axis (translation-along-travel) degeneracy: ICP's Hessian is genuinely weak along the corridor axis, so small residuals get absorbed as "no motion" | [`tunnel_radar.ros.yaml`](https://github.com/rsasaki0109/lidar_slam_ros2/blob/develop/lidarslam/param/presets/tunnel_radar.ros.yaml) if you have radar; [`tunnel_intensity_no_radar.ros.yaml`](https://github.com/rsasaki0109/lidar_slam_ros2/blob/develop/lidarslam/param/presets/tunnel_intensity_no_radar.ros.yaml) if you don't **and** the corridor has distinctive reflectivity markings (see limitations) | LiDAR + IMU (+ radar, strongly preferred) |
+| Trajectory reach is much shorter than the true traveled distance in a long, straight, self-similar corridor/tunnel | ICP can enter a confident zero-motion attractor: nearest-neighbour wall correspondences confirm "no motion" even while the platform moves | [`tunnel_radar.ros.yaml`](https://github.com/rsasaki0109/lidar_slam_ros2/blob/develop/lidarslam/param/presets/tunnel_radar.ros.yaml) if you have radar; [`tunnel_imu_no_radar.ros.yaml`](../lidarslam/param/presets/tunnel_imu_no_radar.ros.yaml) for a mostly-straight, known-speed LiDAR+IMU traverse; the older [`tunnel_intensity_no_radar.ros.yaml`](https://github.com/rsasaki0109/lidar_slam_ros2/blob/develop/lidarslam/param/presets/tunnel_intensity_no_radar.ros.yaml) only when reflectivity is distinctive | LiDAR + IMU (+ radar, strongly preferred) |
 | Pose freezes in fog/dust/smoke despite real motion: point count drops, IMU still shows walking/driving vibration, reported velocity goes to ~0 | "Clutter lock" -- aerosol returns travel with the sensor, so ICP sees a **healthy, well-conditioned** Hessian and confidently reports near-zero motion. Eigenvalue-based weak-direction gates never fire in this mode -- only a second, disagreeing sensor can catch it | [`corridor_fog_radar.ros.yaml`](https://github.com/rsasaki0109/lidar_slam_ros2/blob/develop/lidarslam/param/presets/corridor_fog_radar.ros.yaml) | LiDAR + IMU + radar (required -- no radar-less fix is validated for this failure mode) |
 | The whole traverse bends smoothly downward (or upward): a long, actually-level tunnel maps as a parabola-in-z (tens of meters of height sag over a few hundred meters) even though reach and lateral tracking look fine | Slow pitch/roll drift relative to gravity. The built-in `min_beta` orientation regularization cannot correct this by construction: its reference comes from a body-acceleration Kalman filter whose measurement is built with the *current* rotation estimate, so the reference drifts along with the estimate (measured on the NTNU tunnel: a 0.5 -> 6.3 deg monotonic gravity tilt that survives a 40x stronger `min_beta` weight) | `gravity_window_alignment: true` (included in [`tunnel_radar.ros.yaml`](https://github.com/rsasaki0109/lidar_slam_ros2/blob/develop/lidarslam/param/presets/tunnel_radar.ros.yaml) and [`corridor_fog_radar.ros.yaml`](https://github.com/rsasaki0109/lidar_slam_ros2/blob/develop/lidarslam/param/presets/corridor_fog_radar.ros.yaml)): the ~20 s window mean of raw accelerometer samples, rotated into the world frame, is an absolute up reference; the residual tilt is fed back as a small, capped, roll/pitch-only correction. Verify with `gravity_alignment_summary.json` (`dump_results: true`) -- `last_tilt_deg` should stay small. Preset-scoped on purpose: on a general handheld walk with frequent turns (HILTI exp07) it slightly *worsened* control-point APE (0.208 -> 0.264 m), and on a driving robot (MID-360) the magnitude gate kept it fully dormant (byte-identical trajectory) | LiDAR + IMU (accelerometer only -- no extra sensor) |
 | Otherwise-good tracking but consistent drift along just one axis (e.g. lateral creep down a flat-walled corridor, or vertical creep under a low, featureless ceiling) | A single Hessian eigenvalue is persistently weak along that one world-frame axis. Confirm with `degeneracy_persistence.csv` (dumped when `dump_results: true`; columns include `confirmed`, `axis_tx..axis_rz`) before reaching for a preset -- it tells you which axis and how often it's confirmed | Same as the corridor/tunnel row if an external sensor (radar or a distinctively textured surface) observes that axis; otherwise `degeneracy_aware_solve` alone (in `tunnel_radar.ros.yaml` / `tunnel_intensity_no_radar.ros.yaml`, minus the radar/intensity gates) still blends a geometric/IMU prior into the confirmed weak direction, with no cross-sensor validation behind it | LiDAR + IMU, cross-sensor gate only if the weak axis is externally observable |
@@ -106,6 +106,15 @@ With `dump_results: true`, `rko_lio` writes summary JSON files to
     that it's helping; you still need to A/B the actual trajectory error or
     reach distance against `degeneracy_off.ros.yaml` before trusting a new
     environment.
+- **`kinematic_velocity_blend_summary.json`** (written whenever
+  `kinematic_velocity_blend: true`):
+  - `anchor_refresh_count` -- scans where 3D ICP velocity agreed closely
+    enough with independent IMU propagation to refresh trust.
+  - `corrected_scan_count` and `mean_correction_m` -- how often and how far
+    the optimized translation was moved.
+  - `mean_propagation_weight`, `max_propagation_weight`, and
+    `max_anchor_age_sec` -- whether the run spent long periods bridged by an
+    old prior. These are diagnostics, not a universal pass threshold.
 - `degeneracy_persistence.csv` -- per-scan diagnostics for the
   Hessian-eigenvalue gates (`confirmed`, `consecutive_scans`,
   `matched_absolute_cosine`, `intervention_count`, and the weak-axis
@@ -134,14 +143,16 @@ environment.
   even between environments on the same rig -- the same 1.05 that helps the
   tunnel makes fog slightly *worse*. Only tune it against a sequence with
   trustworthy distance ground truth.
-- **Soft degeneracy without radar remains unsolved.** In the tunnel dataset,
-  confirmed Hessian-weak-direction windows cover only ~17% of the route;
-  the rest of the distance error accumulates during "soft" degeneracy that
-  never triggers a hard eigenvalue gate. The intensity disagreement gate
-  recovers *some* of this (radar-less tunnel: 98.67 m -> 153.75 m of ~500 m
-  true), but nowhere near what radar achieves (457-495 m), and only under
-  the narrow applicability condition above. There is currently no
-  radar-less fix for fog-style clutter lock at all.
+- **Radar-less IMU velocity blending is straight-motion and speed-envelope
+  specific.** `tunnel_imu_no_radar.ros.yaml` improves the radar-less NTNU
+  tunnel reach from 102.3 m to 294.7 m without exceeding the pseudo-GT scale
+  at any time. Its 2.0 m/s propagated-speed cap is calibrated for a 1.7 m/s
+  walk, not a universal value. A sustained-yaw gate is essential: removing it
+  reaches 517.2 m but badly regresses the fog loop. The conservative preset is
+  nearly neutral on fog and HILTI exp07, but changed a MID-360 driving
+  trajectory by 0.101 m aligned RMSE, so it remains preset-scoped and
+  default-off. There is still no validated radar-less fix for fog-style
+  clutter lock.
 - **Kidnap/registration-failure handling is stop-and-split, not
   relocalize, for mapping workflows.** All presets in this repo ship with
   `enable_kidnap_relocalization` and `reset_on_registration_failure` left

--- a/docs/research/radarless-tunnel-velocity-blend-2026-07.md
+++ b/docs/research/radarless-tunnel-velocity-blend-2026-07.md
@@ -1,0 +1,82 @@
+# Radar-less tunnel anchor-decayed velocity blend (2026-07-27)
+
+## Decision
+
+Adopt as a default-off, straight-walking-tunnel preset only:
+`lidarslam/param/presets/tunnel_imu_no_radar.ros.yaml`.
+
+The conservative adopted arm reaches 294.72 m of the ~500 m NTNU
+Fyllingsdalen tunnel, versus 102.3 m plain RKO-LIO and 153.8 m for the older
+intensity-disagreement fallback. It never exceeds the radar-derived pseudo-GT
+scale (maximum reach ratio 0.983).
+
+## Failure mechanism
+
+The tunnel failure is not a gentle scale error. At about 40 m, point-to-point
+ICP locks onto self-similar wall correspondences and reports zero motion for
+roughly 160 s. Its translation Hessian block remains approximately `N * I`,
+so Hessian-derived confidence cannot detect the lock.
+
+The implemented prior independently integrates gravity-compensated IMU
+acceleration from the last scan where 3D ICP velocity agreed with propagation.
+ICP uses a fixed information scale. Propagation information decays
+exponentially with anchor age. Agreement scans refresh time but do not feed ICP
+velocity back into the independently propagated state.
+
+Four guards were required:
+
+1. 3D ICP innovation is norm-capped before fusion; otherwise an arbitrarily
+   large ICP outlier leaks through any finite Gaussian weight.
+2. The propagated pseudo-sensor speed is capped; otherwise accelerometer bias
+   eventually makes the prior itself diverge.
+3. Expected cross-axis velocity is zero relative to the previous motion axis;
+   otherwise IMU lateral drift steers the trajectory.
+4. Sustained yaw clears the anchor. Five consecutive intervals above
+   0.05 rad/s reject fog/handheld turns without reacting to isolated tunnel
+   vibration.
+
+## Adopted parameters
+
+- ICP information 1, propagation information 9 (fresh weight 0.9)
+- decay time 100 s
+- anchor agreement 0.05 m/s in 3D
+- ICP innovation cap 1.0 m/s
+- propagated speed cap 2.0 m/s (dataset pace ~1.7 m/s)
+- minimum speed 0.3 m/s
+- yaw gate 0.05 rad/s for 5 consecutive scans
+- full map insertion
+
+## A/B and holdouts
+
+| sequence | control | adopted candidate | result |
+| --- | ---: | ---: | --- |
+| NTNU tunnel reach | 102.3 m | 294.72 m | 1.92x, max pseudo-GT ratio 0.983 |
+| NTNU fog start/end reach | 32.80 m | 32.88 m | effectively neutral |
+| HILTI exp07 SE(3) APE | 0.2082 m | 0.2264 m | +1.8 cm |
+| MID-360 driving | reference run | 0.101 m aligned delta RMSE | six corrected scans; not byte-identical |
+
+Artifacts:
+
+- `/media/sasaki/aiueo/benchmarks/lidar_degeneracy_datasets_v1/runs/tunnel_velocity_blend_v1`
+- `/media/sasaki/aiueo/benchmarks/lidar_degeneracy_datasets_v1/runs/fog_velocity_blend_v1`
+- `/media/sasaki/aiueo/benchmarks/velocity_blend_holdout_20260727`
+
+## Rejected branches
+
+- Hard kinematic clamp with map insertion: 3.1x self-confirming runaway.
+- Hard clamp with map skip: startup reversal and registration death.
+- Linear soft blend fed from corrected LIO velocity: kilometre-scale positive
+  feedback.
+- Independent IMU state without robust ICP innovation: finite ICP weight still
+  admitted huge outliers.
+- Robust ICP without propagated-speed cap: accelerometer bias made the prior
+  diverge.
+- No yaw gate: 517.18 m tunnel reach (ratio 1.025) but fog reach 87.28 m.
+- Yaw gate persistence 10 scans: 415.59 m tunnel and exp07 0.2133 m, but fog
+  reach worsened to 36.17 m.
+- Localizability weighting combination: tunnel endpoint improved to 499.89 m,
+  but MID-360 changed by 1.424 m aligned RMSE; rejected.
+
+The speed cap is an explicit platform-envelope calibration. Re-tune it for a
+different rig only against trusted distance ground truth, and repeat fog,
+turning-handheld, and driving negative checks.

--- a/lidarslam/param/presets/degeneracy_off.ros.yaml
+++ b/lidarslam/param/presets/degeneracy_off.ros.yaml
@@ -32,3 +32,4 @@
     radar_disagreement_gate: false
     intensity_constraint: false
     intensity_disagreement_gate: false
+    kinematic_velocity_blend: false

--- a/lidarslam/param/presets/degeneracy_off.yaml
+++ b/lidarslam/param/presets/degeneracy_off.yaml
@@ -25,3 +25,4 @@ radar_velocity_fusion: false
 radar_disagreement_gate: false
 intensity_constraint: false
 intensity_disagreement_gate: false
+kinematic_velocity_blend: false

--- a/lidarslam/param/presets/tunnel_imu_no_radar.ros.yaml
+++ b/lidarslam/param/presets/tunnel_imu_no_radar.ros.yaml
@@ -1,0 +1,56 @@
+# Radar-less long straight tunnel/corridor preset (LiDAR + IMU).
+#
+# Symptom: point-to-point ICP enters a confident zero-motion attractor in a
+# long self-similar tunnel. The pose freezes even though IMU propagation still
+# indicates forward motion.
+#
+# Scope is intentionally narrow:
+#   - long, mostly straight, walking-speed traverses;
+#   - LiDAR + IMU only;
+#   - known maximum platform speed, tuned below.
+#
+# Do not use this as a general driving or turning-motion preset. The IMU prior
+# is disabled after sustained yaw, but short turns and the speed limit remain
+# application-specific. For radar-equipped rigs, tunnel_radar.ros.yaml is
+# better validated and does not require a walking-speed cap.
+#
+# Validated on NTNU Fyllingsdalen (~500 m):
+#   plain rko_lio                         102.3 m
+#   intensity-only radar-less preset     153.8 m
+#   this preset                          294.7 m
+#   less-conservative yaw gate (10 scans) 415.6 m, but fog regressed slightly;
+#   no yaw gate reached 517.2 m, but failed the fog negative check.
+#
+# Negative checks for this conservative 5-scan preset:
+#   NTNU fog reach 32.88 m vs baseline 32.80 m;
+#   HILTI exp07 SE(3) APE 0.226 m vs baseline 0.208 m;
+#   MID-360 trajectory delta 0.101 m RMSE (6 corrected scans).
+#
+# Layer this after the sensor config. All feature defaults remain OFF.
+/**:
+  ros__parameters:
+    kinematic_velocity_blend: true
+
+    # Fixed information scales: fresh propagation weight = 9 / (1 + 9) = 0.9.
+    kinematic_blend_icp_information_scale: 1.0
+    kinematic_blend_propagation_information_scale: 9.0
+    kinematic_blend_decay_time_sec: 100.0
+
+    # Only near-exact 3D ICP/propagation agreement refreshes the anchor.
+    kinematic_blend_anchor_agreement_mps: 0.05
+
+    # Robustify both inputs. TODO-USER: set the speed cap from the real
+    # platform envelope. 2.0 m/s is specific to the ~1.7 m/s NTNU walk.
+    kinematic_blend_max_icp_innovation_mps: 1.0
+    kinematic_blend_max_propagated_speed_mps: 2.0
+    kinematic_blend_min_speed: 0.3
+
+    # Clear the straight-motion prior after 5 consecutive scan intervals over
+    # the yaw threshold. Single-scan IMU vibration does not trip the gate.
+    kinematic_blend_max_yaw_rate_rad_s: 0.05
+    kinematic_blend_yaw_gate_min_scans: 5
+
+    # Validated arm keeps map insertion enabled. Lower values are experimental:
+    # partial/full suppression did not prevent runaway in the development sweep.
+    kinematic_blend_map_update_max_propagation_weight: 1.0
+    kinematic_blend_map_update_min_fraction: 1.0


### PR DESCRIPTION
## What changed

- update the `rko_lio` submodule to the radar-less velocity-blend implementation
- add `tunnel_imu_no_radar.ros.yaml`, a default-off straight walking-tunnel preset
- add the symptom-to-preset entry and velocity-blend diagnostics to the degeneracy guide
- add a research note with the design evolution, rejected branches, A/B results, and holdouts
- include the new feature in both documented no-op presets

Depends on rsasaki0109/rko_lio#6.

## Why

Plain RKO-LIO freezes near 40 m in the approximately 500 m NTNU
Fyllingsdalen tunnel. The existing radar-less intensity fallback reaches
153.8 m, but cannot escape the long zero-motion attractor reliably.

The new preset applies an anchor-decayed IMU/ICP velocity blend with robust
3D innovation handling, a calibrated walking-speed envelope, and a
sustained-yaw safety gate. It is intentionally scoped to mostly-straight,
known-speed LiDAR+IMU traverses and remains default-off.

## Results

Adopted conservative preset:

- NTNU tunnel: 102.3 m baseline -> 294.72 m
- maximum time-aligned pseudo-GT reach ratio: 0.983
- NTNU fog: 32.80 m baseline -> 32.88 m
- HILTI exp07 SE(3) APE: 0.2082 m baseline -> 0.2264 m
- MID-360 aligned trajectory delta: 0.101 m RMSE

The 2.0 m/s propagated-speed cap is specific to the measured approximately
1.7 m/s walking pace and is marked as a user calibration point.

## Validation

- Release `rko_lio` ROS build passed
- velocity blend tests: 9/9
- legacy kinematic gate tests: 7/7
- localizability/voxel-normal tests: 8/8
- docs entrypoint tests: 6/6
- all preset YAML files parsed successfully
- `git diff --check` passed in both repositories
