### PR TITLE
Adopt adaptive radar-less tunnel applicability gate

### DIFF
--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -12,6 +12,37 @@ bash scripts/download_ntu_viral_tnp01.sh
 bash scripts/run_rko_lio_graph_benchmark.sh
 ```
 
+### Radar-less tunnel frontend A/B
+
+The radar-less tunnel research track has a frontend-only control/candidate
+runner. It uses isolated DDS domains, stops `offline_node` with `SIGINT` after
+odometry becomes quiet, and records the exact parameter layers, Git SHAs, TUM
+trajectories, and comparison metrics:
+
+```bash
+bash scripts/run_radarless_tunnel_ab.sh \
+  --sequence tunnel \
+  --output-root /media/<ssd>/benchmarks/radarless_tunnel_adaptive_v1
+```
+
+Use `--candidate-param name:=value` for a focused override and `--dry-run` to
+freeze the commands without starting ROS. Run `--sequence fog` as the first
+negative check. HILTI exp07 and MID-360 are also supported with explicit
+`--bag`, topic, base-parameter, and optional reference arguments. The runner
+intentionally rejects exp02, exp03, and exp21 because they are reserved final
+holdouts.
+
+`comparison.json` includes endpoint/path metrics, time-aligned reach-ratio
+quantiles after the first 10 m of reference motion, and an SE(3)-aligned
+translation delta. It also records candidate overrides and the velocity-blend
+diagnostic summary when present. For an existing trajectory, the same evaluator
+can be run directly:
+
+```bash
+python3 scripts/evaluate_degeneracy_trajectory.py <candidate.tum> \
+  --reference-trajectory <dense-reference.tum>
+```
+
 ## FAST-LIVO2 head-to-head
 
 Use the exact same bag, sensor messages, calibration, trajectory reference, and

--- a/docs/degeneracy-guide.md
+++ b/docs/degeneracy-guide.md
@@ -145,14 +145,15 @@ environment.
   trustworthy distance ground truth.
 - **Radar-less IMU velocity blending is straight-motion and speed-envelope
   specific.** `tunnel_imu_no_radar.ros.yaml` improves the radar-less NTNU
-  tunnel reach from 102.3 m to 294.7 m without exceeding the pseudo-GT scale
-  at any time. Its 2.0 m/s propagated-speed cap is calibrated for a 1.7 m/s
-  walk, not a universal value. A sustained-yaw gate is essential: removing it
-  reaches 517.2 m but badly regresses the fog loop. The conservative preset is
-  nearly neutral on fog and HILTI exp07, but changed a MID-360 driving
-  trajectory by 0.101 m aligned RMSE, so it remains preset-scoped and
-  default-off. There is still no validated radar-less fix for fog-style
-  clutter lock.
+  tunnel reach from 102.3 m to 415.6 m; its maximum time-aligned pseudo-GT
+  reach ratio is 0.983. Its 2.0 m/s propagated-speed cap is calibrated for a
+  1.7 m/s walk, not a universal value. Sustained-yaw, walking-speed, and
+  near/far range-distribution gates clear the anchor when the scene leaves the
+  validated envelope. Sixty-second speed and scene cooldowns prevent isolated
+  scans from rearming it. Paired runs on fog, HILTI exp07, and MID-360 were
+  byte-identical to default-off controls, but the feature remains
+  preset-scoped and default-off. There is still no validated radar-less fix
+  for fog-style clutter lock.
 - **Kidnap/registration-failure handling is stop-and-split, not
   relocalize, for mapping workflows.** All presets in this repo ship with
   `enable_kidnap_relocalization` and `reset_on_registration_failure` left

--- a/docs/research/radarless-tunnel-adaptive-applicability-gate-2026-07.md
+++ b/docs/research/radarless-tunnel-adaptive-applicability-gate-2026-07.md
@@ -1,0 +1,98 @@
+# Radar-less tunnel adaptive applicability gate (2026-07-27)
+
+## Decision
+
+Adopt the scene- and speed-gated candidate in the default-off
+`lidarslam/param/presets/tunnel_imu_no_radar.ros.yaml`.
+
+The candidate reaches 415.59 m in the ~500 m NTNU Fyllingsdalen tunnel,
+versus 102.26 m for default-off RKO-LIO. Its final time-aligned reach ratio
+against the radar-derived pseudo-GT is 0.824, with a maximum of 0.983; it does
+not overshoot the reference scale.
+
+Paired candidate/control trajectories are byte-identical on NTNU fog, HILTI
+exp07, and MID-360 driving. The gates therefore retain the tunnel improvement
+without changing any tested negative-check trajectory.
+
+## Applicability signal
+
+The original velocity blend had enough information to detect yaw but not to
+distinguish a long open tunnel from near-field clutter or driving. The adopted
+gate measures two inexpensive fractions from each filtered scan:
+
+- points nearer than 3 m must be no more than 50%;
+- points farther than 10 m must be at least 5%.
+
+Sampled scan distributions motivated those limits:
+
+| sequence | near-fraction p50 | far-fraction p50 | scene gate |
+| --- | ---: | ---: | --- |
+| NTNU tunnel | 0.108 | 0.079 | accepts |
+| NTNU fog | 0.926 | 0.000 | rejects while fog is present |
+| HILTI exp07 | 0.869 | 0.025 | rejects |
+| MID-360 driving | 0.000 | 0.673 | accepts; speed gate rejects |
+
+At least 100 valid points are required. A raw scene rejection starts a 60 s
+cooldown so an isolated clear scan in fog or clutter cannot immediately
+re-arm the anchor.
+
+The independent speed gate rejects activation above 2.5 m/s after three
+consecutive scans, then enforces a 60 s cooldown. The existing 2.0 m/s limit
+still caps the propagated pseudo-sensor itself. The higher activation
+threshold accommodates noisy per-scan ICP velocity around the validated
+~1.7 m/s walking pace; it is not permission to use the prior for driving.
+
+## Adopted parameters
+
+- ICP information 1, propagation information 9, decay time 100 s
+- anchor agreement 0.05 m/s, ICP innovation cap 1.0 m/s
+- propagated speed cap 2.0 m/s, minimum speed 0.3 m/s
+- yaw gate 0.05 rad/s for 10 consecutive scans
+- activation speed limit 2.5 m/s for 3 consecutive scans
+- scene gate: near 3 m / maximum 0.50, far 10 m / minimum 0.05
+- scene and speed re-enable cooldowns 60 s
+- full map insertion
+
+All new library defaults are disabled or behavior-preserving. Only the tunnel
+preset opts into the new gates.
+
+## A/B and holdouts
+
+| sequence | paired control | adopted candidate | decision evidence |
+| --- | ---: | ---: | --- |
+| NTNU tunnel endpoint | 102.26 m | 415.59 m | 4.06x control; max pseudo-GT ratio 0.983 |
+| NTNU fog endpoint | 35.61 m | 35.61 m | byte-identical TUM |
+| HILTI exp07 SE(3) APE | 0.20823 m | 0.20823 m | byte-identical TUM |
+| MID-360 driving | reference run | zero trajectory delta | byte-identical TUM |
+
+The fresh paired fog control reaches 35.61 m. The older 32.80 m result in the
+initial velocity-blend note came from an earlier run configuration and is not
+used as the control for this decision.
+
+The candidate diagnostics explain why each negative check is neutral:
+
+- fog: no blend attempts; 1,364 raw scene rejections plus 359 cooldown
+  rejections;
+- HILTI exp07: no attempts; 1,262 raw scene rejections plus 58 cooldown
+  rejections;
+- MID-360: no corrections; 2,117 raw speed rejections plus 597 cooldown
+  rejections.
+
+Artifacts:
+
+- `/media/sasaki/aiueo/benchmarks/lidar_degeneracy_datasets_v1/runs/radarless_tunnel_scene_gate_v1`
+
+## Rejected variants
+
+- A 2.0 m/s activation limit without cooldown rejected 100 tunnel scans and
+  reduced endpoint reach to 248.29 m.
+- The scene gate without re-enable cooldown admitted 119 fog corrections and
+  shifted the endpoint from 35.61 m to 30.93 m.
+- The speed gate without re-enable cooldown admitted six MID-360 corrections
+  and changed the trajectory by 0.101 m aligned RMSE.
+- Yaw persistence alone at 10 scans reached 415.59 m but previously changed
+  fog and holdout trajectories, so it was not sufficient for adoption.
+
+The preset is still deliberately narrow. Re-tune its speed envelope only
+against trusted distance ground truth, then repeat fog, handheld-turning, and
+driving negative checks.

--- a/docs/research/radarless-tunnel-velocity-blend-2026-07.md
+++ b/docs/research/radarless-tunnel-velocity-blend-2026-07.md
@@ -1,5 +1,10 @@
 # Radar-less tunnel anchor-decayed velocity blend (2026-07-27)
 
+> Update: the adopted preset now includes automatic scene and speed
+> applicability gates. See
+> [adaptive applicability gate](radarless-tunnel-adaptive-applicability-gate-2026-07.md)
+> for the superseding validation.
+
 ## Decision
 
 Adopt as a default-off, straight-walking-tunnel preset only:

--- a/graph_based_slam/test/test_docs_entrypoints.py
+++ b/graph_based_slam/test/test_docs_entrypoints.py
@@ -144,6 +144,7 @@ def test_docs_reference_existing_entrypoint_scripts():
         REPO_ROOT / 'scripts' / 'run_autoware_pointcloud_map_foxglove.sh',
         REPO_ROOT / 'scripts' / 'run_graph_slam_pointcloud_map_in_autoware_foxglove.sh',
         REPO_ROOT / 'scripts' / 'run_rko_lio_graph_benchmark.sh',
+        REPO_ROOT / 'scripts' / 'run_radarless_tunnel_ab.sh',
         REPO_ROOT / 'scripts' / 'run_rko_lio_mid360_crossval_benchmark.sh',
         REPO_ROOT / 'scripts' / 'export_mid360_robot_3d_map_preview.py',
         REPO_ROOT / 'scripts' / 'analyze_mid360_robot_public_loop_cloud.py',
@@ -356,6 +357,8 @@ def test_docs_cover_autoware_and_release_gate_keywords():
 
     assert 'download_ntu_viral_tnp01.sh' in benchmarking_doc
     assert 'run_rko_lio_graph_benchmark.sh' in benchmarking_doc
+    assert 'run_radarless_tunnel_ab.sh' in benchmarking_doc
+    assert 'evaluate_degeneracy_trajectory.py' in benchmarking_doc
     assert 'run_rko_lio_mid360_crossval_benchmark.sh' in benchmarking_doc
     assert 'run_open_data_applanix_velodyne_gnss_benchmark.sh' in benchmarking_doc
     assert 'run_open_data_classic_path_benchmark_suite.sh' in benchmarking_doc

--- a/graph_based_slam/test/test_radarless_tunnel_benchmark_tools.py
+++ b/graph_based_slam/test/test_radarless_tunnel_benchmark_tools.py
@@ -1,0 +1,236 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Regression tests for the radar-less tunnel A/B tools."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+
+import numpy as np
+import pytest
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EVALUATOR_PATH = REPO_ROOT / 'scripts/evaluate_degeneracy_trajectory.py'
+RUNNER_PATH = REPO_ROOT / 'scripts/run_radarless_tunnel_ab.sh'
+PRESET_PATH = (
+    REPO_ROOT / 'lidarslam/param/presets/tunnel_imu_no_radar.ros.yaml'
+)
+
+
+def _load_evaluator():
+    spec = importlib.util.spec_from_file_location(
+        'evaluate_degeneracy_trajectory',
+        EVALUATOR_PATH,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+EVALUATOR = _load_evaluator()
+
+
+def _write_tum(path: Path, timestamps: np.ndarray, xyz: np.ndarray) -> None:
+    rows = [
+        f'{stamp:.6f} {point[0]:.9f} {point[1]:.9f} {point[2]:.9f} '
+        '0 0 0 1'
+        for stamp, point in zip(timestamps, xyz)
+    ]
+    path.write_text('\n'.join(rows) + '\n', encoding='utf-8')
+
+
+def test_reference_metrics_recover_time_aligned_scale_and_rigid_delta(
+    tmp_path: Path,
+) -> None:
+    """Reach ratio should expose scale while rigid alignment removes frame choice."""
+    timestamps = np.linspace(0.0, 20.0, 41)
+    reference_xyz = np.column_stack(
+        (timestamps, 0.05 * timestamps**2, np.sin(timestamps / 4.0)),
+    )
+    rotation = np.array(
+        [[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]],
+    )
+    candidate_xyz = (rotation.T @ (reference_xyz - [3.0, -2.0, 0.5]).T).T
+
+    reference_path = tmp_path / 'reference.tum'
+    candidate_path = tmp_path / 'candidate.tum'
+    _write_tum(reference_path, timestamps, reference_xyz)
+    _write_tum(candidate_path, timestamps, candidate_xyz)
+
+    result = EVALUATOR.evaluate(
+        candidate_path,
+        expected_endpoint_distance=None,
+        reference_path=reference_path,
+        min_reference_reach_m=2.0,
+    )
+
+    assert result['reference']['reach_ratio']['final'] == pytest.approx(1.0)
+    assert result['reference']['reach_ratio']['max'] == pytest.approx(1.0)
+    assert (
+        result['reference']['aligned_translation_delta_m']['rmse']
+        < 1.0e-8
+    )
+
+
+def test_reference_metrics_report_under_reach(tmp_path: Path) -> None:
+    """A scale-deficient candidate should retain its time-aligned reach ratio."""
+    timestamps = np.linspace(0.0, 20.0, 41)
+    reference_xyz = np.column_stack(
+        (timestamps, np.zeros_like(timestamps), np.zeros_like(timestamps)),
+    )
+    candidate_xyz = 0.6 * reference_xyz
+    reference_path = tmp_path / 'reference.tum'
+    candidate_path = tmp_path / 'candidate.tum'
+    _write_tum(reference_path, timestamps, reference_xyz)
+    _write_tum(candidate_path, timestamps, candidate_xyz)
+
+    result = EVALUATOR.evaluate(
+        candidate_path,
+        expected_endpoint_distance=20.0,
+        reference_path=reference_path,
+        min_reference_reach_m=10.0,
+    )
+
+    assert result['endpoint_distance_m'] == pytest.approx(12.0)
+    assert result['reference']['reach_ratio']['final'] == pytest.approx(0.6)
+    assert result['reference']['reach_ratio']['max'] == pytest.approx(0.6)
+
+
+def _minimal_runner_inputs(tmp_path: Path) -> dict[str, Path]:
+    dataset = tmp_path / 'dataset'
+    bag = dataset / 'ros2_radar' / 'tunnel'
+    bag.mkdir(parents=True)
+    (bag / 'metadata.yaml').write_text('rosbag2_bagfile_information:\n')
+    setup = tmp_path / 'setup.bash'
+    setup.write_text('# test setup\n', encoding='utf-8')
+    base = tmp_path / 'base.yaml'
+    base.write_text('/**:\n  ros__parameters: {}\n', encoding='utf-8')
+    candidate = tmp_path / 'candidate.yaml'
+    candidate.write_text('/**:\n  ros__parameters: {}\n', encoding='utf-8')
+    timestamps = np.array([0.0, 1.0, 2.0])
+    reference = tmp_path / 'reference.tum'
+    _write_tum(
+        reference,
+        timestamps,
+        np.column_stack(
+            (timestamps, np.zeros_like(timestamps), np.zeros_like(timestamps)),
+        ),
+    )
+    return {
+        'dataset': dataset,
+        'setup': setup,
+        'base': base,
+        'candidate': candidate,
+        'reference': reference,
+    }
+
+
+def test_runner_dry_run_prints_isolated_control_and_candidate(
+    tmp_path: Path,
+) -> None:
+    """Dry-run should freeze both arms without requiring ROS executables."""
+    paths = _minimal_runner_inputs(tmp_path)
+    result = subprocess.run(
+        [
+            'bash',
+            str(RUNNER_PATH),
+            '--dataset-root',
+            str(paths['dataset']),
+            '--output-root',
+            str(tmp_path / 'output'),
+            '--setup',
+            str(paths['setup']),
+            '--base-params',
+            str(paths['base']),
+            '--candidate-preset',
+            str(paths['candidate']),
+            '--reference-tum',
+            str(paths['reference']),
+            '--candidate-param',
+            'kinematic_blend_yaw_gate_min_scans:=10',
+            '--dry-run',
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.count('DRY_RUN') == 2
+    assert 'ROS_DOMAIN_ID=210' in result.stdout
+    assert 'ROS_DOMAIN_ID=211' in result.stdout
+    assert 'degeneracy_off.ros.yaml' in result.stdout
+    assert 'kinematic_blend_yaw_gate_min_scans:=10' in result.stdout
+
+
+def test_runner_blocks_reserved_final_holdouts() -> None:
+    """The development runner must not consume exp02/03/21."""
+    result = subprocess.run(
+        ['bash', str(RUNNER_PATH), '--sequence', 'exp02', '--dry-run'],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert 'reserved final holdout' in result.stderr
+
+
+def test_adopted_preset_freezes_scene_speed_and_yaw_gates() -> None:
+    """The validated A/B arm must remain reproducible from the preset alone."""
+    document = yaml.safe_load(PRESET_PATH.read_text(encoding='utf-8'))
+    params = document['/**']['ros__parameters']
+
+    assert params['kinematic_velocity_blend'] is True
+    assert params['kinematic_blend_yaw_gate_min_scans'] == 10
+    assert params['kinematic_blend_range_scene_gate'] is True
+    assert params['kinematic_blend_scene_near_range_m'] == pytest.approx(3.0)
+    assert params['kinematic_blend_scene_max_near_fraction'] == pytest.approx(
+        0.5,
+    )
+    assert params['kinematic_blend_scene_far_range_m'] == pytest.approx(10.0)
+    assert params['kinematic_blend_scene_min_far_fraction'] == pytest.approx(
+        0.05,
+    )
+    assert params['kinematic_blend_scene_min_valid_points'] == 100
+    assert params['kinematic_blend_scene_reenable_delay_sec'] == pytest.approx(
+        60.0,
+    )
+    assert params['kinematic_blend_max_activation_speed_mps'] == pytest.approx(
+        2.5,
+    )
+    assert params['kinematic_blend_speed_gate_min_scans'] == 3
+    assert params['kinematic_blend_speed_reenable_delay_sec'] == pytest.approx(
+        60.0,
+    )

--- a/graph_based_slam/test/test_radarless_tunnel_benchmark_tools.py
+++ b/graph_based_slam/test/test_radarless_tunnel_benchmark_tools.py
@@ -30,7 +30,6 @@
 from __future__ import annotations
 
 import importlib.util
-import json
 from pathlib import Path
 import subprocess
 

--- a/lidarslam/param/presets/tunnel_imu_no_radar.ros.yaml
+++ b/lidarslam/param/presets/tunnel_imu_no_radar.ros.yaml
@@ -17,14 +17,12 @@
 # Validated on NTNU Fyllingsdalen (~500 m):
 #   plain rko_lio                         102.3 m
 #   intensity-only radar-less preset     153.8 m
-#   this preset                          294.7 m
-#   less-conservative yaw gate (10 scans) 415.6 m, but fog regressed slightly;
+#   this preset                          415.6 m
 #   no yaw gate reached 517.2 m, but failed the fog negative check.
 #
-# Negative checks for this conservative 5-scan preset:
-#   NTNU fog reach 32.88 m vs baseline 32.80 m;
-#   HILTI exp07 SE(3) APE 0.226 m vs baseline 0.208 m;
-#   MID-360 trajectory delta 0.101 m RMSE (6 corrected scans).
+# Paired negative checks with the applicability gates below:
+#   NTNU fog, HILTI exp07, and MID-360 trajectories are byte-identical
+#   to their default-off controls; HILTI exp07 control APE is 0.208 m.
 #
 # Layer this after the sensor config. All feature defaults remain OFF.
 /**:
@@ -39,16 +37,32 @@
     # Only near-exact 3D ICP/propagation agreement refreshes the anchor.
     kinematic_blend_anchor_agreement_mps: 0.05
 
-    # Robustify both inputs. TODO-USER: set the speed cap from the real
-    # platform envelope. 2.0 m/s is specific to the ~1.7 m/s NTNU walk.
+    # Robustify both inputs. TODO-USER: set these from the real platform
+    # envelope. The 2.0 m/s pseudo-sensor cap is specific to the ~1.7 m/s
+    # NTNU walk. The 2.5 m/s activation limit tolerates per-scan ICP velocity
+    # noise without allowing driving-speed use of this walking prior.
     kinematic_blend_max_icp_innovation_mps: 1.0
     kinematic_blend_max_propagated_speed_mps: 2.0
+    kinematic_blend_max_activation_speed_mps: 2.5
+    kinematic_blend_speed_gate_min_scans: 3
+    kinematic_blend_speed_reenable_delay_sec: 60.0
     kinematic_blend_min_speed: 0.3
 
-    # Clear the straight-motion prior after 5 consecutive scan intervals over
+    # Clear the straight-motion prior after 10 consecutive scan intervals over
     # the yaw threshold. Single-scan IMU vibration does not trip the gate.
     kinematic_blend_max_yaw_rate_rad_s: 0.05
-    kinematic_blend_yaw_gate_min_scans: 5
+    kinematic_blend_yaw_gate_min_scans: 10
+
+    # Activate only when the observed ranges resemble an open, long corridor.
+    # Dense near clutter rejects fog and handheld scenes. A 60 s cooldown
+    # prevents intermittent clear scans from repeatedly rearming the prior.
+    kinematic_blend_range_scene_gate: true
+    kinematic_blend_scene_near_range_m: 3.0
+    kinematic_blend_scene_max_near_fraction: 0.5
+    kinematic_blend_scene_far_range_m: 10.0
+    kinematic_blend_scene_min_far_fraction: 0.05
+    kinematic_blend_scene_min_valid_points: 100
+    kinematic_blend_scene_reenable_delay_sec: 60.0
 
     # Validated arm keeps map insertion enabled. Lower values are experimental:
     # partial/full suppression did not prevent runaway in the development sweep.

--- a/scripts/evaluate_degeneracy_trajectory.py
+++ b/scripts/evaluate_degeneracy_trajectory.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 
@@ -23,7 +25,10 @@ def load_tum(path: Path) -> np.ndarray:
     return trajectory
 
 
-def evaluate(path: Path, expected_endpoint_distance: float | None) -> dict:
+def trajectory_metrics(
+    path: Path,
+    expected_endpoint_distance: float | None,
+) -> tuple[np.ndarray, dict[str, Any]]:
     trajectory = load_tum(path)
     xyz = trajectory[:, 1:4]
     deltas = np.diff(xyz, axis=0)
@@ -35,7 +40,7 @@ def evaluate(path: Path, expected_endpoint_distance: float | None) -> dict:
     transverse_norm = np.linalg.norm(transverse, axis=1)
     endpoint_distance = float(np.linalg.norm(xyz[-1] - xyz[0]))
 
-    result = {
+    result: dict[str, Any] = {
         "trajectory": str(path.resolve()),
         "pose_count": int(len(trajectory)),
         "duration_sec": float(trajectory[-1, 0] - trajectory[0, 0]),
@@ -59,6 +64,115 @@ def evaluate(path: Path, expected_endpoint_distance: float | None) -> dict:
             100.0 * (endpoint_distance - expected_endpoint_distance)
             / expected_endpoint_distance
         )
+    return trajectory, result
+
+
+def _interpolate_reference(
+    reference: np.ndarray,
+    timestamps: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Interpolate a dense reference at candidate timestamps in the shared span."""
+    in_range = (
+        (timestamps >= reference[0, 0])
+        & (timestamps <= reference[-1, 0])
+    )
+    matched_timestamps = timestamps[in_range]
+    if len(matched_timestamps) < 3:
+        raise ValueError("candidate and reference need at least three overlapping poses")
+    xyz = np.column_stack(
+        [
+            np.interp(matched_timestamps, reference[:, 0], reference[:, axis])
+            for axis in range(1, 4)
+        ]
+    )
+    return in_range, xyz
+
+
+def _rigid_alignment(
+    reference_xyz: np.ndarray,
+    candidate_xyz: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    reference_center = reference_xyz.mean(axis=0)
+    candidate_center = candidate_xyz.mean(axis=0)
+    covariance = (
+        (candidate_xyz - candidate_center).T
+        @ (reference_xyz - reference_center)
+    )
+    u, _, vt = np.linalg.svd(covariance)
+    rotation = vt.T @ u.T
+    if np.linalg.det(rotation) < 0.0:
+        vt[-1, :] *= -1.0
+        rotation = vt.T @ u.T
+    translation = reference_center - rotation @ candidate_center
+    return rotation, translation
+
+
+def reference_metrics(
+    candidate: np.ndarray,
+    reference_path: Path,
+    min_reference_reach_m: float,
+) -> dict[str, Any]:
+    reference = load_tum(reference_path)
+    in_range, reference_xyz = _interpolate_reference(reference, candidate[:, 0])
+    candidate_xyz = candidate[in_range, 1:4]
+
+    candidate_reach = np.linalg.norm(
+        candidate_xyz - candidate_xyz[0],
+        axis=1,
+    )
+    reference_reach = np.linalg.norm(
+        reference_xyz - reference_xyz[0],
+        axis=1,
+    )
+    valid_ratio = reference_reach >= min_reference_reach_m
+    if not np.any(valid_ratio):
+        raise ValueError(
+            "reference never reaches --min-reference-reach-m "
+            f"({min_reference_reach_m}) in the overlapping span"
+        )
+    ratios = candidate_reach[valid_ratio] / reference_reach[valid_ratio]
+
+    rotation, translation = _rigid_alignment(reference_xyz, candidate_xyz)
+    candidate_aligned = (rotation @ candidate_xyz.T).T + translation
+    aligned_errors = np.linalg.norm(candidate_aligned - reference_xyz, axis=1)
+
+    return {
+        "trajectory": str(reference_path.resolve()),
+        "overlap_pose_count": int(len(candidate_xyz)),
+        "overlap_duration_sec": float(
+            candidate[in_range, 0][-1] - candidate[in_range, 0][0]
+        ),
+        "min_reach_for_ratio_m": min_reference_reach_m,
+        "reach_ratio": {
+            "sample_count": int(len(ratios)),
+            "final": float(ratios[-1]),
+            "p50": float(np.quantile(ratios, 0.50)),
+            "p95": float(np.quantile(ratios, 0.95)),
+            "max": float(ratios.max()),
+        },
+        "aligned_translation_delta_m": {
+            "alignment": "se3_umeyama",
+            "rmse": float(math.sqrt(np.mean(np.square(aligned_errors)))),
+            "mean": float(aligned_errors.mean()),
+            "p95": float(np.quantile(aligned_errors, 0.95)),
+            "max": float(aligned_errors.max()),
+        },
+    }
+
+
+def evaluate(
+    path: Path,
+    expected_endpoint_distance: float | None,
+    reference_path: Path | None = None,
+    min_reference_reach_m: float = 10.0,
+) -> dict[str, Any]:
+    trajectory, result = trajectory_metrics(path, expected_endpoint_distance)
+    if reference_path is not None:
+        result["reference"] = reference_metrics(
+            trajectory,
+            reference_path,
+            min_reference_reach_m,
+        )
     return result
 
 
@@ -66,11 +180,36 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("trajectory", type=Path)
     parser.add_argument("--expected-endpoint-distance", type=float)
+    parser.add_argument(
+        "--reference-trajectory",
+        type=Path,
+        help=(
+            "Dense TUM reference for time-aligned reach ratios and an "
+            "SE(3)-aligned translation delta"
+        ),
+    )
+    parser.add_argument(
+        "--min-reference-reach-m",
+        type=float,
+        default=10.0,
+        help="Ignore startup reference reach below this value (default: 10.0)",
+    )
     args = parser.parse_args()
     if args.expected_endpoint_distance is not None and args.expected_endpoint_distance <= 0:
         parser.error("--expected-endpoint-distance must be positive")
+    if args.min_reference_reach_m <= 0:
+        parser.error("--min-reference-reach-m must be positive")
+    if args.reference_trajectory is not None and not args.reference_trajectory.is_file():
+        parser.error(
+            f"--reference-trajectory not found: {args.reference_trajectory}"
+        )
     print(json.dumps(
-        evaluate(args.trajectory, args.expected_endpoint_distance),
+        evaluate(
+            args.trajectory,
+            args.expected_endpoint_distance,
+            args.reference_trajectory,
+            args.min_reference_reach_m,
+        ),
         indent=2,
         sort_keys=True,
     ))

--- a/scripts/run_radarless_tunnel_ab.sh
+++ b/scripts/run_radarless_tunnel_ab.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+
+usage() {
+  cat <<'EOF' >&2
+Usage:
+  bash scripts/run_radarless_tunnel_ab.sh [options]
+
+Options:
+  --sequence <label>          tunnel, fog, hilti_exp07, or mid360
+  --dataset-root <dir>        NTNU degeneracy dataset root
+  --bag <dir>                 Override rosbag2 directory
+  --lidar-topic <topic>       PointCloud2 topic
+  --imu-topic <topic>         IMU topic
+  --base-frame <frame>        RKO-LIO base frame (default: base_link)
+  --output-root <dir>         Evidence root
+  --setup <setup.bash>        Workspace setup file
+  --base-params <yaml>        Sensor/base RKO-LIO parameters
+  --candidate-preset <yaml>   Candidate overlay parameters
+  --reference-tum <path>      Dense pseudo-GT/reference TUM
+  --candidate-param <k:=v>    Extra candidate ROS parameter (repeatable)
+  --max-runtime-secs <n>      Hard per-arm timeout (default: 1500)
+  --poll-secs <n>             Completion polling interval (default: 10)
+  --quiet-polls <n>           Quiet polls after activity before SIGINT (default: 2)
+  --ros-domain-base <id>      DDS domain for control; candidate uses +1 (default: 210)
+  --resume                    Reuse complete arm outputs
+  --dry-run                   Validate inputs and print commands
+  --help                      Show this help
+
+The runner executes a default-off control and a candidate arm against the
+same bag, stops offline_node with SIGINT after odometry becomes quiet, and
+writes trajectory metrics plus a candidate-vs-control comparison. It never
+selects the final exp02/exp03/exp21 holdouts.
+EOF
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 2
+}
+
+require_value() {
+  [[ $# -ge 2 && -n "$2" && "$2" != -* ]] || die "$1 requires a value"
+}
+
+SEQUENCE=tunnel
+DATASET_ROOT=${LIDAR_DEGENERACY_DATASET_ROOT:-/media/sasaki/aiueo/benchmarks/lidar_degeneracy_datasets_v1}
+OUTPUT_ROOT=${RADARLESS_TUNNEL_BENCHMARK_ROOT:-${DATASET_ROOT}/runs/radarless_tunnel_adaptive_v1}
+BAG=""
+LIDAR_TOPIC=/os_cloud_node/points
+IMU_TOPIC=/vectornav_node/uncomp_imu
+BASE_FRAME=base_link
+SETUP_FILE="${REPO_ROOT}/install/setup.bash"
+BASE_PARAMS="${REPO_ROOT}/lidarslam/param/rko_lio_lidar_degeneracy.ros.yaml"
+CONTROL_PRESET="${REPO_ROOT}/lidarslam/param/presets/degeneracy_off.ros.yaml"
+CANDIDATE_PRESET="${REPO_ROOT}/lidarslam/param/presets/tunnel_imu_no_radar.ros.yaml"
+REFERENCE_TUM=""
+MAX_RUNTIME_SECS=1500
+POLL_SECS=10
+QUIET_POLLS=2
+ROS_DOMAIN_BASE=210
+RESUME=false
+DRY_RUN=false
+CANDIDATE_PARAMS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --sequence) require_value "$@"; SEQUENCE="$2"; shift 2 ;;
+    --dataset-root) require_value "$@"; DATASET_ROOT=$(realpath -m "$2"); shift 2 ;;
+    --bag) require_value "$@"; BAG=$(realpath -m "$2"); shift 2 ;;
+    --lidar-topic) require_value "$@"; LIDAR_TOPIC="$2"; shift 2 ;;
+    --imu-topic) require_value "$@"; IMU_TOPIC="$2"; shift 2 ;;
+    --base-frame) require_value "$@"; BASE_FRAME="$2"; shift 2 ;;
+    --output-root) require_value "$@"; OUTPUT_ROOT=$(realpath -m "$2"); shift 2 ;;
+    --setup) require_value "$@"; SETUP_FILE=$(realpath -m "$2"); shift 2 ;;
+    --base-params) require_value "$@"; BASE_PARAMS=$(realpath -m "$2"); shift 2 ;;
+    --candidate-preset) require_value "$@"; CANDIDATE_PRESET=$(realpath -m "$2"); shift 2 ;;
+    --reference-tum) require_value "$@"; REFERENCE_TUM=$(realpath -m "$2"); shift 2 ;;
+    --candidate-param) require_value "$@"; CANDIDATE_PARAMS+=("$2"); shift 2 ;;
+    --max-runtime-secs) require_value "$@"; MAX_RUNTIME_SECS="$2"; shift 2 ;;
+    --poll-secs) require_value "$@"; POLL_SECS="$2"; shift 2 ;;
+    --quiet-polls) require_value "$@"; QUIET_POLLS="$2"; shift 2 ;;
+    --ros-domain-base) require_value "$@"; ROS_DOMAIN_BASE="$2"; shift 2 ;;
+    --resume) RESUME=true; shift ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    --help|-h) usage; exit 0 ;;
+    *) die "unknown option: $1" ;;
+  esac
+done
+
+case "${SEQUENCE}" in
+  tunnel|fog|hilti_exp07|mid360) ;;
+  exp02|exp03|exp21)
+    die "${SEQUENCE} is a reserved final holdout and is intentionally blocked"
+    ;;
+  *) die "unknown sequence: ${SEQUENCE}" ;;
+esac
+[[ "${MAX_RUNTIME_SECS}" =~ ^[1-9][0-9]*$ ]] || die "--max-runtime-secs must be positive"
+[[ "${POLL_SECS}" =~ ^[1-9][0-9]*$ ]] || die "--poll-secs must be positive"
+[[ "${QUIET_POLLS}" =~ ^[1-9][0-9]*$ ]] || die "--quiet-polls must be positive"
+[[ "${ROS_DOMAIN_BASE}" =~ ^[0-9]+$ ]] || die "--ros-domain-base must be an integer"
+((ROS_DOMAIN_BASE <= 231)) || die "--ros-domain-base must be <= 231"
+for override in "${CANDIDATE_PARAMS[@]}"; do
+  [[ "${override}" == *":="* ]] || die "--candidate-param expects name:=value: ${override}"
+done
+
+if [[ -z "${BAG}" ]]; then
+  case "${SEQUENCE}" in
+    tunnel|fog) BAG="${DATASET_ROOT}/ros2_radar/${SEQUENCE}" ;;
+    *) die "--bag is required for ${SEQUENCE}" ;;
+  esac
+fi
+[[ -f "${BAG}/metadata.yaml" ]] || die "rosbag2 metadata not found: ${BAG}/metadata.yaml"
+[[ -f "${SETUP_FILE}" ]] || die "setup file not found: ${SETUP_FILE}"
+[[ -f "${BASE_PARAMS}" ]] || die "base parameter file not found: ${BASE_PARAMS}"
+[[ -f "${CONTROL_PRESET}" ]] || die "control preset not found: ${CONTROL_PRESET}"
+[[ -f "${CANDIDATE_PRESET}" ]] || die "candidate preset not found: ${CANDIDATE_PRESET}"
+
+if [[ -z "${REFERENCE_TUM}" && "${SEQUENCE}" == tunnel ]]; then
+  REFERENCE_TUM="${DATASET_ROOT}/runs/tunnel_gravity_alignment_v1/tunnel_gravity_v2_gain02_0/tunnel_gravity_v2_gain02_tum_0.txt"
+fi
+if [[ -n "${REFERENCE_TUM}" ]]; then
+  [[ -f "${REFERENCE_TUM}" ]] || die "reference TUM not found: ${REFERENCE_TUM}"
+fi
+
+SEQUENCE_ROOT="${OUTPUT_ROOT}/${SEQUENCE}"
+
+print_command() {
+  printf 'DRY_RUN'
+  printf ' %q' "$@"
+  printf '\n'
+}
+
+find_trajectory() {
+  local arm_dir="$1"
+  local run_name="$2"
+  local paths=()
+  mapfile -t paths < <(find "${arm_dir}" -type f -name "${run_name}_tum_*.txt" -print 2>/dev/null | sort)
+  [[ ${#paths[@]} -eq 1 ]] || return 1
+  printf '%s\n' "${paths[0]}"
+}
+
+stop_process() {
+  local pid="$1"
+  if ! kill -0 "${pid}" 2>/dev/null; then
+    return
+  fi
+  kill -INT "${pid}" 2>/dev/null || true
+  for _ in $(seq 1 30); do
+    kill -0 "${pid}" 2>/dev/null || return
+    sleep 1
+  done
+  kill -TERM "${pid}" 2>/dev/null || true
+}
+
+run_arm() {
+  local label="$1"
+  local preset="$2"
+  local domain="$3"
+  shift 3
+  local overrides=("$@")
+  local arm_dir="${SEQUENCE_ROOT}/${label}"
+  local run_name="${SEQUENCE}_${label}"
+  local command=(
+    ros2 run rko_lio offline_node --ros-args
+    --params-file "${BASE_PARAMS}"
+    --params-file "${preset}"
+    -p "bag_path:=${BAG}"
+    -p "lidar_topic:=${LIDAR_TOPIC}"
+    -p "imu_topic:=${IMU_TOPIC}"
+    -p "base_frame:=${BASE_FRAME}"
+    -p "odom_topic:=/rko_lio/odometry"
+    -p "dump_results:=true"
+    -p "results_dir:=${arm_dir}"
+    -p "run_name:=${run_name}"
+  )
+  for override in "${overrides[@]}"; do
+    command+=(-p "${override}")
+  done
+
+  if [[ "${DRY_RUN}" == true ]]; then
+    printf 'ROS_DOMAIN_ID=%q ' "${domain}"
+    print_command "${command[@]}"
+    return
+  fi
+  if [[ "${RESUME}" == true ]] && find_trajectory "${arm_dir}" "${run_name}" >/dev/null; then
+    echo "reuse complete ${label} arm: ${arm_dir}"
+    return
+  fi
+  [[ ! -e "${arm_dir}" ]] || die "arm output already exists (use --resume): ${arm_dir}"
+  mkdir -p "${arm_dir}"
+  printf '%q ' "${command[@]}" >"${arm_dir}/command.txt"
+  printf '\n' >>"${arm_dir}/command.txt"
+
+  echo "=== ${SEQUENCE} ${label} start ==="
+  ROS_DOMAIN_ID="${domain}" stdbuf -oL -eL "${command[@]}" \
+    >"${arm_dir}/offline_node.log" 2>&1 &
+  local pid=$!
+  local start_time
+  start_time=$(date +%s)
+  local saw_odometry=false
+  local quiet_count=0
+  local timed_out=false
+  while kill -0 "${pid}" 2>/dev/null; do
+    sleep "${POLL_SECS}"
+    local now
+    now=$(date +%s)
+    if ((now - start_time >= MAX_RUNTIME_SECS)); then
+      timed_out=true
+      break
+    fi
+    if ROS_DOMAIN_ID="${domain}" timeout 8 ros2 topic echo /rko_lio/odometry --once \
+        >/dev/null 2>&1; then
+      saw_odometry=true
+      quiet_count=0
+    elif [[ "${saw_odometry}" == true ]]; then
+      quiet_count=$((quiet_count + 1))
+      if ((quiet_count >= QUIET_POLLS)); then
+        break
+      fi
+    fi
+  done
+  stop_process "${pid}"
+  set +e
+  wait "${pid}"
+  local status=$?
+  set -e
+  if [[ "${timed_out}" == true ]]; then
+    die "${label} arm exceeded ${MAX_RUNTIME_SECS}s; see ${arm_dir}/offline_node.log"
+  fi
+  if [[ "${status}" -ne 0 && "${status}" -ne 130 && "${status}" -ne 143 ]]; then
+    die "${label} arm exited ${status}; see ${arm_dir}/offline_node.log"
+  fi
+  find_trajectory "${arm_dir}" "${run_name}" >/dev/null \
+    || die "${label} arm did not produce exactly one TUM trajectory"
+  echo "=== ${SEQUENCE} ${label} done ==="
+}
+
+if [[ "${DRY_RUN}" != true ]]; then
+  # The workspace setup chains the selected ROS distribution.
+  # shellcheck disable=SC1090
+  set +u
+  source "${SETUP_FILE}"
+  set -u
+  mkdir -p "${SEQUENCE_ROOT}"
+  SOURCE_BASE_PARAMS="${BASE_PARAMS}"
+  BASE_PARAMS="${SEQUENCE_ROOT}/base_params.ros.yaml"
+  python3 - "${SOURCE_BASE_PARAMS}" "${BASE_PARAMS}" <<'PY'
+import shutil
+import sys
+from pathlib import Path
+
+import yaml
+
+source, output = map(Path, sys.argv[1:])
+if source.resolve() == output.resolve():
+    raise SystemExit(0)
+document = yaml.safe_load(source.read_text(encoding="utf-8")) or {}
+if isinstance(document, dict) and any(
+    isinstance(value, dict) and "ros__parameters" in value
+    for value in document.values()
+):
+    shutil.copyfile(source, output)
+else:
+    output.write_text(
+        yaml.safe_dump({"/**": {"ros__parameters": document}}, sort_keys=False),
+        encoding="utf-8",
+    )
+PY
+fi
+
+run_arm control "${CONTROL_PRESET}" "${ROS_DOMAIN_BASE}"
+run_arm candidate "${CANDIDATE_PRESET}" "$((ROS_DOMAIN_BASE + 1))" "${CANDIDATE_PARAMS[@]}"
+
+if [[ "${DRY_RUN}" == true ]]; then
+  exit 0
+fi
+
+CONTROL_TUM=$(find_trajectory "${SEQUENCE_ROOT}/control" "${SEQUENCE}_control")
+CANDIDATE_TUM=$(find_trajectory "${SEQUENCE_ROOT}/candidate" "${SEQUENCE}_candidate")
+EXPECTED_ARGS=()
+if [[ "${SEQUENCE}" == tunnel ]]; then
+  EXPECTED_ARGS=(--expected-endpoint-distance 500)
+fi
+
+python3 "${SCRIPT_DIR}/evaluate_degeneracy_trajectory.py" \
+  "${CONTROL_TUM}" "${EXPECTED_ARGS[@]}" \
+  >"${SEQUENCE_ROOT}/control_metrics.json"
+python3 "${SCRIPT_DIR}/evaluate_degeneracy_trajectory.py" \
+  "${CANDIDATE_TUM}" "${EXPECTED_ARGS[@]}" \
+  --reference-trajectory "${CONTROL_TUM}" --min-reference-reach-m 10 \
+  >"${SEQUENCE_ROOT}/candidate_vs_control.json"
+if [[ -n "${REFERENCE_TUM}" ]]; then
+  python3 "${SCRIPT_DIR}/evaluate_degeneracy_trajectory.py" \
+    "${CANDIDATE_TUM}" "${EXPECTED_ARGS[@]}" \
+    --reference-trajectory "${REFERENCE_TUM}" --min-reference-reach-m 10 \
+    >"${SEQUENCE_ROOT}/candidate_metrics.json"
+else
+  cp "${SEQUENCE_ROOT}/candidate_vs_control.json" "${SEQUENCE_ROOT}/candidate_metrics.json"
+fi
+
+python3 - "${SEQUENCE_ROOT}" "${SEQUENCE}" "${BAG}" "${BASE_PARAMS}" \
+  "${CANDIDATE_PRESET}" "${REFERENCE_TUM}" \
+  "$(git -C "${REPO_ROOT}" rev-parse HEAD)" \
+  "$(git -C "${REPO_ROOT}/Thirdparty/rko_lio" rev-parse HEAD)" \
+  "${CANDIDATE_PARAMS[@]}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+root_text, sequence, bag, base_params, preset, reference, parent_sha, submodule_sha = sys.argv[1:9]
+candidate_overrides = sys.argv[9:]
+root = Path(root_text)
+summary_paths = sorted(
+    (root / "candidate").glob("*/kinematic_velocity_blend_summary.json")
+)
+payload = {
+    "schema_version": 1,
+    "sequence": sequence,
+    "inputs": {
+        "bag": bag,
+        "base_params": base_params,
+        "candidate_preset": preset,
+        "candidate_overrides": candidate_overrides,
+        "reference_tum": reference or None,
+    },
+    "git": {
+        "lidar_slam_ros2": parent_sha,
+        "rko_lio": submodule_sha,
+    },
+    "control": json.loads((root / "control_metrics.json").read_text()),
+    "candidate": json.loads((root / "candidate_metrics.json").read_text()),
+    "candidate_vs_control": json.loads(
+        (root / "candidate_vs_control.json").read_text()
+    ),
+    "kinematic_velocity_blend_summary": (
+        json.loads(summary_paths[0].read_text())
+        if len(summary_paths) == 1
+        else None
+    ),
+}
+(root / "comparison.json").write_text(
+    json.dumps(payload, indent=2, sort_keys=True) + "\n",
+    encoding="utf-8",
+)
+PY
+
+echo "comparison: ${SEQUENCE_ROOT}/comparison.json"


### PR DESCRIPTION
## What changed

- advance rko_lio to the merged scene/speed applicability-gate implementation
- adopt the validated gate and cooldown parameters in the default-off radar-less tunnel preset
- extend the trajectory evaluator with time-aligned reach ratios and SE(3)-aligned deltas
- add a reproducible isolated-domain control/candidate runner with diagnostic manifests
- document the decision, rejected variants, limitations, and benchmark workflow
- add regression coverage for evaluator behavior, runner safety, and the frozen adopted preset

## Why

The yaw-gated inertial velocity bridge improved long self-similar tunnels but still changed fog, handheld, and driving holdouts. Scene-range and persistent-speed applicability gates retain the tunnel benefit while preventing correction outside the validated walking-corridor envelope.

## Dataset validation

- NTNU tunnel: 102.26 m control to 415.59 m candidate; maximum pseudo-GT reach ratio 0.983
- NTNU fog: candidate and control TUM files byte-identical
- HILTI exp07: candidate and control TUM files byte-identical; control APE 0.20823 m
- MID-360 driving: candidate and control TUM files byte-identical

## Automated validation

- Release rko_lio build passed
- 35 focused C++ tests passed
- 11 Python regression/documentation tests passed
- all preset YAML files parsed
- shell syntax and git diff checks passed

HANDOFF_radarless_tunnel.md remains an untracked local work note and is intentionally excluded.