### PR TITLE
Add safe partial-run recovery

### DIFF
--- a/docs/golden-path-cli.md
+++ b/docs/golden-path-cli.md
@@ -27,22 +27,47 @@ when either name already exists, so a new run never overwrites prior evidence.
 Completed, failed, and interrupted workflows retain their artifacts and
 terminal state for diagnosis.
 
-Every non-dry run produces `run_manifest.json`. It records:
+If the workflow has stopped but verification, finalization, diagnosis, or
+checksum generation was interrupted, resume only those terminal
+post-processing stages:
+
+```bash
+./scripts/lidarslam run <rosbag2_dir> \
+  --output-dir output/my_map \
+  --resume
+```
+
+Resume requires the original bag, software checkout, ROS distribution,
+profile, options, and output path. Their checksums and identities must match
+the manifest exactly. It accepts either `output/my_map.partial` before the
+atomic rename or `output/my_map` after the rename, but never both. A manifest
+at `initialized` or `workflow_running` is refused because the original process
+may still be active. An advisory lock also prevents two post-processing
+processes from owning the same output.
+
+Resume never starts the SLAM workflow again.
+
+Every non-dry run produces a schema-v2 `run_manifest.json`. It records:
 
 - SHA-256 identities for `metadata.yaml`, every referenced rosbag storage file,
   and every output artifact;
 - product, core package, Git commit/dirty-state, and ROS distribution identity;
 - the selected profile and exact argument vector;
 - UTC start/finish timestamps, exit code, terminal status, and diagnosis
-  status.
+  status;
+- the durable lifecycle stage, resume count, runner exit code, and last
+  post-processing error.
 
 Hashing large bags adds a sequential input read before execution. This is
 deliberate: the manifest identifies the data that was actually processed,
 rather than only the path where it happened to be stored.
 
-`succeeded` means the workflow exited successfully. When verification is
-enabled (the default), a non-`success` diagnosis changes the manifest to
-`failed`. With `--no-verify-map`, inspect `output.diagnosis_status` separately;
+`execution.exit_code` is always the map-workflow exit code.
+`lifecycle.runner_exit_code` is the overall runner result, including
+verification and post-processing. `succeeded` means both the workflow and
+enabled verification completed successfully. When verification is enabled
+(the default), a non-`success` diagnosis changes the manifest to `failed`.
+With `--no-verify-map`, inspect `output.diagnosis_status` separately;
 `succeeded` does not claim that map verification ran.
 
 `inspect` classifies an output as `success`, `map_saved`, `verify_failed`,
@@ -57,10 +82,15 @@ it must not infer compatibility from the repository version.
 - [Preflight schema v1](schemas/preflight-v1.schema.json)
 - [Diagnosis schema v1](schemas/diagnosis-v1.schema.json)
 - [Run manifest schema v1](schemas/run-manifest-v1.schema.json)
+- [Run manifest schema v2](schemas/run-manifest-v2.schema.json) — current;
+  adds resumable lifecycle state
 
 Top-level fields are closed within a published schema. A field addition,
 removal, type change, or semantic break requires a new schema file and
 migration guidance.
+
+Run manifest v1 remains published for existing artifacts. It predates durable
+lifecycle stages, so it can be inspected but cannot be resumed safely.
 
 Each subcommand accepts the same options as its delegated tool:
 

--- a/docs/product-contract.md
+++ b/docs/product-contract.md
@@ -31,7 +31,10 @@ not surveyed road semantics; review them before use.
 The versioned machine-readable contracts are published with the
 [golden-path CLI documentation](golden-path-cli.md#versioned-json-contracts).
 Existing output directories are immutable to the runner: operators must choose
-a new name, and in-progress work is isolated under a `.partial` sibling.
+a new name, and in-progress work is isolated under a `.partial` sibling. The
+only exception is explicit `--resume` of an incomplete schema-v2 lifecycle:
+the runner revalidates the original execution identity and completes terminal
+post-processing without rerunning SLAM or replacing map artifacts.
 
 ## Official entrypoints
 

--- a/docs/roadmap/v0.9.md
+++ b/docs/roadmap/v0.9.md
@@ -1,7 +1,7 @@
 # lidarslam_ros2 v0.9 roadmap — product foundation
 
 > Status: **direction approved 2026-07-27; Phase 0 complete; Phase 1 in
-> progress (CLI and manifest lifecycle landed; resume semantics pending)**.
+> progress (CLI, manifest lifecycle and safe terminal resume landed)**.
 > This roadmap
 > turns the existing benchmark-heavy map-authoring stack into a product-level
 > OSS project. It does not replace the evidence-driven capability roadmaps;

--- a/docs/schemas/run-manifest-v2.schema.json
+++ b/docs/schemas/run-manifest-v2.schema.json
@@ -1,0 +1,194 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://rsasaki0109.github.io/lidar_slam_ros2/schemas/run-manifest-v2.schema.json",
+  "title": "lidarslam_ros2 run manifest v2",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "schema_uri",
+    "run_id",
+    "status",
+    "lifecycle",
+    "input",
+    "software",
+    "profile",
+    "execution",
+    "output"
+  ],
+  "properties": {
+    "schema_version": {"const": 2},
+    "schema_uri": {
+      "const": "https://rsasaki0109.github.io/lidar_slam_ros2/schemas/run-manifest-v2.schema.json"
+    },
+    "run_id": {"type": "string", "format": "uuid"},
+    "status": {
+      "enum": ["planned", "running", "succeeded", "failed", "interrupted"]
+    },
+    "lifecycle": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "stage",
+        "resume_count",
+        "verification_enabled",
+        "runner_exit_code",
+        "last_error"
+      ],
+      "properties": {
+        "stage": {
+          "enum": [
+            "initialized",
+            "workflow_running",
+            "workflow_finished",
+            "verifying",
+            "verified",
+            "finalizing",
+            "finalized",
+            "diagnosing",
+            "diagnosed",
+            "checksumming",
+            "complete"
+          ]
+        },
+        "resume_count": {"type": "integer", "minimum": 0},
+        "verification_enabled": {"type": "boolean"},
+        "runner_exit_code": {"type": ["integer", "null"]},
+        "last_error": {"type": ["string", "null"]}
+      }
+    },
+    "input": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "bag_path",
+        "metadata_path",
+        "metadata_size_bytes",
+        "metadata_sha256",
+        "storage_identifier",
+        "storage_files",
+        "identity_algorithm"
+      ],
+      "properties": {
+        "bag_path": {"type": "string"},
+        "metadata_path": {"type": "string"},
+        "metadata_size_bytes": {"type": "integer", "minimum": 0},
+        "metadata_sha256": {"$ref": "#/definitions/sha256"},
+        "storage_identifier": {"type": ["string", "null"]},
+        "storage_files": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/file_identity"}
+        },
+        "identity_algorithm": {"const": "sha256"}
+      }
+    },
+    "software": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "product_version",
+        "git_commit",
+        "git_dirty",
+        "package_versions",
+        "ros_distro"
+      ],
+      "properties": {
+        "product_version": {"type": "string", "minLength": 1},
+        "git_commit": {
+          "type": ["string", "null"],
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "git_dirty": {"type": ["boolean", "null"]},
+        "package_versions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "ros_distro": {"type": ["string", "null"]}
+      }
+    },
+    "profile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "label"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "label": {"type": "string", "minLength": 1}
+      }
+    },
+    "execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "argv",
+        "command_shell",
+        "started_at",
+        "finished_at",
+        "exit_code"
+      ],
+      "properties": {
+        "argv": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"type": "string"}
+        },
+        "command_shell": {"type": "string", "minLength": 1},
+        "started_at": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "finished_at": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "exit_code": {"type": ["integer", "null"]}
+      }
+    },
+    "output": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "requested_dir",
+        "working_dir",
+        "finalized",
+        "artifact_checksums"
+      ],
+      "properties": {
+        "requested_dir": {"type": "string"},
+        "working_dir": {"type": "string"},
+        "finalized": {"type": "boolean"},
+        "diagnosis_status": {
+          "enum": [
+            "success",
+            "map_saved",
+            "verify_failed",
+            "runtime_failed",
+            "incomplete"
+          ]
+        },
+        "artifact_checksums": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/file_identity"}
+        }
+      }
+    }
+  },
+  "definitions": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "file_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "size_bytes", "sha256"],
+      "properties": {
+        "path": {"type": "string", "minLength": 1},
+        "size_bytes": {"type": "integer", "minimum": 0},
+        "sha256": {"$ref": "#/definitions/sha256"}
+      }
+    }
+  }
+}

--- a/graph_based_slam/test/test_docs_entrypoints.py
+++ b/graph_based_slam/test/test_docs_entrypoints.py
@@ -66,6 +66,9 @@ GOLDEN_PATH_CLI_DOC = REPO_ROOT / 'docs' / 'golden-path-cli.md'
 PREFLIGHT_SCHEMA = REPO_ROOT / 'docs' / 'schemas' / 'preflight-v1.schema.json'
 DIAGNOSIS_SCHEMA = REPO_ROOT / 'docs' / 'schemas' / 'diagnosis-v1.schema.json'
 RUN_MANIFEST_SCHEMA = REPO_ROOT / 'docs' / 'schemas' / 'run-manifest-v1.schema.json'
+RUN_MANIFEST_V2_SCHEMA = (
+    REPO_ROOT / 'docs' / 'schemas' / 'run-manifest-v2.schema.json'
+)
 V09_ROADMAP_DOC = REPO_ROOT / 'docs' / 'roadmap' / 'v0.9.md'
 SOCIAL_POST_DOC = REPO_ROOT / 'docs' / 'social' / 'autoware_map_authoring_post_v0.2.2.md'
 ISSUE_TEMPLATE_DIR = REPO_ROOT / '.github' / 'ISSUE_TEMPLATE'
@@ -120,6 +123,7 @@ def test_docs_exist_and_are_linked_from_readme():
     assert PREFLIGHT_SCHEMA.is_file()
     assert DIAGNOSIS_SCHEMA.is_file()
     assert RUN_MANIFEST_SCHEMA.is_file()
+    assert RUN_MANIFEST_V2_SCHEMA.is_file()
     assert V09_ROADMAP_DOC.is_file()
     assert SOCIAL_POST_DOC.is_file()
     assert DOCS_SITE_WORKFLOW.is_file()
@@ -273,6 +277,9 @@ def test_product_contract_has_bounded_official_surface():
     assert 'preflight-v1.schema.json' in golden_path
     assert 'diagnosis-v1.schema.json' in golden_path
     assert 'run-manifest-v1.schema.json' in golden_path
+    assert 'run-manifest-v2.schema.json' in golden_path
+    assert '--resume' in golden_path
+    assert 'Resume never starts the SLAM workflow again.' in golden_path
     assert 'existing outputs are never overwritten' in (
         REPO_ROOT / 'scripts' / 'run_autoware_map_from_bag.py'
     ).read_text(encoding='utf-8')

--- a/lidarslam/test/test_autoware_map_runner_script.py
+++ b/lidarslam/test/test_autoware_map_runner_script.py
@@ -99,6 +99,7 @@ def test_runner_script_supports_profiles_and_viewers():
     assert 'run_graph_slam_pointcloud_map_in_autoware_foxglove.sh' in script
     assert 'run_graph_slam_pointcloud_map_in_autoware.sh' in script
     assert '--dry-run' in script
+    assert '--resume' in script
     assert 'run_manifest.json' in script
     assert 'artifact_checksums' in script
 
@@ -117,6 +118,7 @@ def test_runner_help_is_user_facing():
     assert 'Workflow profiles:' in result.stdout
     assert 'Expected successful outputs:' in result.stdout
     assert '--output-dir <dir>' in result.stdout
+    assert '--resume' in result.stdout
 
 
 def test_runner_rejects_db3_file_without_traceback(tmp_path: Path):
@@ -196,12 +198,19 @@ def test_manifest_helpers_capture_identity_and_finalize_atomically(tmp_path: Pat
     saved = json.loads((final_dir / 'run_manifest.json').read_text(encoding='utf-8'))
     schema = json.loads(
         (
-            REPO_ROOT / 'docs' / 'schemas' / 'run-manifest-v1.schema.json'
+            REPO_ROOT / 'docs' / 'schemas' / 'run-manifest-v2.schema.json'
         ).read_text(encoding='utf-8')
     )
     jsonschema.Draft7Validator.check_schema(schema)
     jsonschema.validate(saved, schema)
-    assert saved['schema_version'] == 1
+    assert saved['schema_version'] == 2
+    assert saved['lifecycle'] == {
+        'last_error': None,
+        'resume_count': 0,
+        'runner_exit_code': None,
+        'stage': 'initialized',
+        'verification_enabled': True,
+    }
     assert saved['input']['metadata_sha256'] == module._sha256(
         bag_dir / 'metadata.yaml'
     )
@@ -238,6 +247,16 @@ def test_manifest_rejects_storage_path_outside_bag(tmp_path: Path):
 
     with pytest.raises(ValueError, match='outside the bag'):
         module._bag_identity(bag_dir)
+
+
+def test_postprocessing_lock_rejects_concurrent_owner(tmp_path: Path):
+    module = _load_module()
+    output_dir = tmp_path / 'map_output'
+
+    with module._postprocess_lock(output_dir):
+        with pytest.raises(RuntimeError, match='post-processing is already active'):
+            with module._postprocess_lock(output_dir):
+                pytest.fail('a second post-processing owner acquired the lock')
 
 
 def test_main_writes_success_manifest_and_rejects_collision(
@@ -302,8 +321,16 @@ def test_main_writes_success_manifest_and_rejects_collision(
     manifest = json.loads(
         (output_dir / 'run_manifest.json').read_text(encoding='utf-8')
     )
+    schema = json.loads(
+        (
+            REPO_ROOT / 'docs' / 'schemas' / 'run-manifest-v2.schema.json'
+        ).read_text(encoding='utf-8')
+    )
+    jsonschema.validate(manifest, schema)
     assert manifest['status'] == 'succeeded'
     assert manifest['execution']['exit_code'] == 0
+    assert manifest['lifecycle']['stage'] == 'complete'
+    assert manifest['lifecycle']['runner_exit_code'] == 0
     assert manifest['output']['finalized'] is True
     assert manifest['output']['diagnosis_status'] == 'success'
     assert any(
@@ -376,6 +403,8 @@ def test_main_retains_terminal_manifest_for_failed_and_interrupted_runs(
     )
     assert manifest['status'] == expected_status
     assert manifest['execution']['exit_code'] == expected_exit_code
+    assert manifest['lifecycle']['stage'] == 'complete'
+    assert manifest['lifecycle']['runner_exit_code'] == expected_exit_code
     assert manifest['output']['finalized'] is True
     assert not output_dir.with_name('failed_map.partial').exists()
 
@@ -425,8 +454,262 @@ def test_main_preserves_failed_manifest_when_post_finalize_diagnosis_fails(
         (output_dir / 'run_manifest.json').read_text(encoding='utf-8')
     )
     assert manifest['status'] == 'failed'
-    assert manifest['execution']['exit_code'] == 70
+    assert manifest['execution']['exit_code'] == 0
+    assert manifest['lifecycle']['runner_exit_code'] == 70
+    assert manifest['lifecycle']['last_error'] == 'diagnosis fixture failure'
     assert manifest['output']['finalized'] is True
+
+
+@pytest.mark.parametrize(
+    ('resume_from_final', 'stage'),
+    [
+        (False, 'workflow_finished'),
+        (True, 'finalizing'),
+    ],
+)
+def test_main_resumes_only_terminal_postprocessing_without_rerunning_workflow(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    resume_from_final: bool,
+    stage: str,
+):
+    module = _load_module()
+    bag_dir = _write_metadata(
+        tmp_path,
+        'demo_bag',
+        [
+            ('/points', 'sensor_msgs/msg/PointCloud2', 20),
+            ('/imu', 'sensor_msgs/msg/Imu', 180),
+        ],
+    )
+    output_dir = tmp_path / 'map_output'
+    working_dir = tmp_path / 'map_output.partial'
+    plan = {
+        'payload': {},
+        'profile_id': 'rko_lio_graph_public_path',
+        'label': 'RKO-LIO + graph_based_slam public path',
+        'command': ['map-workflow', '--output-dir', str(working_dir)],
+        'output_dir': working_dir,
+    }
+    software = {
+        'product_version': '0.6.0',
+        'git_commit': '0' * 40,
+        'git_dirty': False,
+        'package_versions': {'lidarslam': '0.6.0'},
+        'ros_distro': 'jazzy',
+    }
+    monkeypatch.setattr(module, 'build_execution_plan', lambda **kwargs: plan)
+    monkeypatch.setattr(module, '_software_identity', lambda: software)
+
+    manifest = module._build_manifest(bag_dir, output_dir, working_dir, plan)
+    manifest['status'] = 'succeeded'
+    manifest['execution'].update({
+        'started_at': '2026-07-27T00:00:00Z',
+        'finished_at': '2026-07-27T00:01:00Z',
+        'exit_code': 0,
+    })
+    manifest['lifecycle']['stage'] = stage
+    run_dir = output_dir if resume_from_final else working_dir
+    run_dir.mkdir()
+    (run_dir / 'pointcloud_map').mkdir()
+    (run_dir / 'pointcloud_map' / 'pointcloud_map_metadata.yaml').write_text(
+        'tiles: []\n',
+        encoding='utf-8',
+    )
+    (run_dir / 'map_projector_info.yaml').write_text(
+        'projector_type: Local\n',
+        encoding='utf-8',
+    )
+    module._write_manifest(run_dir, manifest)
+
+    def fake_verify(current_dir: Path, enabled: bool):
+        assert enabled is True
+        (current_dir / 'verify_autoware_map.log').write_text(
+            'RESULT: PASS\n',
+            encoding='utf-8',
+        )
+
+    def fake_diagnosis(current_dir: Path, current_bag: Path):
+        assert current_bag == bag_dir
+        (current_dir / 'autoware_map_diagnosis.md').write_text(
+            '# success\n',
+            encoding='utf-8',
+        )
+        (current_dir / 'autoware_map_diagnosis.json').write_text(
+            '{"status":"success"}\n',
+            encoding='utf-8',
+        )
+        return {'status': 'success'}
+
+    def fail_if_workflow_runs(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError('resume must not execute the map workflow')
+
+    monkeypatch.setattr(module, 'maybe_verify_map', fake_verify)
+    monkeypatch.setattr(module, 'write_diagnostics', fake_diagnosis)
+    monkeypatch.setattr(module.subprocess, 'run', fail_if_workflow_runs)
+    monkeypatch.setattr(
+        module.sys,
+        'argv',
+        [
+            str(SCRIPT_PATH),
+            str(bag_dir),
+            '--output-dir',
+            str(output_dir),
+            '--resume',
+        ],
+    )
+
+    assert module.main() == 0
+    assert output_dir.is_dir()
+    assert not working_dir.exists()
+    saved = json.loads(
+        (output_dir / 'run_manifest.json').read_text(encoding='utf-8')
+    )
+    assert saved['status'] == 'succeeded'
+    assert saved['execution']['exit_code'] == 0
+    assert saved['lifecycle'] == {
+        'last_error': None,
+        'resume_count': 1,
+        'runner_exit_code': 0,
+        'stage': 'complete',
+        'verification_enabled': True,
+    }
+    assert saved['output']['finalized'] is True
+
+
+@pytest.mark.parametrize(
+    ('schema_version', 'stage', 'expected_error'),
+    [
+        (2, 'workflow_running', 'workflow may still be running'),
+        (1, 'workflow_finished', 'resume requires run manifest schema v2'),
+    ],
+)
+def test_main_refuses_unsafe_or_legacy_resume_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+    schema_version: int,
+    stage: str,
+    expected_error: str,
+):
+    module = _load_module()
+    bag_dir = _write_metadata(
+        tmp_path,
+        'demo_bag',
+        [
+            ('/points', 'sensor_msgs/msg/PointCloud2', 20),
+            ('/imu', 'sensor_msgs/msg/Imu', 180),
+        ],
+    )
+    output_dir = tmp_path / 'map_output'
+    working_dir = tmp_path / 'map_output.partial'
+    plan = {
+        'payload': {},
+        'profile_id': 'rko_lio_graph_public_path',
+        'label': 'RKO-LIO + graph_based_slam public path',
+        'command': ['map-workflow'],
+        'output_dir': working_dir,
+    }
+    monkeypatch.setattr(module, 'build_execution_plan', lambda **kwargs: plan)
+    monkeypatch.setattr(module, '_software_identity', lambda: {
+        'product_version': '0.6.0',
+        'git_commit': '0' * 40,
+        'git_dirty': False,
+        'package_versions': {'lidarslam': '0.6.0'},
+        'ros_distro': 'jazzy',
+    })
+    manifest = module._build_manifest(bag_dir, output_dir, working_dir, plan)
+    manifest['schema_version'] = schema_version
+    manifest['lifecycle']['stage'] = stage
+    manifest['status'] = 'running' if stage == 'workflow_running' else 'succeeded'
+    manifest['execution'].update({
+        'started_at': '2026-07-27T00:00:00Z',
+        'finished_at': (
+            None if stage == 'workflow_running' else '2026-07-27T00:01:00Z'
+        ),
+        'exit_code': None if stage == 'workflow_running' else 0,
+    })
+    working_dir.mkdir()
+    module._write_manifest(working_dir, manifest)
+    original_manifest = (working_dir / 'run_manifest.json').read_text(encoding='utf-8')
+    monkeypatch.setattr(
+        module.sys,
+        'argv',
+        [
+            str(SCRIPT_PATH),
+            str(bag_dir),
+            '--output-dir',
+            str(output_dir),
+            '--resume',
+        ],
+    )
+
+    assert module.main() == 2
+    assert expected_error in capsys.readouterr().err
+    assert (working_dir / 'run_manifest.json').read_text(
+        encoding='utf-8'
+    ) == original_manifest
+
+
+def test_main_refuses_resume_when_bag_identity_changed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+):
+    module = _load_module()
+    bag_dir = _write_metadata(
+        tmp_path,
+        'demo_bag',
+        [
+            ('/points', 'sensor_msgs/msg/PointCloud2', 20),
+            ('/imu', 'sensor_msgs/msg/Imu', 180),
+        ],
+    )
+    output_dir = tmp_path / 'map_output'
+    working_dir = tmp_path / 'map_output.partial'
+    plan = {
+        'payload': {},
+        'profile_id': 'rko_lio_graph_public_path',
+        'label': 'RKO-LIO + graph_based_slam public path',
+        'command': ['map-workflow'],
+        'output_dir': working_dir,
+    }
+    monkeypatch.setattr(module, 'build_execution_plan', lambda **kwargs: plan)
+    monkeypatch.setattr(module, '_software_identity', lambda: {
+        'product_version': '0.6.0',
+        'git_commit': '0' * 40,
+        'git_dirty': False,
+        'package_versions': {'lidarslam': '0.6.0'},
+        'ros_distro': 'jazzy',
+    })
+    manifest = module._build_manifest(bag_dir, output_dir, working_dir, plan)
+    manifest['status'] = 'succeeded'
+    manifest['execution'].update({
+        'started_at': '2026-07-27T00:00:00Z',
+        'finished_at': '2026-07-27T00:01:00Z',
+        'exit_code': 0,
+    })
+    manifest['lifecycle']['stage'] = 'workflow_finished'
+    working_dir.mkdir()
+    module._write_manifest(working_dir, manifest)
+    (bag_dir / 'demo_bag_0.db3').write_bytes(b'changed bag fixture\n')
+    monkeypatch.setattr(
+        module.sys,
+        'argv',
+        [
+            str(SCRIPT_PATH),
+            str(bag_dir),
+            '--output-dir',
+            str(output_dir),
+            '--resume',
+        ],
+    )
+
+    assert module.main() == 2
+    assert 'resume input identity mismatch' in capsys.readouterr().err
+    assert working_dir.is_dir()
+    assert not output_dir.exists()
 
 
 def test_runner_rejects_incompatible_profile_with_available_hint(tmp_path: Path):
@@ -479,6 +762,7 @@ def test_beginner_wrapper_exposes_simple_viewer_flags():
     assert '--autoware' in script
     assert '--no-viewer' in script
     assert '--dry-run' in script
+    assert '--resume' in script
     assert '--preflight-only' in script
     assert 'metadata.yaml not found' in script
     assert 'not a .db3 file' in script
@@ -498,6 +782,7 @@ def test_beginner_wrapper_help_is_user_facing():
     assert 'Expected successful outputs:' in result.stderr
     assert '--output-dir <dir>' in result.stderr
     assert '--viewer-rebuild' in result.stderr
+    assert '--resume' in result.stderr
 
 
 def test_beginner_wrapper_rejects_missing_option_value_before_bag_validation(

--- a/scripts/run_autoware_map_beginner.sh
+++ b/scripts/run_autoware_map_beginner.sh
@@ -18,6 +18,7 @@ Options:
   --autoware                    Open the saved map in the Dockerized Autoware viewer after the run
   --no-viewer                   Do not open a viewer after the run (default)
   --dry-run                     Print the selected command without executing it
+  --resume                      Resume terminal post-processing; never rerun SLAM
   --help                        Show this help
 
 Common forwarded options:
@@ -35,12 +36,14 @@ Expected successful outputs:
   map_projector_info.yaml
   verify_autoware_map.log
   autoware_map_diagnosis.md
+  run_manifest.json
 
 Examples:
   bash scripts/run_autoware_map_beginner.sh /path/to/rosbag2
   bash scripts/run_autoware_map_beginner.sh /path/to/rosbag2 --preflight-only
   bash scripts/run_autoware_map_beginner.sh /path/to/rosbag2 --foxglove
   bash scripts/run_autoware_map_beginner.sh /path/to/rosbag2 --output-dir output/my_map
+  bash scripts/run_autoware_map_beginner.sh /path/to/rosbag2 --output-dir output/my_map --resume
 EOF
   exit "$exit_code"
 }
@@ -110,7 +113,7 @@ while [[ $# -gt 0 ]]; do
     --help|-h)
       usage 0
       ;;
-    --dry-run|--no-verify-map|--viewer-rebuild)
+    --dry-run|--resume|--no-verify-map|--viewer-rebuild)
       FORWARDED_ARGS+=("$1")
       shift
       ;;

--- a/scripts/run_autoware_map_from_bag.py
+++ b/scripts/run_autoware_map_from_bag.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import argparse
+from contextlib import contextmanager
 from datetime import datetime, timezone
+import fcntl
 import hashlib
 import importlib.util
 import json
@@ -21,10 +23,10 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 MANIFEST_NAME = 'run_manifest.json'
-MANIFEST_SCHEMA_VERSION = 1
+MANIFEST_SCHEMA_VERSION = 2
 MANIFEST_SCHEMA_URI = (
     'https://rsasaki0109.github.io/lidar_slam_ros2/'
-    'schemas/run-manifest-v1.schema.json'
+    'schemas/run-manifest-v2.schema.json'
 )
 PROFILE_CHOICES = (
     'rko_lio_graph_public_path',
@@ -298,6 +300,17 @@ def _package_versions() -> dict[str, str]:
     return dict(sorted(versions.items()))
 
 
+def _software_identity() -> dict[str, object]:
+    git_state = _git_state()
+    return {
+        'product_version': _product_version(),
+        'git_commit': git_state['commit'],
+        'git_dirty': git_state['dirty'],
+        'package_versions': _package_versions(),
+        'ros_distro': os.environ.get('ROS_DISTRO'),
+    }
+
+
 def _bag_identity(bag_path: Path) -> dict[str, object]:
     metadata_path = bag_path / 'metadata.yaml'
     metadata_before = metadata_path.stat()
@@ -312,6 +325,12 @@ def _bag_identity(bag_path: Path) -> dict[str, object]:
     metadata = yaml.safe_load(metadata_bytes) or {}
     bag_info = metadata.get('rosbag2_bagfile_information') or {}
     relative_paths = bag_info.get('relative_file_paths') or []
+    if not isinstance(relative_paths, list) or not all(
+        isinstance(path, str) for path in relative_paths
+    ):
+        raise ValueError(
+            'rosbag2 metadata relative_file_paths must be a list of strings'
+        )
     if not relative_paths:
         relative_paths = [
             path.relative_to(bag_path).as_posix()
@@ -377,21 +396,22 @@ def _build_manifest(
     final_output_dir: Path,
     working_output_dir: Path,
     plan: dict[str, object],
+    verify_map: bool = True,
 ) -> dict[str, object]:
-    git_state = _git_state()
     return {
         'schema_version': MANIFEST_SCHEMA_VERSION,
         'schema_uri': MANIFEST_SCHEMA_URI,
         'run_id': str(uuid.uuid4()),
         'status': 'planned',
-        'input': _bag_identity(bag_path),
-        'software': {
-            'product_version': _product_version(),
-            'git_commit': git_state['commit'],
-            'git_dirty': git_state['dirty'],
-            'package_versions': _package_versions(),
-            'ros_distro': os.environ.get('ROS_DISTRO'),
+        'lifecycle': {
+            'stage': 'initialized',
+            'resume_count': 0,
+            'verification_enabled': verify_map,
+            'runner_exit_code': None,
+            'last_error': None,
         },
+        'input': _bag_identity(bag_path),
+        'software': _software_identity(),
         'profile': {
             'id': plan['profile_id'],
             'label': plan['label'],
@@ -410,6 +430,127 @@ def _build_manifest(
             'artifact_checksums': [],
         },
     }
+
+
+def _load_manifest(run_dir: Path) -> dict[str, object]:
+    manifest_path = run_dir / MANIFEST_NAME
+    if not manifest_path.is_file():
+        raise ValueError(f'run manifest not found: {manifest_path}')
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding='utf-8'))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f'run manifest is not readable JSON: {manifest_path}: {exc}') from exc
+    if not isinstance(manifest, dict):
+        raise ValueError(f'run manifest root must be an object: {manifest_path}')
+    return manifest
+
+
+def _validate_resume_state(
+    bag_path: Path,
+    final_output_dir: Path,
+    working_output_dir: Path,
+    plan: dict[str, object],
+    verify_map: bool,
+) -> tuple[Path, dict[str, object]]:
+    existing_dirs = [
+        path for path in (working_output_dir, final_output_dir) if path.exists()
+    ]
+    if len(existing_dirs) != 1:
+        if not existing_dirs:
+            raise ValueError(
+                'no resumable output found. Expected exactly one of '
+                f'{working_output_dir} or {final_output_dir}'
+            )
+        raise ValueError(
+            'ambiguous resume state: both the partial and final output exist: '
+            f'{working_output_dir}, {final_output_dir}'
+        )
+
+    run_dir = existing_dirs[0]
+    if not run_dir.is_dir():
+        raise ValueError(f'resume output path is not a directory: {run_dir}')
+    manifest = _load_manifest(run_dir)
+    if manifest.get('schema_version') != MANIFEST_SCHEMA_VERSION:
+        raise ValueError(
+            'resume requires run manifest schema v2; older manifests remain '
+            'inspectable but cannot be resumed safely'
+        )
+    if manifest.get('schema_uri') != MANIFEST_SCHEMA_URI:
+        raise ValueError('resume manifest schema_uri does not match schema v2')
+
+    lifecycle = manifest.get('lifecycle')
+    execution = manifest.get('execution')
+    output = manifest.get('output')
+    if not all(isinstance(item, dict) for item in (lifecycle, execution, output)):
+        raise ValueError('resume manifest is missing lifecycle, execution, or output state')
+
+    stage = lifecycle.get('stage')
+    valid_stages = {
+        'initialized',
+        'workflow_running',
+        'workflow_finished',
+        'verifying',
+        'verified',
+        'finalizing',
+        'finalized',
+        'diagnosing',
+        'diagnosed',
+        'checksumming',
+        'complete',
+    }
+    if stage not in valid_stages:
+        raise ValueError(f'resume manifest has an unknown lifecycle stage: {stage!r}')
+    if stage in ('initialized', 'workflow_running'):
+        raise ValueError(
+            f'refusing resume from lifecycle stage {stage!r}: the workflow may '
+            'still be running, so starting post-processing could corrupt evidence'
+        )
+    if stage == 'complete':
+        raise ValueError(
+            'run is already complete; use `./scripts/lidarslam inspect '
+            f'{final_output_dir}` instead'
+        )
+    if execution.get('finished_at') is None or execution.get('exit_code') is None:
+        raise ValueError('resume requires a durably recorded terminal workflow result')
+    if lifecycle.get('verification_enabled') is not verify_map:
+        raise ValueError(
+            'resume verification option mismatch; use the same --no-verify-map '
+            'setting as the original run'
+        )
+
+    expected_values = (
+        ('input identity', manifest.get('input'), _bag_identity(bag_path)),
+        ('software identity', manifest.get('software'), _software_identity()),
+        (
+            'profile',
+            manifest.get('profile'),
+            {'id': plan['profile_id'], 'label': plan['label']},
+        ),
+        ('execution argv', execution.get('argv'), plan['command']),
+        ('requested output', output.get('requested_dir'), str(final_output_dir)),
+        ('working output', output.get('working_dir'), str(working_output_dir)),
+    )
+    for label, actual, expected in expected_values:
+        if actual != expected:
+            raise ValueError(
+                f'resume {label} mismatch; use the original bag, software, '
+                'profile, options, and output path'
+            )
+
+    if run_dir == working_output_dir and output.get('finalized') is True:
+        raise ValueError('partial output claims it was already finalized')
+
+    resume_count = lifecycle.get('resume_count')
+    if not isinstance(resume_count, int) or isinstance(resume_count, bool):
+        raise ValueError('resume manifest lifecycle.resume_count must be an integer')
+    lifecycle['resume_count'] = resume_count + 1
+    lifecycle['last_error'] = None
+    workflow_exit_code = execution['exit_code']
+    if manifest.get('status') == 'interrupted' and workflow_exit_code == 130:
+        manifest['status'] = 'interrupted'
+    else:
+        manifest['status'] = 'succeeded' if workflow_exit_code == 0 else 'failed'
+    return run_dir, manifest
 
 
 def _finalize_output(working_dir: Path, final_dir: Path) -> None:
@@ -516,6 +657,130 @@ def write_diagnostics(output_dir: Path, bag_path: Path) -> dict[str, object]:
     return summary
 
 
+@contextmanager
+def _postprocess_lock(output_dir: Path):
+    lock_path = output_dir.with_name(f'.{output_dir.name}.postprocess.lock')
+    try:
+        stream = lock_path.open('a+', encoding='utf-8')
+    except OSError as exc:
+        raise RuntimeError(f'cannot open post-processing lock {lock_path}: {exc}') from exc
+    try:
+        try:
+            fcntl.flock(stream.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            raise RuntimeError(
+                f'post-processing is already active for {output_dir}'
+            ) from exc
+        yield
+    finally:
+        stream.close()
+
+
+def _postprocess_run(
+    args: argparse.Namespace,
+    manifest: dict[str, object],
+    bag_path: Path,
+    working_dir: Path,
+    output_dir: Path,
+    run_dir: Path,
+) -> int:
+    lifecycle = manifest['lifecycle']
+    execution = manifest['execution']
+    workflow_exit_code = execution['exit_code']
+    current_dir = run_dir
+    try:
+        _write_manifest(current_dir, manifest)
+        lifecycle['stage'] = 'verifying'
+        _write_manifest(current_dir, manifest)
+        maybe_verify_map(current_dir, enabled=not args.no_verify_map)
+        lifecycle['stage'] = 'verified'
+        _write_manifest(current_dir, manifest)
+
+        if current_dir == working_dir:
+            lifecycle['stage'] = 'finalizing'
+            _write_manifest(current_dir, manifest)
+            _finalize_output(working_dir, output_dir)
+            current_dir = output_dir
+        elif current_dir != output_dir:
+            raise RuntimeError(f'unexpected resume directory: {current_dir}')
+
+        manifest['output']['finalized'] = True
+        lifecycle['stage'] = 'finalized'
+        _write_manifest(current_dir, manifest)
+
+        lifecycle['stage'] = 'diagnosing'
+        _write_manifest(current_dir, manifest)
+        diagnosis = write_diagnostics(current_dir, bag_path)
+        manifest['output']['diagnosis_status'] = diagnosis['status']
+        lifecycle['stage'] = 'diagnosed'
+        _write_manifest(current_dir, manifest)
+
+        interrupted = manifest['status'] == 'interrupted' and workflow_exit_code == 130
+        if interrupted:
+            runner_exit_code = 130
+        elif workflow_exit_code != 0:
+            runner_exit_code = workflow_exit_code
+            manifest['status'] = 'failed'
+        elif not args.no_verify_map and diagnosis['status'] != 'success':
+            runner_exit_code = 1
+            manifest['status'] = 'failed'
+        else:
+            runner_exit_code = 0
+            manifest['status'] = 'succeeded'
+
+        lifecycle['stage'] = 'checksumming'
+        _write_manifest(current_dir, manifest)
+        manifest['output']['artifact_checksums'] = _artifact_checksums(current_dir)
+        lifecycle['stage'] = 'complete'
+        lifecycle['runner_exit_code'] = runner_exit_code
+        lifecycle['last_error'] = None
+        _write_manifest(current_dir, manifest)
+        return runner_exit_code
+    except (OSError, RuntimeError, ValueError, KeyError, TypeError) as exc:
+        print(f'error: failed to finalize output: {exc}', file=sys.stderr)
+        manifest_dir = output_dir if output_dir.exists() else working_dir
+        if manifest_dir.exists():
+            if manifest.get('status') not in ('failed', 'interrupted'):
+                manifest['status'] = 'failed'
+            manifest['output']['finalized'] = output_dir.exists()
+            lifecycle['runner_exit_code'] = 70
+            lifecycle['last_error'] = str(exc)
+            try:
+                manifest['output']['artifact_checksums'] = _artifact_checksums(
+                    manifest_dir
+                )
+                _write_manifest(manifest_dir, manifest)
+            except (OSError, RuntimeError) as manifest_exc:
+                print(
+                    f'warning: failed to preserve terminal manifest: {manifest_exc}',
+                    file=sys.stderr,
+                )
+        return 70
+
+
+def _postprocess_with_lock(
+    args: argparse.Namespace,
+    manifest: dict[str, object],
+    bag_path: Path,
+    working_dir: Path,
+    output_dir: Path,
+    run_dir: Path,
+) -> int:
+    try:
+        with _postprocess_lock(output_dir):
+            return _postprocess_run(
+                args,
+                manifest,
+                bag_path,
+                working_dir,
+                output_dir,
+                run_dir,
+            )
+    except RuntimeError as exc:
+        print(f'error: {exc}', file=sys.stderr)
+        return 70
+
+
 def _profile_help_text() -> str:
     lines = ['Workflow profiles:']
     for profile_id, description in PROFILE_HELP:
@@ -535,12 +800,17 @@ def _help_epilog() -> str:
         '  map_projector_info.yaml',
         '  verify_autoware_map.log',
         '  autoware_map_diagnosis.md',
+        '  run_manifest.json',
         '',
         'Examples:',
         '  python3 scripts/run_autoware_map_from_bag.py /path/to/rosbag2 --dry-run',
         (
             '  python3 scripts/run_autoware_map_from_bag.py /path/to/rosbag2 '
             '--output-dir output/my_map'
+        ),
+        (
+            '  python3 scripts/run_autoware_map_from_bag.py /path/to/rosbag2 '
+            '--output-dir output/my_map --resume'
         ),
         '  python3 scripts/run_autoware_map_from_bag.py /path/to/rosbag2 --viewer foxglove',
     ])
@@ -609,11 +879,26 @@ def parse_args() -> argparse.Namespace:
         action='store_true',
         help='Print the selected command without executing it.',
     )
+    parser.add_argument(
+        '--resume',
+        action='store_true',
+        help=(
+            'Resume verification, finalization, diagnosis, and checksums for a '
+            'terminal schema-v2 run; the map workflow is never re-executed.'
+        ),
+    )
     return parser.parse_args()
 
 
 def main() -> int:
     args = parse_args()
+    if args.resume and args.dry_run:
+        print('error: --resume cannot be combined with --dry-run', file=sys.stderr)
+        return 2
+    if args.resume and not args.output_dir:
+        print('error: --resume requires an explicit --output-dir', file=sys.stderr)
+        return 2
+
     bag_path = Path(args.bag).expanduser().resolve()
     timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
     output_dir = Path(args.output_dir).expanduser().resolve() if args.output_dir else (
@@ -622,8 +907,9 @@ def main() -> int:
     working_dir = output_dir.with_name(f'{output_dir.name}.partial')
     try:
         validate_bag_path(bag_path)
-        validate_output_dir(output_dir)
-        validate_output_dir(working_dir)
+        if not args.resume:
+            validate_output_dir(output_dir)
+            validate_output_dir(working_dir)
         plan = build_execution_plan(
             bag_path=bag_path,
             profile_id=args.profile,
@@ -642,11 +928,44 @@ def main() -> int:
 
     if args.dry_run:
         return 0
+    if args.resume:
+        try:
+            with _postprocess_lock(output_dir):
+                run_dir, manifest = _validate_resume_state(
+                    bag_path,
+                    output_dir,
+                    working_dir,
+                    plan,
+                    not args.no_verify_map,
+                )
+                print(f'Resuming terminal post-processing from: {run_dir}')
+                exit_code = _postprocess_run(
+                    args,
+                    manifest,
+                    bag_path,
+                    working_dir,
+                    output_dir,
+                    run_dir,
+                )
+        except ValueError as exc:
+            print(f'error: {exc}', file=sys.stderr)
+            return 2
+        except RuntimeError as exc:
+            print(f'error: {exc}', file=sys.stderr)
+            return 70
+        return _finish_run(args, plan, output_dir, exit_code)
 
     try:
-        manifest = _build_manifest(bag_path, output_dir, working_dir, plan)
+        manifest = _build_manifest(
+            bag_path,
+            output_dir,
+            working_dir,
+            plan,
+            verify_map=not args.no_verify_map,
+        )
         working_dir.mkdir(parents=True, exist_ok=False)
         manifest['status'] = 'running'
+        manifest['lifecycle']['stage'] = 'workflow_running'
         manifest['execution']['started_at'] = _utc_now()
         _write_manifest(working_dir, manifest)
     except (OSError, RuntimeError, ValueError, ET.ParseError, yaml.YAMLError) as exc:
@@ -673,47 +992,27 @@ def main() -> int:
     manifest['status'] = (
         'interrupted' if interrupted else ('succeeded' if exit_code == 0 else 'failed')
     )
+    manifest['lifecycle']['stage'] = 'workflow_finished'
+    exit_code = _postprocess_with_lock(
+        args,
+        manifest,
+        bag_path,
+        working_dir,
+        output_dir,
+        working_dir,
+    )
+    return _finish_run(args, plan, output_dir, exit_code)
 
-    try:
-        _write_manifest(working_dir, manifest)
-        maybe_verify_map(working_dir, enabled=not args.no_verify_map)
-        _finalize_output(working_dir, output_dir)
-        manifest['output']['finalized'] = True
-        diagnosis = write_diagnostics(output_dir, bag_path)
-        manifest['output']['diagnosis_status'] = diagnosis['status']
-        if (
-            manifest['status'] == 'succeeded'
-            and not args.no_verify_map
-            and diagnosis['status'] != 'success'
-        ):
-            manifest['status'] = 'failed'
-            if exit_code == 0:
-                exit_code = 1
-                manifest['execution']['exit_code'] = exit_code
-        manifest['output']['artifact_checksums'] = _artifact_checksums(output_dir)
-        _write_manifest(output_dir, manifest)
-    except (OSError, RuntimeError, ValueError) as exc:
-        print(f'error: failed to finalize output: {exc}', file=sys.stderr)
-        manifest_dir = output_dir if output_dir.exists() else working_dir
-        if manifest_dir.exists():
-            manifest['status'] = 'failed'
-            manifest['execution']['exit_code'] = 70
-            manifest['output']['finalized'] = output_dir.exists()
-            try:
-                manifest['output']['artifact_checksums'] = _artifact_checksums(
-                    manifest_dir
-                )
-                _write_manifest(manifest_dir, manifest)
-            except (OSError, RuntimeError) as manifest_exc:
-                print(
-                    f'warning: failed to preserve terminal manifest: {manifest_exc}',
-                    file=sys.stderr,
-                )
-        return 70
 
+def _finish_run(
+    args: argparse.Namespace,
+    plan: dict[str, object],
+    output_dir: Path,
+    exit_code: int,
+) -> int:
     if exit_code != 0:
         print(
-            f'error: map workflow failed with exit code {exit_code}.',
+            f'error: map run failed with exit code {exit_code}.',
             file=sys.stderr,
         )
         print('failed command:', shlex.join(plan['command']), file=sys.stderr)


### PR DESCRIPTION
## Changes
- publish run manifest schema v2 with durable lifecycle, verification mode, resume count, separate workflow/runner exit codes, and recoverable errors
- add `lidarslam run --resume` for terminal-only verification, atomic finalization, diagnosis, and checksum recovery
- revalidate bag hashes, software/ROS/package identity, profile, argv, options, and output paths before recovery
- refuse active, ambiguous, legacy, completed, or identity-mismatched states and serialize post-processing with an advisory lock
- document the recovery contract and add regression coverage for partial/final recovery and unsafe-state rejection

## Why
A terminated map-authoring run could preserve evidence but required manual recovery. This makes post-workflow recovery deterministic without risking a second SLAM execution or silently changing the original run contract.

## Compatibility / impact
- new runs emit run manifest v2; v1 remains published and inspectable but is intentionally not resumable
- `execution.exit_code` now remains the workflow result while `lifecycle.runner_exit_code` records verification/post-processing failures
- existing outputs remain immutable except for explicit recovery of an incomplete schema-v2 lifecycle

## Checks
- `bash scripts/run_default_ci_checks.sh` (2557 tests, 0 errors, 0 failures, 125 skipped)
- focused runner/docs tests (30 passed)
- Draft 7 schema validation
- `python3 -m mkdocs build --strict`
- Python/shell syntax and `git diff --check`