### PR TITLE
Add golden-path product CLI

### DIFF
--- a/docs/golden-path-cli.md
+++ b/docs/golden-path-cli.md
@@ -1,0 +1,55 @@
+# Golden-path CLI
+
+Phase 1 introduces one repo-local command surface over the existing,
+well-tested map-authoring tools:
+
+```bash
+./scripts/lidarslam doctor <rosbag2_dir>
+./scripts/lidarslam run <rosbag2_dir> --output-dir output/my_map
+./scripts/lidarslam inspect output/my_map
+```
+
+This is initially a source-checkout interface. It delegates to
+`preflight_autoware_map_bag.py`, `run_autoware_map_from_bag.py`, and
+`diagnose_autoware_map_run.py`, so the established profile selection and map
+verification behavior remain authoritative.
+
+## Commands
+
+`doctor` checks rosbag2 metadata, reports detected topic capabilities, and
+selects a compatible maintained profile. Add `--json` for automation.
+
+`run` prints the selected profile and deterministic command before execution.
+Use `--dry-run` to inspect the plan without creating the output directory.
+The existing runner continues to verify and diagnose completed outputs.
+
+`inspect` classifies an output as `success`, `map_saved`, `verify_failed`,
+`runtime_failed`, or `incomplete`. Add `--write` to create the Markdown and
+JSON diagnosis artifacts in the output directory.
+
+Each subcommand accepts the same options as its delegated tool:
+
+```bash
+./scripts/lidarslam doctor --help
+./scripts/lidarslam run --help
+./scripts/lidarslam inspect --help
+```
+
+## Exit-code contract
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Command completed successfully |
+| `2` | Invalid usage, input, profile, or output path |
+| `70` | Internal/tooling error prevented the command from starting |
+| other non-zero | Map-workflow exit code, propagated unchanged |
+
+## Installation-name decision
+
+The ROS package already installs a C++ node named `lidarslam`. Replacing that
+binary silently would break `ros2 run lidarslam lidarslam` users. Until Phase 2
+resolves the installed command and compatibility shim together, the supported
+Phase 1 spelling is explicitly `./scripts/lidarslam`.
+
+This staged decision does not add a fourth beginner workflow: the CLI is a
+single command surface over the existing own-bag product path.

--- a/docs/roadmap/v0.9.md
+++ b/docs/roadmap/v0.9.md
@@ -1,6 +1,7 @@
 # lidarslam_ros2 v0.9 roadmap — product foundation
 
-> Status: **direction approved 2026-07-27; Phase 0 in progress**. This roadmap
+> Status: **direction approved 2026-07-27; Phase 0 complete; Phase 1 in
+> progress**. This roadmap
 > turns the existing benchmark-heavy map-authoring stack into a product-level
 > OSS project. It does not replace the evidence-driven capability roadmaps;
 > it defines the stable product surface they must integrate with.
@@ -62,14 +63,18 @@ Gate:
 Build one stable command surface over the existing runners:
 
 ```text
-lidarslam doctor <bag>
-lidarslam run <bag> --profile <profile>
-lidarslam inspect <output>
+./scripts/lidarslam doctor <bag>
+./scripts/lidarslam run <bag> --profile <profile>
+./scripts/lidarslam inspect <output>
 ```
 
 The implementation may initially be a Python console package delegating to
 the proven scripts. The public contract is the command behavior, exit codes
 and artifacts—not the internal wrapper language.
+
+The repo-local spelling is deliberate during Phase 1: the ROS package already
+installs a C++ node named `lidarslam`. Phase 2 must provide an installed CLI
+and compatibility shim together rather than silently replacing that node.
 
 Deliverables:
 

--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -980,6 +980,11 @@ if(BUILD_TESTING)
     TIMEOUT 120
   )
   ament_add_pytest_test(
+    test_lidarslam_product_cli
+    test/test_lidarslam_product_cli.py
+    TIMEOUT 120
+  )
+  ament_add_pytest_test(
     test_aligned_trajectory_metrics
     test/test_aligned_trajectory_metrics.py
     TIMEOUT 120

--- a/graph_based_slam/test/test_docs_entrypoints.py
+++ b/graph_based_slam/test/test_docs_entrypoints.py
@@ -62,6 +62,7 @@ WORKFLOWS_DOC = REPO_ROOT / 'docs' / 'workflows.md'
 BENCHMARKING_DOC = REPO_ROOT / 'docs' / 'benchmarking.md'
 COMPARISON_DOC = REPO_ROOT / 'docs' / 'comparison.md'
 PRODUCT_CONTRACT_DOC = REPO_ROOT / 'docs' / 'product-contract.md'
+GOLDEN_PATH_CLI_DOC = REPO_ROOT / 'docs' / 'golden-path-cli.md'
 V09_ROADMAP_DOC = REPO_ROOT / 'docs' / 'roadmap' / 'v0.9.md'
 SOCIAL_POST_DOC = REPO_ROOT / 'docs' / 'social' / 'autoware_map_authoring_post_v0.2.2.md'
 ISSUE_TEMPLATE_DIR = REPO_ROOT / '.github' / 'ISSUE_TEMPLATE'
@@ -112,6 +113,7 @@ def test_docs_exist_and_are_linked_from_readme():
     assert BENCHMARKING_DOC.is_file()
     assert COMPARISON_DOC.is_file()
     assert PRODUCT_CONTRACT_DOC.is_file()
+    assert GOLDEN_PATH_CLI_DOC.is_file()
     assert V09_ROADMAP_DOC.is_file()
     assert SOCIAL_POST_DOC.is_file()
     assert DOCS_SITE_WORKFLOW.is_file()
@@ -336,6 +338,7 @@ def test_release_metadata_and_core_package_versions_match():
     assert 'assets/stylesheets/extra.css' in mkdocs_config
     assert 'Getting Started: getting-started.md' in mkdocs_config
     assert 'Product Contract: product-contract.md' in mkdocs_config
+    assert 'Golden-path CLI: golden-path-cli.md' in mkdocs_config
     assert 'Autoware-Compatible Map Authoring: autoware-map-authoring.md' in mkdocs_config
     assert 'Autoware Foxglove: autoware-foxglove.md' in mkdocs_config
     assert 'Benchmarking And Release Gate: benchmarking.md' in mkdocs_config

--- a/graph_based_slam/test/test_lidarslam_product_cli.py
+++ b/graph_based_slam/test/test_lidarslam_product_cli.py
@@ -1,0 +1,146 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for the repo-local golden-path product CLI."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CLI = REPO_ROOT / 'scripts' / 'lidarslam'
+VERSION = (REPO_ROOT / 'VERSION').read_text(encoding='utf-8').strip()
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(CLI), *args],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_bag_metadata(path: Path) -> None:
+    path.mkdir()
+    payload = {
+        'rosbag2_bagfile_information': {
+            'duration': {'nanoseconds': 2_000_000_000},
+            'message_count': 220,
+            'topics_with_message_count': [
+                {
+                    'topic_metadata': {
+                        'name': '/points',
+                        'type': 'sensor_msgs/msg/PointCloud2',
+                    },
+                    'message_count': 20,
+                },
+                {
+                    'topic_metadata': {
+                        'name': '/imu',
+                        'type': 'sensor_msgs/msg/Imu',
+                    },
+                    'message_count': 200,
+                },
+            ],
+        },
+    }
+    (path / 'metadata.yaml').write_text(
+        __import__('yaml').safe_dump(payload),
+        encoding='utf-8',
+    )
+
+
+def test_global_help_version_and_usage_contract():
+    help_result = _run('--help')
+    assert help_result.returncode == 0
+    assert 'doctor <rosbag2_dir>' in help_result.stdout
+    assert 'run <rosbag2_dir>' in help_result.stdout
+    assert 'inspect <output_dir>' in help_result.stdout
+
+    version_result = _run('--version')
+    assert version_result.returncode == 0
+    assert version_result.stdout.strip() == f'lidarslam_ros2 {VERSION}'
+
+    missing_result = _run()
+    assert missing_result.returncode == 2
+    assert 'Usage:' in missing_result.stderr
+
+    unknown_result = _run('unknown')
+    assert unknown_result.returncode == 2
+    assert 'unknown command: unknown' in unknown_result.stderr
+
+
+def test_doctor_emits_machine_readable_preflight(tmp_path: Path):
+    bag = tmp_path / 'sample_bag'
+    _write_bag_metadata(bag)
+
+    result = _run('doctor', str(bag), '--json')
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload['recommended_profile_id'] == 'rko_lio_graph_public_path'
+    assert payload['summary']['capabilities']['has_pointcloud2'] is True
+    assert payload['summary']['capabilities']['has_imu'] is True
+
+
+def test_run_dry_run_and_inspect_delegate_to_proven_tools(tmp_path: Path):
+    bag = tmp_path / 'sample_bag'
+    output = tmp_path / 'map_output'
+    _write_bag_metadata(bag)
+
+    run_result = _run(
+        'run',
+        str(bag),
+        '--output-dir',
+        str(output),
+        '--dry-run',
+    )
+    assert run_result.returncode == 0, run_result.stderr
+    assert 'Selected profile:' in run_result.stdout
+    assert str(output) in run_result.stdout
+    assert not output.exists()
+
+    output.mkdir()
+    inspect_result = _run('inspect', str(output), '--json')
+    assert inspect_result.returncode == 0, inspect_result.stderr
+    diagnosis = json.loads(inspect_result.stdout)
+    assert diagnosis['status'] == 'incomplete'
+    assert diagnosis['run_dir'] == str(output)
+
+
+def test_child_input_error_is_propagated(tmp_path: Path):
+    result = _run('doctor', str(tmp_path / 'missing'))
+
+    assert result.returncode == 2
+    assert 'rosbag2 directory does not exist' in result.stderr

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ nav:
   - Home: index.md
   - Getting Started: getting-started.md
   - Product Contract: product-contract.md
+  - Golden-path CLI: golden-path-cli.md
   - Autoware-Compatible Map Authoring: autoware-map-authoring.md
   - Autoware Quickstart: autoware-quickstart.md
   - Autoware Foxglove: autoware-foxglove.md

--- a/scripts/lidarslam
+++ b/scripts/lidarslam
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+exec python3 "${SCRIPT_DIR}/lidarslam_cli.py" "$@"

--- a/scripts/lidarslam_cli.py
+++ b/scripts/lidarslam_cli.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Stable product command surface over the proven map-authoring tools."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+from typing import Sequence
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+VERSION_PATH = REPO_ROOT / 'VERSION'
+COMMANDS = {
+    'doctor': 'preflight_autoware_map_bag.py',
+    'run': 'run_autoware_map_from_bag.py',
+    'inspect': 'diagnose_autoware_map_run.py',
+}
+EX_USAGE = 2
+EX_SOFTWARE = 70
+
+
+def render_help() -> str:
+    """Return top-level CLI help."""
+    return '\n'.join([
+        'Usage: ./scripts/lidarslam <command> [options]',
+        '',
+        'Offline rosbag2-to-map product commands:',
+        '  doctor <rosbag2_dir>   Check inputs and select a compatible profile',
+        '  run <rosbag2_dir>      Build and verify a map bundle',
+        '  inspect <output_dir>   Diagnose an existing map-authoring output',
+        '',
+        'Global options:',
+        '  --version              Print the repository product version',
+        '  --help                 Show this help',
+        '',
+        'Run "./scripts/lidarslam <command> --help" for command options.',
+        '',
+        'Exit codes:',
+        '  0   command completed successfully',
+        '  2   invalid usage, input, profile, or output path',
+        '  70  the command could not start because of an internal/tooling error',
+        '  other non-zero values are propagated from the map workflow',
+    ])
+
+
+def read_version() -> str:
+    """Read the root VERSION source of truth."""
+    try:
+        version = VERSION_PATH.read_text(encoding='utf-8').strip()
+    except OSError as exc:
+        raise RuntimeError(f'failed to read product version: {exc}') from exc
+    if not version:
+        raise RuntimeError(f'product version is empty: {VERSION_PATH}')
+    return version
+
+
+def command_argv(command: str, args: Sequence[str]) -> list[str]:
+    """Build a delegated product command."""
+    helper_name = COMMANDS[command]
+    helper_path = SCRIPT_DIR / helper_name
+    if not helper_path.is_file():
+        raise RuntimeError(f'product helper is missing: {helper_path}')
+    return [sys.executable, str(helper_path), *args]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Dispatch the stable product command surface."""
+    args = list(sys.argv[1:] if argv is None else argv)
+    if args in (['--help'], ['-h']):
+        print(render_help())
+        return 0
+    if args == ['--version']:
+        try:
+            print(f'lidarslam_ros2 {read_version()}')
+        except RuntimeError as exc:
+            print(f'error: {exc}', file=sys.stderr)
+            return EX_SOFTWARE
+        return 0
+    if not args:
+        print(render_help(), file=sys.stderr)
+        return EX_USAGE
+
+    command = args.pop(0)
+    if command not in COMMANDS:
+        print(f'error: unknown command: {command}', file=sys.stderr)
+        print('hint: run "./scripts/lidarslam --help".', file=sys.stderr)
+        return EX_USAGE
+
+    try:
+        completed = subprocess.run(command_argv(command, args), check=False)
+    except (OSError, RuntimeError) as exc:
+        print(f'error: failed to start {command}: {exc}', file=sys.stderr)
+        return EX_SOFTWARE
+    return completed.returncode
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- adds a repo-local `./scripts/lidarslam` command with `doctor`, `run`, and `inspect` subcommands
- delegates to the proven preflight, runner, and diagnosis tools without changing algorithm defaults
- defines stable top-level help, version output, and exit-code behavior
- documents the ROS-node naming collision and defers the installed compatibility shim to Phase 2
- adds subprocess-level regression tests and MkDocs navigation

## Why

The v0.9 roadmap requires one bounded command surface before manifest, resume, and reliability work can be layered on. The ROS package already installs a C++ binary named `lidarslam`, so this first slice uses an explicit repo-local spelling instead of silently breaking `ros2 run lidarslam lidarslam`.

## Validation

- `python3 -m pytest -q graph_based_slam/test/test_lidarslam_product_cli.py graph_based_slam/test/test_docs_entrypoints.py` — 11 passed
- full ament flake8 on the changed Python files
- `python3 -m mkdocs build --strict`
- `bash -n scripts/lidarslam`
- `python3 -m py_compile scripts/lidarslam_cli.py graph_based_slam/test/test_lidarslam_product_cli.py`
- `git diff --check`

This does not add a fourth beginner workflow; it is a command surface over the existing own-bag product path.
