### PR TITLE
Add versioned run manifest lifecycle

### DIFF
--- a/docs/golden-path-cli.md
+++ b/docs/golden-path-cli.md
@@ -21,11 +21,46 @@ selects a compatible maintained profile. Add `--json` for automation.
 
 `run` prints the selected profile and deterministic command before execution.
 Use `--dry-run` to inspect the plan without creating the output directory.
-The existing runner continues to verify and diagnose completed outputs.
+The runner writes into `<output>.partial` and atomically renames that directory
+to the requested output name after the workflow stops. It refuses to start
+when either name already exists, so a new run never overwrites prior evidence.
+Completed, failed, and interrupted workflows retain their artifacts and
+terminal state for diagnosis.
+
+Every non-dry run produces `run_manifest.json`. It records:
+
+- SHA-256 identities for `metadata.yaml`, every referenced rosbag storage file,
+  and every output artifact;
+- product, core package, Git commit/dirty-state, and ROS distribution identity;
+- the selected profile and exact argument vector;
+- UTC start/finish timestamps, exit code, terminal status, and diagnosis
+  status.
+
+Hashing large bags adds a sequential input read before execution. This is
+deliberate: the manifest identifies the data that was actually processed,
+rather than only the path where it happened to be stored.
+
+`succeeded` means the workflow exited successfully. When verification is
+enabled (the default), a non-`success` diagnosis changes the manifest to
+`failed`. With `--no-verify-map`, inspect `output.diagnosis_status` separately;
+`succeeded` does not claim that map verification ran.
 
 `inspect` classifies an output as `success`, `map_saved`, `verify_failed`,
 `runtime_failed`, or `incomplete`. Add `--write` to create the Markdown and
 JSON diagnosis artifacts in the output directory.
+
+## Versioned JSON contracts
+
+Automation should select the schema using `schema_version` and `schema_uri`;
+it must not infer compatibility from the repository version.
+
+- [Preflight schema v1](schemas/preflight-v1.schema.json)
+- [Diagnosis schema v1](schemas/diagnosis-v1.schema.json)
+- [Run manifest schema v1](schemas/run-manifest-v1.schema.json)
+
+Top-level fields are closed within a published schema. A field addition,
+removal, type change, or semantic break requires a new schema file and
+migration guidance.
 
 Each subcommand accepts the same options as its delegated tool:
 
@@ -42,6 +77,7 @@ Each subcommand accepts the same options as its delegated tool:
 | `0` | Command completed successfully |
 | `2` | Invalid usage, input, profile, or output path |
 | `70` | Internal/tooling error prevented the command from starting |
+| `130` | Run was interrupted by the operator |
 | other non-zero | Map-workflow exit code, propagated unchanged |
 
 ## Installation-name decision

--- a/docs/product-contract.md
+++ b/docs/product-contract.md
@@ -20,11 +20,18 @@ A successful product-path run produces an output directory containing:
 - `traj_corrected.tum`;
 - `verify_autoware_map.log`;
 - `autoware_map_diagnosis.md`;
+- `autoware_map_diagnosis.json`;
+- `run_manifest.json`, with input/output checksums and execution identity;
 - `lanelet2_map.osm` when lanelet generation is enabled and succeeds.
 
 `verify_autoware_map.py` must report `PASS` before the point-cloud bundle is
 treated as valid. Generated lanelets are a starting point for map authoring,
 not surveyed road semantics; review them before use.
+
+The versioned machine-readable contracts are published with the
+[golden-path CLI documentation](golden-path-cli.md#versioned-json-contracts).
+Existing output directories are immutable to the runner: operators must choose
+a new name, and in-progress work is isolated under a `.partial` sibling.
 
 ## Official entrypoints
 

--- a/docs/roadmap/v0.9.md
+++ b/docs/roadmap/v0.9.md
@@ -1,7 +1,8 @@
 # lidarslam_ros2 v0.9 roadmap — product foundation
 
 > Status: **direction approved 2026-07-27; Phase 0 complete; Phase 1 in
-> progress**. This roadmap
+> progress (CLI and manifest lifecycle landed; resume semantics pending)**.
+> This roadmap
 > turns the existing benchmark-heavy map-authoring stack into a product-level
 > OSS project. It does not replace the evidence-driven capability roadmaps;
 > it defines the stable product surface they must integrate with.

--- a/docs/schemas/diagnosis-v1.schema.json
+++ b/docs/schemas/diagnosis-v1.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://rsasaki0109.github.io/lidar_slam_ros2/schemas/diagnosis-v1.schema.json",
+  "title": "lidarslam_ros2 diagnosis v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "schema_uri",
+    "run_dir",
+    "status",
+    "files",
+    "launch_flags",
+    "verify",
+    "projector_type",
+    "problem_hints",
+    "suggested_next_steps"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "schema_uri": {
+      "const": "https://rsasaki0109.github.io/lidar_slam_ros2/schemas/diagnosis-v1.schema.json"
+    },
+    "run_dir": {"type": "string"},
+    "status": {
+      "enum": [
+        "success",
+        "map_saved",
+        "verify_failed",
+        "runtime_failed",
+        "incomplete"
+      ]
+    },
+    "files": {"type": "object"},
+    "launch_flags": {"type": "object"},
+    "verify": {"type": "object"},
+    "projector_type": {"type": ["string", "null"]},
+    "bag_preflight": {"type": "object"},
+    "problem_hints": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "suggested_next_steps": {
+      "type": "array",
+      "items": {"type": "string"}
+    }
+  }
+}

--- a/docs/schemas/preflight-v1.schema.json
+++ b/docs/schemas/preflight-v1.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://rsasaki0109.github.io/lidar_slam_ros2/schemas/preflight-v1.schema.json",
+  "title": "lidarslam_ros2 preflight v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "schema_uri",
+    "summary",
+    "recommendations",
+    "recommended_profile_id",
+    "beginner_commands",
+    "advisory",
+    "missing_requirements"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "schema_uri": {
+      "const": "https://rsasaki0109.github.io/lidar_slam_ros2/schemas/preflight-v1.schema.json"
+    },
+    "summary": {
+      "type": "object",
+      "required": ["bag_path", "topics", "capabilities"]
+    },
+    "recommendations": {"type": "array", "items": {"type": "object"}},
+    "recommended_profile_id": {"type": ["string", "null"]},
+    "beginner_commands": {"type": "array", "items": {"type": "object"}},
+    "advisory": {"type": "array"},
+    "missing_requirements": {
+      "type": "array",
+      "items": {"type": "string"}
+    }
+  }
+}

--- a/docs/schemas/run-manifest-v1.schema.json
+++ b/docs/schemas/run-manifest-v1.schema.json
@@ -1,0 +1,161 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://rsasaki0109.github.io/lidar_slam_ros2/schemas/run-manifest-v1.schema.json",
+  "title": "lidarslam_ros2 run manifest v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "schema_uri",
+    "run_id",
+    "status",
+    "input",
+    "software",
+    "profile",
+    "execution",
+    "output"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "schema_uri": {
+      "const": "https://rsasaki0109.github.io/lidar_slam_ros2/schemas/run-manifest-v1.schema.json"
+    },
+    "run_id": {"type": "string", "format": "uuid"},
+    "status": {
+      "enum": ["planned", "running", "succeeded", "failed", "interrupted"]
+    },
+    "input": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "bag_path",
+        "metadata_path",
+        "metadata_size_bytes",
+        "metadata_sha256",
+        "storage_identifier",
+        "storage_files",
+        "identity_algorithm"
+      ],
+      "properties": {
+        "bag_path": {"type": "string"},
+        "metadata_path": {"type": "string"},
+        "metadata_size_bytes": {"type": "integer", "minimum": 0},
+        "metadata_sha256": {"$ref": "#/definitions/sha256"},
+        "storage_identifier": {"type": ["string", "null"]},
+        "storage_files": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/file_identity"}
+        },
+        "identity_algorithm": {"const": "sha256"}
+      }
+    },
+    "software": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "product_version",
+        "git_commit",
+        "git_dirty",
+        "package_versions",
+        "ros_distro"
+      ],
+      "properties": {
+        "product_version": {"type": "string", "minLength": 1},
+        "git_commit": {
+          "type": ["string", "null"],
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "git_dirty": {"type": ["boolean", "null"]},
+        "package_versions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "ros_distro": {"type": ["string", "null"]}
+      }
+    },
+    "profile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "label"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "label": {"type": "string", "minLength": 1}
+      }
+    },
+    "execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "argv",
+        "command_shell",
+        "started_at",
+        "finished_at",
+        "exit_code"
+      ],
+      "properties": {
+        "argv": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"type": "string"}
+        },
+        "command_shell": {"type": "string", "minLength": 1},
+        "started_at": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "finished_at": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "exit_code": {"type": ["integer", "null"]}
+      }
+    },
+    "output": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "requested_dir",
+        "working_dir",
+        "finalized",
+        "artifact_checksums"
+      ],
+      "properties": {
+        "requested_dir": {"type": "string"},
+        "working_dir": {"type": "string"},
+        "finalized": {"type": "boolean"},
+        "diagnosis_status": {
+          "enum": [
+            "success",
+            "map_saved",
+            "verify_failed",
+            "runtime_failed",
+            "incomplete"
+          ]
+        },
+        "artifact_checksums": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/file_identity"}
+        }
+      }
+    }
+  },
+  "definitions": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "file_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "size_bytes", "sha256"],
+      "properties": {
+        "path": {"type": "string", "minLength": 1},
+        "size_bytes": {"type": "integer", "minimum": 0},
+        "sha256": {"$ref": "#/definitions/sha256"}
+      }
+    }
+  }
+}

--- a/graph_based_slam/package.xml
+++ b/graph_based_slam/package.xml
@@ -31,6 +31,7 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>python3-jsonschema</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/graph_based_slam/test/test_autoware_map_preflight.py
+++ b/graph_based_slam/test/test_autoware_map_preflight.py
@@ -37,6 +37,7 @@ from pathlib import Path
 import subprocess
 import sys
 
+import jsonschema
 import yaml
 
 
@@ -91,6 +92,15 @@ def test_rko_lio_public_path_is_preferred_for_pointcloud_and_imu(tmp_path: Path)
 
     payload = module.build_preflight_payload(bag_dir)
 
+    schema = json.loads(
+        (
+            REPO_ROOT / 'docs' / 'schemas' / 'preflight-v1.schema.json'
+        ).read_text(encoding='utf-8')
+    )
+    jsonschema.Draft7Validator.check_schema(schema)
+    jsonschema.validate(payload, schema)
+    assert payload['schema_version'] == 1
+    assert payload['schema_uri'].endswith('/schemas/preflight-v1.schema.json')
     assert payload['recommended_profile_id'] == 'rko_lio_graph_public_path'
     assert payload['beginner_commands'][0]['command'].startswith(
         'bash scripts/run_autoware_map_beginner.sh'

--- a/graph_based_slam/test/test_autoware_map_run_diagnosis.py
+++ b/graph_based_slam/test/test_autoware_map_run_diagnosis.py
@@ -32,10 +32,12 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
 import subprocess
 import sys
 
+import jsonschema
 import yaml
 
 
@@ -72,8 +74,30 @@ def test_summary_marks_success_when_map_and_verify_pass_exist(tmp_path: Path):
         encoding='utf-8',
     )
 
-    summary = module.summarize_run(run_dir)
+    bag_dir = tmp_path / 'bag'
+    bag_dir.mkdir()
+    (bag_dir / 'metadata.yaml').write_text(
+        yaml.safe_dump({
+            'rosbag2_bagfile_information': {
+                'duration': {'nanoseconds': 1},
+                'message_count': 0,
+                'topics_with_message_count': [],
+            },
+        }),
+        encoding='utf-8',
+    )
+    summary = module.summarize_run(run_dir, bag_dir)
 
+    schema = json.loads(
+        (
+            REPO_ROOT / 'docs' / 'schemas' / 'diagnosis-v1.schema.json'
+        ).read_text(encoding='utf-8')
+    )
+    jsonschema.Draft7Validator.check_schema(schema)
+    jsonschema.validate(summary, schema)
+    assert summary['bag_preflight']['schema_version'] == 1
+    assert summary['schema_version'] == 1
+    assert summary['schema_uri'].endswith('/schemas/diagnosis-v1.schema.json')
     assert summary['status'] == 'success'
     assert summary['verify']['result'] == 'PASS'
     assert summary['projector_type'] == 'LocalCartesian'

--- a/graph_based_slam/test/test_docs_entrypoints.py
+++ b/graph_based_slam/test/test_docs_entrypoints.py
@@ -63,6 +63,9 @@ BENCHMARKING_DOC = REPO_ROOT / 'docs' / 'benchmarking.md'
 COMPARISON_DOC = REPO_ROOT / 'docs' / 'comparison.md'
 PRODUCT_CONTRACT_DOC = REPO_ROOT / 'docs' / 'product-contract.md'
 GOLDEN_PATH_CLI_DOC = REPO_ROOT / 'docs' / 'golden-path-cli.md'
+PREFLIGHT_SCHEMA = REPO_ROOT / 'docs' / 'schemas' / 'preflight-v1.schema.json'
+DIAGNOSIS_SCHEMA = REPO_ROOT / 'docs' / 'schemas' / 'diagnosis-v1.schema.json'
+RUN_MANIFEST_SCHEMA = REPO_ROOT / 'docs' / 'schemas' / 'run-manifest-v1.schema.json'
 V09_ROADMAP_DOC = REPO_ROOT / 'docs' / 'roadmap' / 'v0.9.md'
 SOCIAL_POST_DOC = REPO_ROOT / 'docs' / 'social' / 'autoware_map_authoring_post_v0.2.2.md'
 ISSUE_TEMPLATE_DIR = REPO_ROOT / '.github' / 'ISSUE_TEMPLATE'
@@ -114,6 +117,9 @@ def test_docs_exist_and_are_linked_from_readme():
     assert COMPARISON_DOC.is_file()
     assert PRODUCT_CONTRACT_DOC.is_file()
     assert GOLDEN_PATH_CLI_DOC.is_file()
+    assert PREFLIGHT_SCHEMA.is_file()
+    assert DIAGNOSIS_SCHEMA.is_file()
+    assert RUN_MANIFEST_SCHEMA.is_file()
     assert V09_ROADMAP_DOC.is_file()
     assert SOCIAL_POST_DOC.is_file()
     assert DOCS_SITE_WORKFLOW.is_file()
@@ -252,6 +258,7 @@ def test_contributing_and_issue_templates_exist():
 def test_product_contract_has_bounded_official_surface():
     """The beginner product surface should stay explicit and bounded."""
     contract = PRODUCT_CONTRACT_DOC.read_text(encoding='utf-8')
+    golden_path = GOLDEN_PATH_CLI_DOC.read_text(encoding='utf-8')
     roadmap = V09_ROADMAP_DOC.read_text(encoding='utf-8')
 
     assert '## Official entrypoints' in contract
@@ -261,6 +268,14 @@ def test_product_contract_has_bounded_official_surface():
     assert 'run_autoware_map_beginner.sh <rosbag2_dir>' in contract
     assert 'download_ntu_viral_tnp01.sh && bash scripts/run_autoware_quickstart.sh' in contract
     assert 'Other scripts and ROS' in contract
+    assert '`run_manifest.json`' in contract
+    assert '`<output>.partial`' in golden_path
+    assert 'preflight-v1.schema.json' in golden_path
+    assert 'diagnosis-v1.schema.json' in golden_path
+    assert 'run-manifest-v1.schema.json' in golden_path
+    assert 'existing outputs are never overwritten' in (
+        REPO_ROOT / 'scripts' / 'run_autoware_map_from_bag.py'
+    ).read_text(encoding='utf-8')
     assert '## Non-goals' in contract
     assert 'No more than three beginner-facing entrypoints' in roadmap
     assert 'Phase 1 — Golden-path UX' in roadmap

--- a/lidarslam/package.xml
+++ b/lidarslam/package.xml
@@ -23,6 +23,7 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>python3-jsonschema</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/lidarslam/test/test_autoware_map_runner_script.py
+++ b/lidarslam/test/test_autoware_map_runner_script.py
@@ -32,9 +32,12 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
 import subprocess
 
+import jsonschema
+import pytest
 import yaml
 
 
@@ -55,10 +58,13 @@ def _load_module():
 def _write_metadata(tmp_path: Path, bag_name: str, topics: list[tuple[str, str, int]]) -> Path:
     bag_dir = tmp_path / bag_name
     bag_dir.mkdir()
+    storage_name = f'{bag_name}_0.db3'
     metadata = {
         'rosbag2_bagfile_information': {
             'duration': {'nanoseconds': 2_000_000_000},
             'message_count': sum(count for _, _, count in topics),
+            'storage_identifier': 'sqlite3',
+            'relative_file_paths': [storage_name],
             'topics_with_message_count': [
                 {
                     'topic_metadata': {
@@ -73,6 +79,7 @@ def _write_metadata(tmp_path: Path, bag_name: str, topics: list[tuple[str, str, 
             ],
         },
     }
+    (bag_dir / storage_name).write_bytes(b'rosbag2 fixture\n')
     (bag_dir / 'metadata.yaml').write_text(yaml.safe_dump(metadata), encoding='utf-8')
     return bag_dir
 
@@ -92,6 +99,8 @@ def test_runner_script_supports_profiles_and_viewers():
     assert 'run_graph_slam_pointcloud_map_in_autoware_foxglove.sh' in script
     assert 'run_graph_slam_pointcloud_map_in_autoware.sh' in script
     assert '--dry-run' in script
+    assert 'run_manifest.json' in script
+    assert 'artifact_checksums' in script
 
 
 def test_runner_help_is_user_facing():
@@ -156,6 +165,268 @@ def test_runner_rejects_output_file_without_traceback(tmp_path: Path):
     assert result.returncode == 2
     assert 'output directory path is a file' in result.stderr
     assert 'Traceback' not in result.stderr
+
+
+def test_manifest_helpers_capture_identity_and_finalize_atomically(tmp_path: Path):
+    module = _load_module()
+    bag_dir = _write_metadata(
+        tmp_path,
+        'demo_bag',
+        [
+            ('/points', 'sensor_msgs/msg/PointCloud2', 20),
+            ('/imu', 'sensor_msgs/msg/Imu', 180),
+        ],
+    )
+    final_dir = tmp_path / 'map_output'
+    working_dir = tmp_path / 'map_output.partial'
+    working_dir.mkdir()
+    plan = {
+        'profile_id': 'rko_lio_graph_public_path',
+        'label': 'RKO-LIO + graph_based_slam public path',
+        'command': ['python3', '-c', 'pass'],
+    }
+
+    manifest = module._build_manifest(bag_dir, final_dir, working_dir, plan)
+    module._write_manifest(working_dir, manifest)
+    (working_dir / 'artifact.txt').write_text('map artifact\n', encoding='utf-8')
+    manifest['output']['artifact_checksums'] = module._artifact_checksums(working_dir)
+    module._write_manifest(working_dir, manifest)
+    module._finalize_output(working_dir, final_dir)
+
+    saved = json.loads((final_dir / 'run_manifest.json').read_text(encoding='utf-8'))
+    schema = json.loads(
+        (
+            REPO_ROOT / 'docs' / 'schemas' / 'run-manifest-v1.schema.json'
+        ).read_text(encoding='utf-8')
+    )
+    jsonschema.Draft7Validator.check_schema(schema)
+    jsonschema.validate(saved, schema)
+    assert saved['schema_version'] == 1
+    assert saved['input']['metadata_sha256'] == module._sha256(
+        bag_dir / 'metadata.yaml'
+    )
+    assert saved['input']['storage_identifier'] == 'sqlite3'
+    assert saved['input']['storage_files'] == [{
+        'path': 'demo_bag_0.db3',
+        'sha256': module._sha256(bag_dir / 'demo_bag_0.db3'),
+        'size_bytes': 16,
+    }]
+    assert saved['software']['product_version'] == '0.6.0'
+    assert saved['software']['package_versions']['lidarslam'] == '0.6.0'
+    assert isinstance(saved['software']['git_dirty'], bool)
+    assert saved['profile']['id'] == 'rko_lio_graph_public_path'
+    assert saved['output']['artifact_checksums'][0]['path'] == 'artifact.txt'
+    assert not working_dir.exists()
+
+
+def test_manifest_rejects_storage_path_outside_bag(tmp_path: Path):
+    module = _load_module()
+    bag_dir = tmp_path / 'bag'
+    bag_dir.mkdir()
+    (tmp_path / 'outside.db3').write_bytes(b'outside\n')
+    metadata = {
+        'rosbag2_bagfile_information': {
+            'storage_identifier': 'sqlite3',
+            'relative_file_paths': ['../outside.db3'],
+            'topics_with_message_count': [],
+        },
+    }
+    (bag_dir / 'metadata.yaml').write_text(
+        yaml.safe_dump(metadata),
+        encoding='utf-8',
+    )
+
+    with pytest.raises(ValueError, match='outside the bag'):
+        module._bag_identity(bag_dir)
+
+
+def test_main_writes_success_manifest_and_rejects_collision(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    module = _load_module()
+    bag_dir = _write_metadata(
+        tmp_path,
+        'demo_bag',
+        [
+            ('/points', 'sensor_msgs/msg/PointCloud2', 20),
+            ('/imu', 'sensor_msgs/msg/Imu', 180),
+        ],
+    )
+    output_dir = tmp_path / 'map_output'
+
+    def fake_plan(bag_path, profile_id, output_dir, verify_map):
+        del bag_path, profile_id, verify_map
+        working_dir = output_dir
+        command_script = '\n'.join([
+            'from pathlib import Path',
+            f'root = Path({str(working_dir)!r})',
+            "(root / 'pointcloud_map').mkdir(parents=True, exist_ok=True)",
+            (
+                "(root / 'pointcloud_map' / 'pointcloud_map_metadata.yaml')"
+                ".write_text('tiles: []\\n')"
+            ),
+            "(root / 'map_projector_info.yaml').write_text('projector_type: Local\\n')",
+        ])
+        return {
+            'payload': {},
+            'profile_id': 'rko_lio_graph_public_path',
+            'label': 'RKO-LIO + graph_based_slam public path',
+            'command': ['python3', '-c', command_script],
+            'output_dir': working_dir,
+        }
+
+    def fake_verify(run_dir: Path, enabled: bool):
+        assert enabled is True
+        (run_dir / 'verify_autoware_map.log').write_text(
+            'RESULT: PASS\nPASS: 1 | WARN: 0 | FAIL: 0\n',
+            encoding='utf-8',
+        )
+
+    monkeypatch.setattr(module, 'build_execution_plan', fake_plan)
+    monkeypatch.setattr(module, 'maybe_verify_map', fake_verify)
+    monkeypatch.setattr(
+        module.sys,
+        'argv',
+        [
+            str(SCRIPT_PATH),
+            str(bag_dir),
+            '--output-dir',
+            str(output_dir),
+        ],
+    )
+
+    assert module.main() == 0
+    assert output_dir.is_dir()
+    assert not output_dir.with_name('map_output.partial').exists()
+    manifest = json.loads(
+        (output_dir / 'run_manifest.json').read_text(encoding='utf-8')
+    )
+    assert manifest['status'] == 'succeeded'
+    assert manifest['execution']['exit_code'] == 0
+    assert manifest['output']['finalized'] is True
+    assert manifest['output']['diagnosis_status'] == 'success'
+    assert any(
+        item['path'] == 'autoware_map_diagnosis.json'
+        for item in manifest['output']['artifact_checksums']
+    )
+
+    assert module.main() == 2
+
+
+@pytest.mark.parametrize(
+    ('workflow_error', 'expected_status', 'expected_exit_code'),
+    [
+        (subprocess.CompletedProcess([], 17), 'failed', 17),
+        (KeyboardInterrupt(), 'interrupted', 130),
+    ],
+)
+def test_main_retains_terminal_manifest_for_failed_and_interrupted_runs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    workflow_error,
+    expected_status: str,
+    expected_exit_code: int,
+):
+    module = _load_module()
+    bag_dir = _write_metadata(
+        tmp_path,
+        'demo_bag',
+        [
+            ('/points', 'sensor_msgs/msg/PointCloud2', 20),
+            ('/imu', 'sensor_msgs/msg/Imu', 180),
+        ],
+    )
+    output_dir = tmp_path / 'failed_map'
+    plan = {
+        'payload': {},
+        'profile_id': 'rko_lio_graph_public_path',
+        'label': 'RKO-LIO + graph_based_slam public path',
+        'command': ['map-workflow'],
+        'output_dir': output_dir.with_name('failed_map.partial'),
+    }
+    monkeypatch.setattr(module, 'build_execution_plan', lambda **kwargs: plan)
+    monkeypatch.setattr(module, '_git_state', lambda: {
+        'commit': '0' * 40,
+        'dirty': False,
+    })
+    monkeypatch.setattr(module, 'maybe_verify_map', lambda *args, **kwargs: None)
+
+    if isinstance(workflow_error, BaseException):
+        def fake_run(*args, **kwargs):
+            raise workflow_error
+    else:
+        def fake_run(*args, **kwargs):
+            return workflow_error
+    monkeypatch.setattr(module.subprocess, 'run', fake_run)
+    monkeypatch.setattr(
+        module.sys,
+        'argv',
+        [
+            str(SCRIPT_PATH),
+            str(bag_dir),
+            '--output-dir',
+            str(output_dir),
+        ],
+    )
+
+    assert module.main() == expected_exit_code
+    manifest = json.loads(
+        (output_dir / 'run_manifest.json').read_text(encoding='utf-8')
+    )
+    assert manifest['status'] == expected_status
+    assert manifest['execution']['exit_code'] == expected_exit_code
+    assert manifest['output']['finalized'] is True
+    assert not output_dir.with_name('failed_map.partial').exists()
+
+
+def test_main_preserves_failed_manifest_when_post_finalize_diagnosis_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    module = _load_module()
+    bag_dir = _write_metadata(
+        tmp_path,
+        'demo_bag',
+        [
+            ('/points', 'sensor_msgs/msg/PointCloud2', 20),
+            ('/imu', 'sensor_msgs/msg/Imu', 180),
+        ],
+    )
+    output_dir = tmp_path / 'map_output'
+    plan = {
+        'payload': {},
+        'profile_id': 'rko_lio_graph_public_path',
+        'label': 'RKO-LIO + graph_based_slam public path',
+        'command': ['python3', '-c', 'pass'],
+        'output_dir': output_dir.with_name('map_output.partial'),
+    }
+    monkeypatch.setattr(module, 'build_execution_plan', lambda **kwargs: plan)
+    monkeypatch.setattr(module, 'maybe_verify_map', lambda *args, **kwargs: None)
+
+    def fail_diagnosis(*args, **kwargs):
+        del args, kwargs
+        raise RuntimeError('diagnosis fixture failure')
+
+    monkeypatch.setattr(module, 'write_diagnostics', fail_diagnosis)
+    monkeypatch.setattr(
+        module.sys,
+        'argv',
+        [
+            str(SCRIPT_PATH),
+            str(bag_dir),
+            '--output-dir',
+            str(output_dir),
+        ],
+    )
+
+    assert module.main() == 70
+    manifest = json.loads(
+        (output_dir / 'run_manifest.json').read_text(encoding='utf-8')
+    )
+    assert manifest['status'] == 'failed'
+    assert manifest['execution']['exit_code'] == 70
+    assert manifest['output']['finalized'] is True
 
 
 def test_runner_rejects_incompatible_profile_with_available_hint(tmp_path: Path):

--- a/scripts/diagnose_autoware_map_run.py
+++ b/scripts/diagnose_autoware_map_run.py
@@ -12,6 +12,9 @@ from typing import Any
 
 import yaml
 
+SCHEMA_VERSION = 1
+SCHEMA_URI = 'https://rsasaki0109.github.io/lidar_slam_ros2/schemas/diagnosis-v1.schema.json'
+
 
 def _load_preflight_module():
     import importlib.util
@@ -175,6 +178,8 @@ def summarize_run(run_dir: Path, bag_path: Path | None = None) -> dict[str, Any]
         status = 'runtime_failed'
 
     summary: dict[str, Any] = {
+        'schema_version': SCHEMA_VERSION,
+        'schema_uri': SCHEMA_URI,
         'run_dir': str(run_dir),
         'status': status,
         'files': {

--- a/scripts/preflight_autoware_map_bag.py
+++ b/scripts/preflight_autoware_map_bag.py
@@ -21,6 +21,8 @@ TFMESSAGE = 'tf2_msgs/msg/TFMessage'
 GSOF49 = 'applanix_msgs/msg/NavigationSolutionGsof49'
 GSOF50 = 'applanix_msgs/msg/NavigationPerformanceGsof50'
 VELOCITY_REPORT = 'autoware_auto_vehicle_msgs/msg/VelocityReport'
+SCHEMA_VERSION = 1
+SCHEMA_URI = 'https://rsasaki0109.github.io/lidar_slam_ros2/schemas/preflight-v1.schema.json'
 
 PROFILE_HELP = (
     (
@@ -321,6 +323,8 @@ def build_preflight_payload(bag_path: Path) -> dict[str, Any]:
         ]
 
     return {
+        'schema_version': SCHEMA_VERSION,
+        'schema_uri': SCHEMA_URI,
         'summary': summary,
         'recommendations': recommendations,
         'recommended_profile_id': recommendations[0]['id'] if recommendations else None,

--- a/scripts/run_autoware_map_from_bag.py
+++ b/scripts/run_autoware_map_from_bag.py
@@ -4,15 +4,28 @@
 from __future__ import annotations
 
 import argparse
+from datetime import datetime, timezone
+import hashlib
 import importlib.util
+import json
+import os
+from pathlib import Path
 import shlex
 import subprocess
 import sys
-from datetime import datetime
-from pathlib import Path
+import uuid
+import xml.etree.ElementTree as ET
+
+import yaml
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_NAME = 'run_manifest.json'
+MANIFEST_SCHEMA_VERSION = 1
+MANIFEST_SCHEMA_URI = (
+    'https://rsasaki0109.github.io/lidar_slam_ros2/'
+    'schemas/run-manifest-v1.schema.json'
+)
 PROFILE_CHOICES = (
     'rko_lio_graph_public_path',
     'rko_lio_graph_mid360_preset',
@@ -30,6 +43,13 @@ PROFILE_HELP = (
     ),
     ('pointcloud_gnss_smoke', 'PointCloud2 + NavSatFix smoke workflow.'),
     ('packet_applanix_smoke', 'VelodyneScan + Applanix GSOF49 smoke workflow.'),
+)
+PACKAGE_XML_PATHS = (
+    REPO_ROOT / 'lidarslam' / 'package.xml',
+    REPO_ROOT / 'graph_based_slam' / 'package.xml',
+    REPO_ROOT / 'lidarslam_msgs' / 'package.xml',
+    REPO_ROOT / 'scanmatcher' / 'package.xml',
+    REPO_ROOT / 'Thirdparty' / 'rko_lio' / 'package.xml',
 )
 
 
@@ -189,13 +209,215 @@ def validate_bag_path(bag_path: Path) -> None:
 
 def validate_output_dir(output_dir: Path) -> None:
     if output_dir.exists() and not output_dir.is_dir():
-        raise ValueError(f'output directory path is a file, not a directory: {output_dir}')
+        raise ValueError(f'output directory path is a file: {output_dir}')
+    if output_dir.exists():
+        raise ValueError(
+            f'output directory already exists: {output_dir}. '
+            'Choose a new directory; existing outputs are never overwritten.'
+        )
 
     for parent in output_dir.parents:
         if parent.exists():
             if not parent.is_dir():
                 raise ValueError(f'output directory parent is not a directory: {parent}')
             return
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open('rb') as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b''):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _file_identity(path: Path, display_path: str) -> dict[str, object]:
+    before = path.stat()
+    digest = _sha256(path)
+    after = path.stat()
+    if (
+        before.st_size != after.st_size
+        or before.st_mtime_ns != after.st_mtime_ns
+        or before.st_ino != after.st_ino
+    ):
+        raise RuntimeError(f'file changed while hashing: {path}')
+    return {
+        'path': display_path,
+        'size_bytes': after.st_size,
+        'sha256': digest,
+    }
+
+
+def _git_state() -> dict[str, object]:
+    commit_result = subprocess.run(
+        ['git', 'rev-parse', 'HEAD'],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    status_result = subprocess.run(
+        ['git', 'status', '--porcelain', '--untracked-files=no'],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return {
+        'commit': (
+            commit_result.stdout.strip()
+            if commit_result.returncode == 0
+            else None
+        ),
+        'dirty': (
+            bool(status_result.stdout.strip())
+            if status_result.returncode == 0
+            else None
+        ),
+    }
+
+
+def _product_version() -> str:
+    return (REPO_ROOT / 'VERSION').read_text(encoding='utf-8').strip()
+
+
+def _package_versions() -> dict[str, str]:
+    versions = {}
+    for package_xml in PACKAGE_XML_PATHS:
+        if not package_xml.is_file():
+            continue
+        root = ET.parse(package_xml).getroot()
+        name = root.findtext('name')
+        version = root.findtext('version')
+        if name and version:
+            versions[name.strip()] = version.strip()
+    return dict(sorted(versions.items()))
+
+
+def _bag_identity(bag_path: Path) -> dict[str, object]:
+    metadata_path = bag_path / 'metadata.yaml'
+    metadata_before = metadata_path.stat()
+    metadata_bytes = metadata_path.read_bytes()
+    metadata_after = metadata_path.stat()
+    if (
+        metadata_before.st_size != metadata_after.st_size
+        or metadata_before.st_mtime_ns != metadata_after.st_mtime_ns
+        or metadata_before.st_ino != metadata_after.st_ino
+    ):
+        raise RuntimeError(f'file changed while reading: {metadata_path}')
+    metadata = yaml.safe_load(metadata_bytes) or {}
+    bag_info = metadata.get('rosbag2_bagfile_information') or {}
+    relative_paths = bag_info.get('relative_file_paths') or []
+    if not relative_paths:
+        relative_paths = [
+            path.relative_to(bag_path).as_posix()
+            for pattern in ('*.db3', '*.mcap')
+            for path in sorted(bag_path.glob(pattern))
+        ]
+
+    storage_files = []
+    seen_paths = set()
+    resolved_bag_path = bag_path.resolve()
+    for relative_path in relative_paths:
+        path = (bag_path / str(relative_path)).resolve()
+        try:
+            normalized_relative = path.relative_to(resolved_bag_path).as_posix()
+        except ValueError as exc:
+            raise ValueError(
+                f'rosbag2 metadata references a file outside the bag: {relative_path}'
+            ) from exc
+        if normalized_relative in seen_paths:
+            continue
+        if not path.is_file():
+            raise ValueError(
+                f'rosbag2 storage file referenced by metadata is missing: {path}'
+            )
+        seen_paths.add(normalized_relative)
+        storage_files.append(_file_identity(path, normalized_relative))
+
+    return {
+        'bag_path': str(bag_path),
+        'metadata_path': str(metadata_path),
+        'metadata_size_bytes': metadata_after.st_size,
+        'metadata_sha256': hashlib.sha256(metadata_bytes).hexdigest(),
+        'storage_identifier': bag_info.get('storage_identifier'),
+        'storage_files': storage_files,
+        'identity_algorithm': 'sha256',
+    }
+
+
+def _write_manifest(run_dir: Path, manifest: dict[str, object]) -> None:
+    destination = run_dir / MANIFEST_NAME
+    temporary = run_dir / f'.{MANIFEST_NAME}.tmp'
+    temporary.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + '\n',
+        encoding='utf-8',
+    )
+    os.replace(temporary, destination)
+
+
+def _artifact_checksums(run_dir: Path) -> list[dict[str, object]]:
+    artifacts = []
+    for path in sorted(item for item in run_dir.rglob('*') if item.is_file()):
+        relative = path.relative_to(run_dir)
+        if relative.as_posix() == MANIFEST_NAME or relative.name.startswith(
+            f'.{MANIFEST_NAME}.'
+        ):
+            continue
+        artifacts.append(_file_identity(path, relative.as_posix()))
+    return artifacts
+
+
+def _build_manifest(
+    bag_path: Path,
+    final_output_dir: Path,
+    working_output_dir: Path,
+    plan: dict[str, object],
+) -> dict[str, object]:
+    git_state = _git_state()
+    return {
+        'schema_version': MANIFEST_SCHEMA_VERSION,
+        'schema_uri': MANIFEST_SCHEMA_URI,
+        'run_id': str(uuid.uuid4()),
+        'status': 'planned',
+        'input': _bag_identity(bag_path),
+        'software': {
+            'product_version': _product_version(),
+            'git_commit': git_state['commit'],
+            'git_dirty': git_state['dirty'],
+            'package_versions': _package_versions(),
+            'ros_distro': os.environ.get('ROS_DISTRO'),
+        },
+        'profile': {
+            'id': plan['profile_id'],
+            'label': plan['label'],
+        },
+        'execution': {
+            'argv': plan['command'],
+            'command_shell': shlex.join(plan['command']),
+            'started_at': None,
+            'finished_at': None,
+            'exit_code': None,
+        },
+        'output': {
+            'requested_dir': str(final_output_dir),
+            'working_dir': str(working_output_dir),
+            'finalized': False,
+            'artifact_checksums': [],
+        },
+    }
+
+
+def _finalize_output(working_dir: Path, final_dir: Path) -> None:
+    if final_dir.exists():
+        raise RuntimeError(
+            f'output collision detected before finalization: {final_dir}'
+        )
+    os.replace(working_dir, final_dir)
 
 
 def maybe_open_viewer(args: argparse.Namespace, output_dir: Path) -> None:
@@ -282,15 +504,16 @@ def print_next_steps(args: argparse.Namespace, output_dir: Path) -> None:
         )
 
 
-def write_diagnostics(output_dir: Path, bag_path: Path) -> None:
+def write_diagnostics(output_dir: Path, bag_path: Path) -> dict[str, object]:
     diagnose = _load_script_module('diagnose_autoware_map_run.py', 'diagnose_autoware_map_run')
     summary = diagnose.summarize_run(output_dir, bag_path)
     markdown = diagnose.render_markdown(summary)
     (output_dir / 'autoware_map_diagnosis.md').write_text(markdown, encoding='utf-8')
     (output_dir / 'autoware_map_diagnosis.json').write_text(
-        __import__('json').dumps(summary, indent=2, sort_keys=True),
+        json.dumps(summary, indent=2, sort_keys=True),
         encoding='utf-8',
     )
+    return summary
 
 
 def _profile_help_text() -> str:
@@ -396,13 +619,15 @@ def main() -> int:
     output_dir = Path(args.output_dir).expanduser().resolve() if args.output_dir else (
         REPO_ROOT / 'output' / f'autoware_map_authoring_{bag_path.stem}_{timestamp}'
     )
+    working_dir = output_dir.with_name(f'{output_dir.name}.partial')
     try:
         validate_bag_path(bag_path)
         validate_output_dir(output_dir)
+        validate_output_dir(working_dir)
         plan = build_execution_plan(
             bag_path=bag_path,
             profile_id=args.profile,
-            output_dir=output_dir,
+            output_dir=working_dir,
             verify_map=not args.no_verify_map,
         )
     except (FileNotFoundError, RuntimeError, ValueError) as exc:
@@ -410,7 +635,8 @@ def main() -> int:
         return 2
 
     print(f"Selected profile: {plan['label']}")
-    print(f"Output directory: {plan['output_dir']}")
+    print(f'Output directory: {output_dir}')
+    print(f'Atomic working directory: {working_dir}')
     print('Command:')
     print('  ' + shlex.join(plan['command']))
 
@@ -418,33 +644,82 @@ def main() -> int:
         return 0
 
     try:
-        output_dir.mkdir(parents=True, exist_ok=True)
-    except OSError as exc:
-        print(f'error: failed to create output directory {output_dir}: {exc}', file=sys.stderr)
+        manifest = _build_manifest(bag_path, output_dir, working_dir, plan)
+        working_dir.mkdir(parents=True, exist_ok=False)
+        manifest['status'] = 'running'
+        manifest['execution']['started_at'] = _utc_now()
+        _write_manifest(working_dir, manifest)
+    except (OSError, RuntimeError, ValueError, ET.ParseError, yaml.YAMLError) as exc:
+        print(
+            f'error: failed to initialize output directory {working_dir}: {exc}',
+            file=sys.stderr,
+        )
         return 2
 
-    command_error: subprocess.CalledProcessError | None = None
+    exit_code = 0
+    interrupted = False
     try:
-        subprocess.run(plan['command'], check=True, cwd=REPO_ROOT)
-    except subprocess.CalledProcessError as exc:
-        command_error = exc
-    finally:
-        if output_dir.exists():
-            try:
-                maybe_verify_map(output_dir, enabled=not args.no_verify_map)
-                write_diagnostics(output_dir, bag_path)
-            except (OSError, RuntimeError, ValueError) as exc:
-                print(f'warning: failed to write run diagnostics: {exc}', file=sys.stderr)
+        result = subprocess.run(plan['command'], check=False, cwd=REPO_ROOT)
+        exit_code = result.returncode
+    except KeyboardInterrupt:
+        interrupted = True
+        exit_code = 130
+    except OSError as exc:
+        print(f'error: failed to start map workflow: {exc}', file=sys.stderr)
+        exit_code = 70
 
-    if command_error is not None:
+    manifest['execution']['exit_code'] = exit_code
+    manifest['execution']['finished_at'] = _utc_now()
+    manifest['status'] = (
+        'interrupted' if interrupted else ('succeeded' if exit_code == 0 else 'failed')
+    )
+
+    try:
+        _write_manifest(working_dir, manifest)
+        maybe_verify_map(working_dir, enabled=not args.no_verify_map)
+        _finalize_output(working_dir, output_dir)
+        manifest['output']['finalized'] = True
+        diagnosis = write_diagnostics(output_dir, bag_path)
+        manifest['output']['diagnosis_status'] = diagnosis['status']
+        if (
+            manifest['status'] == 'succeeded'
+            and not args.no_verify_map
+            and diagnosis['status'] != 'success'
+        ):
+            manifest['status'] = 'failed'
+            if exit_code == 0:
+                exit_code = 1
+                manifest['execution']['exit_code'] = exit_code
+        manifest['output']['artifact_checksums'] = _artifact_checksums(output_dir)
+        _write_manifest(output_dir, manifest)
+    except (OSError, RuntimeError, ValueError) as exc:
+        print(f'error: failed to finalize output: {exc}', file=sys.stderr)
+        manifest_dir = output_dir if output_dir.exists() else working_dir
+        if manifest_dir.exists():
+            manifest['status'] = 'failed'
+            manifest['execution']['exit_code'] = 70
+            manifest['output']['finalized'] = output_dir.exists()
+            try:
+                manifest['output']['artifact_checksums'] = _artifact_checksums(
+                    manifest_dir
+                )
+                _write_manifest(manifest_dir, manifest)
+            except (OSError, RuntimeError) as manifest_exc:
+                print(
+                    f'warning: failed to preserve terminal manifest: {manifest_exc}',
+                    file=sys.stderr,
+                )
+        return 70
+
+    if exit_code != 0:
         print(
-            f'error: map workflow failed with exit code {command_error.returncode}.',
+            f'error: map workflow failed with exit code {exit_code}.',
             file=sys.stderr,
         )
         print('failed command:', shlex.join(plan['command']), file=sys.stderr)
         if (output_dir / 'autoware_map_diagnosis.md').is_file():
             print(f'Diagnosis written to: {output_dir / "autoware_map_diagnosis.md"}')
-        return command_error.returncode or 1
+        return exit_code
 
     print_next_steps(args, output_dir)
     try:
@@ -453,6 +728,7 @@ def main() -> int:
         print(f'error: viewer failed with exit code {exc.returncode}.', file=sys.stderr)
         return exc.returncode or 1
     print(f'Diagnosis written to: {output_dir / "autoware_map_diagnosis.md"}')
+    print(f'Run manifest: {output_dir / MANIFEST_NAME}')
     return 0
 
 


### PR DESCRIPTION
## What changed

- publish Draft 7 v1 schemas for preflight, diagnosis, and run manifests, compatible with the standard Humble/Jazzy test dependencies
- write `run_manifest.json` with full rosbag SHA-256 identities, product/package/Git/ROS identity, exact argv, timestamps, terminal state, and artifact checksums
- isolate execution under `<output>.partial`, reject collisions, and atomically finalize completed, failed, or interrupted runs
- preserve a terminal manifest when execution, verification, diagnosis, or post-finalize processing fails
- document the machine-readable contracts and immutable-output behavior

## Why

Phase 1 of the product roadmap requires reproducible, diagnosable own-bag runs. Previously outputs could be reused silently and there was no durable record connecting an artifact bundle to its input bytes, software state, command, or completion state.

## User impact

Existing output paths are never overwritten. Large bags receive one sequential SHA-256 read before execution. Automation can select and validate contracts through `schema_version` and `schema_uri`.

## Validation

- `bash scripts/run_default_ci_checks.sh` — 2557 tests, 0 failures, 125 skipped (ROS 2 Jazzy)
- focused product/schema suite — 45 passed
- `python3 -m mkdocs build --strict`
- `ament_flake8` on changed Python and tests
- `ament_xmllint lidarslam/package.xml graph_based_slam/package.xml`
- `git diff --check`
