### PR TITLE
Verify PointCloud2 fields before RKO recommendation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Smoke-test MID-360 robot runbook
         shell: bash
         run: |
-          python3 -m pip install --upgrade pyyaml
+          python3 -m pip install --upgrade pyyaml rosbags
           bash scripts/smoke_mid360_robot_runbook.sh
 
   default-workflow:

--- a/docs/golden-path-cli.md
+++ b/docs/golden-path-cli.md
@@ -25,7 +25,12 @@ verification behavior remain authoritative.
 ## Commands
 
 `doctor` checks rosbag2 metadata, reports detected topic capabilities, and
-selects a compatible maintained profile. Add `--json` for automation.
+selects a compatible maintained profile. For RKO-LIO profiles it also reads
+the first selected `PointCloud2` record and requires FLOAT32 XYZ fields plus a
+supported per-point timestamp field (`t`, `timestamp`, `time`, or `stamps`).
+If the record cannot be inspected or does not satisfy that layout, no RKO-LIO
+profile is recommended. Add `--json` for automation. This field-layout check
+does not certify timestamp units, monotonicity, calibration, or TF.
 
 `run` prints the selected profile and deterministic command before execution.
 Use `--dry-run` to inspect the plan without creating the output directory.
@@ -96,6 +101,8 @@ JSON diagnosis artifacts in the output directory.
 Automation should select the schema using `schema_version` and `schema_uri`;
 it must not infer compatibility from the repository version.
 
+- [Preflight schema v2](schemas/preflight-v2.schema.json) — current; adds
+  record-level PointCloud2 field inspection
 - [Preflight schema v1](schemas/preflight-v1.schema.json)
 - [Diagnosis schema v1](schemas/diagnosis-v1.schema.json)
 - [Run manifest schema v1](schemas/run-manifest-v1.schema.json)
@@ -106,8 +113,10 @@ Top-level fields are closed within a published schema. A field addition,
 removal, type change, or semantic break requires a new schema file and
 migration guidance.
 
-Run manifest v1 remains published for existing artifacts. It predates durable
-lifecycle stages, so it can be inspected but cannot be resumed safely.
+Preflight v1 and run manifest v1 remain published for existing artifacts.
+Preflight v1 only reports metadata-level topic compatibility. Run manifest v1
+predates durable lifecycle stages, so it can be inspected but cannot be
+resumed safely.
 
 Each subcommand accepts the same options as its delegated tool:
 

--- a/docs/operational-reliability.md
+++ b/docs/operational-reliability.md
@@ -9,7 +9,7 @@ only marked covered when an automated test exercises the public behavior.
 | Failure | Public behavior | Preserved state | Operator action | Coverage |
 | --- | --- | --- | --- | --- |
 | Missing or corrupt `metadata.yaml`, missing referenced storage file | Exit `2` before workflow launch | Existing output is untouched; a new output is not created | Correct or replace the bag, then rerun `lidarslam-map doctor` | Automated |
-| Incompatible topic/profile selection | Exit `2` with available profiles and missing requirements | Existing output is untouched | Choose a compatible profile or fix the input | Automated |
+| Incompatible topic/profile or PointCloud2 field layout | Exit `2` with available profiles and missing requirements before workflow launch; RKO-LIO requires FLOAT32 XYZ and a supported per-point timestamp field | Existing output is untouched | Choose a compatible profile or fix the input fields | Automated |
 | Final or `.partial` output collision | Exit `2`; no overwrite | Both existing paths remain immutable | Inspect the existing run or choose a new output name | Automated |
 | Output filesystem below the configured reserve | Exit `2` before workflow launch with required and observed GiB | Existing output is untouched; a new output is not created | Free storage, choose another output filesystem, or set a deliberately sized `--min-free-space-gib` budget | Automated |
 | Workflow exits non-zero | Propagate the workflow exit code | Final output, diagnosis, checksums, and schema-v2 manifest with `failed` status | Inspect the diagnosis and launch log; rerun into a new directory after fixing the cause | Automated |

--- a/docs/product-contract.md
+++ b/docs/product-contract.md
@@ -73,15 +73,18 @@ The general product path accepts a rosbag2 directory containing
 
 Topic presence is necessary but not sufficient. A bag with the right message
 types can still require a sensor-specific point-time field, calibration,
-frame override or parameter profile. The preflight report describes detected
-capabilities; it does not certify calibration.
+frame override or parameter profile. Before recommending RKO-LIO, the preflight
+reads the first record on the selected `PointCloud2` topic and verifies
+FLOAT32 `x`, `y`, and `z` plus a supported per-point timestamp field named
+`t`, `timestamp`, `time`, or `stamps`. It does not certify timestamp units,
+monotonicity, calibration, or TF connectivity.
 
 ## Support tiers
 
 | Tier | Scope | Evidence and expectation |
 | --- | --- | --- |
 | Validated | Tracked MID-360 Docker demo; NTU VIRAL Ouster/VN-100 quickstart | Fixed public input, parameters and expected artifacts; release documentation records measured accuracy |
-| Maintained-compatible | Generic `PointCloud2 + Imu` through the beginner wrapper on ROS 2 Humble and Jazzy | Built and tested in CI; the operator supplies correct calibration, frames and sensor parameters |
+| Maintained-compatible | Generic record-verified `PointCloud2 + Imu` through the beginner wrapper on ROS 2 Humble and Jazzy | Built and tested in CI; the operator supplies correct timestamp units, calibration, frames and sensor parameters |
 | Evaluation | GNSS/Applanix packet paths, radar degeneracy presets, HILTI, coloured maps and optional loop detectors | Reproducible research or benchmark evidence exists, but it is not a universal plug-and-play hardware guarantee |
 | Out of scope | Safety-certified localization, autonomous-driving validation, arbitrary proprietary bags, Windows native builds | No product support promise |
 

--- a/docs/schemas/preflight-v2.schema.json
+++ b/docs/schemas/preflight-v2.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://rsasaki0109.github.io/lidar_slam_ros2/schemas/preflight-v2.schema.json",
+  "title": "lidarslam_ros2 preflight v2",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "schema_uri",
+    "summary",
+    "recommendations",
+    "recommended_profile_id",
+    "beginner_commands",
+    "advisory",
+    "missing_requirements"
+  ],
+  "properties": {
+    "schema_version": {"const": 2},
+    "schema_uri": {
+      "const": "https://rsasaki0109.github.io/lidar_slam_ros2/schemas/preflight-v2.schema.json"
+    },
+    "summary": {
+      "type": "object",
+      "required": ["bag_path", "topics", "capabilities", "pointcloud_inspection"],
+      "properties": {
+        "pointcloud_inspection": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "status",
+            "topic",
+            "fields",
+            "rko_lio_compatible",
+            "timestamp_field",
+            "reason"
+          ],
+          "properties": {
+            "status": {
+              "enum": ["not_applicable", "unavailable", "error", "empty", "inspected"]
+            },
+            "topic": {"type": ["string", "null"]},
+            "fields": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["name", "datatype", "count"],
+                "properties": {
+                  "name": {"type": "string"},
+                  "datatype": {"type": "integer"},
+                  "count": {"type": "integer", "minimum": 0}
+                }
+              }
+            },
+            "rko_lio_compatible": {"type": ["boolean", "null"]},
+            "timestamp_field": {"type": ["string", "null"]},
+            "reason": {"type": "string", "minLength": 1}
+          }
+        }
+      }
+    },
+    "recommendations": {"type": "array", "items": {"type": "object"}},
+    "recommended_profile_id": {"type": ["string", "null"]},
+    "beginner_commands": {"type": "array", "items": {"type": "object"}},
+    "advisory": {"type": "array"},
+    "missing_requirements": {
+      "type": "array",
+      "items": {"type": "string"}
+    }
+  }
+}

--- a/graph_based_slam/test/test_autoware_map_preflight.py
+++ b/graph_based_slam/test/test_autoware_map_preflight.py
@@ -79,6 +79,22 @@ def _write_metadata(tmp_path: Path, topics: list[tuple[str, str, int]]) -> Path:
     return bag_dir
 
 
+def _compatible_inspection(_bag_path: Path, topic: str, _storage_id: str) -> dict:
+    return {
+        'status': 'inspected',
+        'topic': topic,
+        'fields': [
+            {'name': 'x', 'datatype': 7, 'count': 1},
+            {'name': 'y', 'datatype': 7, 'count': 1},
+            {'name': 'z', 'datatype': 7, 'count': 1},
+            {'name': 'time', 'datatype': 7, 'count': 1},
+        ],
+        'rko_lio_compatible': True,
+        'timestamp_field': 'time',
+        'reason': "RKO-LIO-compatible per-point timestamp field 'time' was found.",
+    }
+
+
 def test_rko_lio_public_path_is_preferred_for_pointcloud_and_imu(tmp_path: Path):
     module = _load_module()
     bag_dir = _write_metadata(
@@ -90,17 +106,21 @@ def test_rko_lio_public_path_is_preferred_for_pointcloud_and_imu(tmp_path: Path)
         ],
     )
 
-    payload = module.build_preflight_payload(bag_dir)
+    payload = module.build_preflight_payload(
+        bag_dir,
+        pointcloud_inspector=_compatible_inspection,
+    )
 
     schema = json.loads(
         (
-            REPO_ROOT / 'docs' / 'schemas' / 'preflight-v1.schema.json'
+            REPO_ROOT / 'docs' / 'schemas' / 'preflight-v2.schema.json'
         ).read_text(encoding='utf-8')
     )
     jsonschema.Draft7Validator.check_schema(schema)
     jsonschema.validate(payload, schema)
-    assert payload['schema_version'] == 1
-    assert payload['schema_uri'].endswith('/schemas/preflight-v1.schema.json')
+    assert payload['schema_version'] == 2
+    assert payload['schema_uri'].endswith('/schemas/preflight-v2.schema.json')
+    assert payload['summary']['pointcloud_inspection']['timestamp_field'] == 'time'
     assert payload['recommended_profile_id'] == 'rko_lio_graph_public_path'
     assert payload['beginner_commands'][0]['command'].startswith(
         'bash scripts/run_autoware_map_beginner.sh'
@@ -283,7 +303,10 @@ def test_livox_mid360_bag_emits_tuned_preset_hint(tmp_path: Path):
     }
     (bag_dir / 'metadata.yaml').write_text(yaml.safe_dump(metadata), encoding='utf-8')
 
-    payload = module.build_preflight_payload(bag_dir)
+    payload = module.build_preflight_payload(
+        bag_dir,
+        pointcloud_inspector=_compatible_inspection,
+    )
     recommendation_ids = [item['id'] for item in payload['recommendations']]
 
     assert payload['recommended_profile_id'] == 'rko_lio_graph_public_path'
@@ -294,3 +317,87 @@ def test_livox_mid360_bag_emits_tuned_preset_hint(tmp_path: Path):
     )
     assert 'lidarslam_mid360_rko_graph.yaml' in tuned['command']
     assert 'rko_lio_mid360.yaml' in tuned['command']
+
+
+def test_pointcloud_field_assessment_accepts_supported_timestamp():
+    module = _load_module()
+
+    assessment = module.assess_pointcloud_fields([
+        {'name': 'x', 'datatype': 7, 'count': 1},
+        {'name': 'y', 'datatype': 7, 'count': 1},
+        {'name': 'z', 'datatype': 7, 'count': 1},
+        {'name': 'timestamp', 'datatype': 8, 'count': 1},
+    ])
+
+    assert assessment['rko_lio_compatible'] is True
+    assert assessment['timestamp_field'] == 'timestamp'
+
+
+def test_pointcloud_field_assessment_rejects_missing_timestamp():
+    module = _load_module()
+
+    assessment = module.assess_pointcloud_fields([
+        {'name': 'x', 'datatype': 7, 'count': 1},
+        {'name': 'y', 'datatype': 7, 'count': 1},
+        {'name': 'z', 'datatype': 7, 'count': 1},
+        {'name': 'intensity', 'datatype': 7, 'count': 1},
+    ])
+
+    assert assessment['rko_lio_compatible'] is False
+    assert assessment['timestamp_field'] is None
+    assert 'expected t/timestamp/time/stamps' in assessment['reason']
+
+
+def test_pointcloud_field_assessment_rejects_unsupported_timestamp_type():
+    module = _load_module()
+
+    assessment = module.assess_pointcloud_fields([
+        {'name': 'x', 'datatype': 7, 'count': 1},
+        {'name': 'y', 'datatype': 7, 'count': 1},
+        {'name': 'z', 'datatype': 7, 'count': 1},
+        {'name': 'time', 'datatype': 2, 'count': 1},
+    ])
+
+    assert assessment['rko_lio_compatible'] is False
+    assert 'UINT32, FLOAT32, or FLOAT64' in assessment['reason']
+
+
+def test_missing_point_timestamp_prevents_rko_recommendation(tmp_path: Path):
+    module = _load_module()
+    bag_dir = _write_metadata(
+        tmp_path,
+        [
+            ('/points', 'sensor_msgs/msg/PointCloud2', 200),
+            ('/imu/data', 'sensor_msgs/msg/Imu', 2000),
+        ],
+    )
+
+    def incompatible(_bag_path: Path, topic: str, _storage_id: str) -> dict:
+        return {
+            'status': 'inspected',
+            'topic': topic,
+            'fields': [
+                {'name': 'x', 'datatype': 7, 'count': 1},
+                {'name': 'y', 'datatype': 7, 'count': 1},
+                {'name': 'z', 'datatype': 7, 'count': 1},
+            ],
+            'rko_lio_compatible': False,
+            'timestamp_field': None,
+            'reason': (
+                'PointCloud2 has no per-point timestamp field required for '
+                'RKO-LIO deskewing (expected t/timestamp/time/stamps).'
+            ),
+        }
+
+    payload = module.build_preflight_payload(
+        bag_dir,
+        pointcloud_inspector=incompatible,
+    )
+
+    assert payload['recommended_profile_id'] is None
+    assert payload['recommendations'] == []
+    assert payload['beginner_commands'] == []
+    assert any(
+        'expected t/timestamp/time/stamps' in item
+        for item in payload['missing_requirements']
+    )

--- a/graph_based_slam/test/test_autoware_map_run_diagnosis.py
+++ b/graph_based_slam/test/test_autoware_map_run_diagnosis.py
@@ -95,7 +95,7 @@ def test_summary_marks_success_when_map_and_verify_pass_exist(tmp_path: Path):
     )
     jsonschema.Draft7Validator.check_schema(schema)
     jsonschema.validate(summary, schema)
-    assert summary['bag_preflight']['schema_version'] == 1
+    assert summary['bag_preflight']['schema_version'] == 2
     assert summary['schema_version'] == 1
     assert summary['schema_uri'].endswith('/schemas/diagnosis-v1.schema.json')
     assert summary['status'] == 'success'

--- a/graph_based_slam/test/test_docs_entrypoints.py
+++ b/graph_based_slam/test/test_docs_entrypoints.py
@@ -66,7 +66,7 @@ GOLDEN_PATH_CLI_DOC = REPO_ROOT / 'docs' / 'golden-path-cli.md'
 DISTRIBUTION_DOC = REPO_ROOT / 'docs' / 'distribution.md'
 OPERATIONAL_RELIABILITY_DOC = REPO_ROOT / 'docs' / 'operational-reliability.md'
 REAL_DATA_E2E_DOC = REPO_ROOT / 'docs' / 'real-data-e2e.md'
-PREFLIGHT_SCHEMA = REPO_ROOT / 'docs' / 'schemas' / 'preflight-v1.schema.json'
+PREFLIGHT_SCHEMA = REPO_ROOT / 'docs' / 'schemas' / 'preflight-v2.schema.json'
 DIAGNOSIS_SCHEMA = REPO_ROOT / 'docs' / 'schemas' / 'diagnosis-v1.schema.json'
 RUN_MANIFEST_SCHEMA = REPO_ROOT / 'docs' / 'schemas' / 'run-manifest-v1.schema.json'
 RUN_MANIFEST_V2_SCHEMA = (
@@ -284,6 +284,7 @@ def test_product_contract_has_bounded_official_surface():
     assert 'Other scripts and ROS' in contract
     assert '`run_manifest.json`' in contract
     assert '`<output>.partial`' in golden_path
+    assert 'preflight-v2.schema.json' in golden_path
     assert 'preflight-v1.schema.json' in golden_path
     assert 'diagnosis-v1.schema.json' in golden_path
     assert 'run-manifest-v1.schema.json' in golden_path

--- a/graph_based_slam/test/test_lidarslam_product_cli.py
+++ b/graph_based_slam/test/test_lidarslam_product_cli.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import struct
 import subprocess
 
 
@@ -52,33 +53,50 @@ def _run(*args: str) -> subprocess.CompletedProcess[str]:
 
 
 def _write_bag_metadata(path: Path) -> None:
-    path.mkdir()
-    payload = {
-        'rosbag2_bagfile_information': {
-            'duration': {'nanoseconds': 2_000_000_000},
-            'message_count': 220,
-            'topics_with_message_count': [
-                {
-                    'topic_metadata': {
-                        'name': '/points',
-                        'type': 'sensor_msgs/msg/PointCloud2',
-                    },
-                    'message_count': 20,
-                },
-                {
-                    'topic_metadata': {
-                        'name': '/imu',
-                        'type': 'sensor_msgs/msg/Imu',
-                    },
-                    'message_count': 200,
-                },
-            ],
-        },
-    }
-    (path / 'metadata.yaml').write_text(
-        __import__('yaml').safe_dump(payload),
-        encoding='utf-8',
+    import rosbag2_py
+    from rclpy.serialization import serialize_message
+    from sensor_msgs.msg import Imu, PointCloud2, PointField
+
+    def topic_metadata(topic_id: int, name: str, msg_type: str):
+        kwargs = {
+            'name': name,
+            'type': msg_type,
+            'serialization_format': 'cdr',
+        }
+        try:
+            return rosbag2_py.TopicMetadata(id=topic_id, **kwargs)
+        except TypeError:  # Humble TopicMetadata predates the numeric id
+            return rosbag2_py.TopicMetadata(**kwargs)
+
+    writer = rosbag2_py.SequentialWriter()
+    writer.open(
+        rosbag2_py.StorageOptions(uri=str(path), storage_id='sqlite3'),
+        rosbag2_py.ConverterOptions('', ''),
     )
+    writer.create_topic(
+        topic_metadata(0, '/points', 'sensor_msgs/msg/PointCloud2')
+    )
+    writer.create_topic(topic_metadata(1, '/imu', 'sensor_msgs/msg/Imu'))
+
+    points = PointCloud2()
+    points.header.frame_id = 'lidar'
+    points.height = 1
+    points.width = 1
+    points.fields = [
+        PointField(name='x', offset=0, datatype=PointField.FLOAT32, count=1),
+        PointField(name='y', offset=4, datatype=PointField.FLOAT32, count=1),
+        PointField(name='z', offset=8, datatype=PointField.FLOAT32, count=1),
+        PointField(name='time', offset=12, datatype=PointField.FLOAT32, count=1),
+    ]
+    points.is_bigendian = False
+    points.point_step = 16
+    points.row_step = 16
+    points.data = list(struct.pack('<ffff', 1.0, 2.0, 3.0, 0.0))
+    points.is_dense = True
+    writer.write('/points', serialize_message(points), 1_000_000_000)
+    writer.write('/imu', serialize_message(Imu()), 1_000_000_001)
+    if hasattr(writer, 'close'):
+        writer.close()
 
 
 def test_global_help_version_and_usage_contract():

--- a/graph_based_slam/test/test_mid360_robot_preflight.py
+++ b/graph_based_slam/test/test_mid360_robot_preflight.py
@@ -34,11 +34,9 @@ from __future__ import annotations
 import importlib
 import json
 from pathlib import Path
+import struct
 import subprocess
 import sys
-
-import yaml
-
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS_DIR = REPO_ROOT / 'scripts'
@@ -52,27 +50,64 @@ def _load_module():
 
 
 def _write_metadata(tmp_path: Path, topics: list[tuple[str, str, int]]) -> Path:
+    import rosbag2_py
+    from rclpy.serialization import serialize_message
+    from sensor_msgs.msg import Imu, PointCloud2, PointField
+    from tf2_msgs.msg import TFMessage
+
+    def topic_metadata(topic_id: int, name: str, msg_type: str):
+        kwargs = {
+            'name': name,
+            'type': msg_type,
+            'serialization_format': 'cdr',
+        }
+        try:
+            return rosbag2_py.TopicMetadata(id=topic_id, **kwargs)
+        except TypeError:  # Humble TopicMetadata predates the numeric id
+            return rosbag2_py.TopicMetadata(**kwargs)
+
     bag_dir = tmp_path / 'mid360_robot_bag'
-    bag_dir.mkdir()
-    metadata = {
-        'rosbag2_bagfile_information': {
-            'duration': {'nanoseconds': 5_000_000_000},
-            'message_count': sum(count for _, _, count in topics),
-            'topics_with_message_count': [
-                {
-                    'topic_metadata': {
-                        'name': name,
-                        'type': msg_type,
-                        'serialization_format': 'cdr',
-                        'offered_qos_profiles': '',
-                    },
-                    'message_count': count,
-                }
-                for name, msg_type, count in topics
-            ],
-        },
+    writer = rosbag2_py.SequentialWriter()
+    writer.open(
+        rosbag2_py.StorageOptions(uri=str(bag_dir), storage_id='sqlite3'),
+        rosbag2_py.ConverterOptions('', ''),
+    )
+    for topic_id, (name, msg_type, _) in enumerate(topics):
+        writer.create_topic(topic_metadata(topic_id, name, msg_type))
+
+    points = PointCloud2()
+    points.header.frame_id = 'livox_frame'
+    points.height = 1
+    points.width = 1
+    points.fields = [
+        PointField(name='x', offset=0, datatype=PointField.FLOAT32, count=1),
+        PointField(name='y', offset=4, datatype=PointField.FLOAT32, count=1),
+        PointField(name='z', offset=8, datatype=PointField.FLOAT32, count=1),
+        PointField(name='time', offset=12, datatype=PointField.FLOAT32, count=1),
+    ]
+    points.point_step = 16
+    points.row_step = 16
+    points.data = list(struct.pack('<ffff', 1.0, 2.0, 3.0, 0.0))
+    points.is_dense = True
+    imu = Imu()
+    imu.header.frame_id = 'livox_frame'
+    tf_message = TFMessage()
+    message_by_type = {
+        'sensor_msgs/msg/PointCloud2': points,
+        'sensor_msgs/msg/Imu': imu,
+        'tf2_msgs/msg/TFMessage': tf_message,
     }
-    (bag_dir / 'metadata.yaml').write_text(yaml.safe_dump(metadata), encoding='utf-8')
+    for name, msg_type, count in topics:
+        message = message_by_type[msg_type]
+        interval_ns = max(1, 5_000_000_000 // max(1, count))
+        for index in range(count):
+            writer.write(
+                name,
+                serialize_message(message),
+                1_000_000_000 + index * interval_ns,
+            )
+    if hasattr(writer, 'close'):
+        writer.close()
     return bag_dir
 
 

--- a/graph_based_slam/test/test_mid360_robot_recording_check.py
+++ b/graph_based_slam/test/test_mid360_robot_recording_check.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import struct
 import subprocess
 import sys
 
@@ -68,7 +69,23 @@ def _write_metadata(
     imu: bool = True,
     tf: bool = True,
 ) -> None:
-    bag_dir.mkdir(parents=True, exist_ok=True)
+    import rosbag2_py
+    from geometry_msgs.msg import TransformStamped
+    from rclpy.serialization import serialize_message
+    from sensor_msgs.msg import Imu, PointCloud2, PointField
+    from tf2_msgs.msg import TFMessage
+
+    def topic_metadata(topic_id: int, name: str, msg_type: str):
+        kwargs = {
+            'name': name,
+            'type': msg_type,
+            'serialization_format': 'cdr',
+        }
+        try:
+            return rosbag2_py.TopicMetadata(id=topic_id, **kwargs)
+        except TypeError:  # Humble TopicMetadata predates the numeric id
+            return rosbag2_py.TopicMetadata(**kwargs)
+
     topics = []
     if pointcloud:
         topics.append(('/livox/lidar', 'sensor_msgs/msg/PointCloud2', 50))
@@ -76,25 +93,50 @@ def _write_metadata(
         topics.append(('/livox/imu', 'sensor_msgs/msg/Imu', 500))
     if tf:
         topics.append(('/tf_static', 'tf2_msgs/msg/TFMessage', 1))
-    metadata = {
-        'rosbag2_bagfile_information': {
-            'duration': {'nanoseconds': 5_000_000_000},
-            'message_count': sum(count for _, _, count in topics),
-            'topics_with_message_count': [
-                {
-                    'topic_metadata': {
-                        'name': name,
-                        'type': msg_type,
-                        'serialization_format': 'cdr',
-                        'offered_qos_profiles': '',
-                    },
-                    'message_count': count,
-                }
-                for name, msg_type, count in topics
-            ],
-        },
+    writer = rosbag2_py.SequentialWriter()
+    writer.open(
+        rosbag2_py.StorageOptions(uri=str(bag_dir), storage_id='sqlite3'),
+        rosbag2_py.ConverterOptions('', ''),
+    )
+    for topic_id, (name, msg_type, _) in enumerate(topics):
+        writer.create_topic(topic_metadata(topic_id, name, msg_type))
+
+    points = PointCloud2()
+    points.header.frame_id = 'livox_frame'
+    points.height = 1
+    points.width = 1
+    points.fields = [
+        PointField(name='x', offset=0, datatype=PointField.FLOAT32, count=1),
+        PointField(name='y', offset=4, datatype=PointField.FLOAT32, count=1),
+        PointField(name='z', offset=8, datatype=PointField.FLOAT32, count=1),
+        PointField(name='time', offset=12, datatype=PointField.FLOAT32, count=1),
+    ]
+    points.point_step = 16
+    points.row_step = 16
+    points.data = list(struct.pack('<ffff', 1.0, 2.0, 3.0, 0.0))
+    points.is_dense = True
+    imu_message = Imu()
+    imu_message.header.frame_id = 'livox_frame'
+    transform = TransformStamped()
+    transform.header.frame_id = 'base_link'
+    transform.child_frame_id = 'livox_frame'
+    transform.transform.rotation.w = 1.0
+    message_by_type = {
+        'sensor_msgs/msg/PointCloud2': points,
+        'sensor_msgs/msg/Imu': imu_message,
+        'tf2_msgs/msg/TFMessage': TFMessage(transforms=[transform]),
     }
-    (bag_dir / 'metadata.yaml').write_text(yaml.safe_dump(metadata), encoding='utf-8')
+    for name, msg_type, count in topics:
+        message = message_by_type[msg_type]
+        interval_ns = max(1, 5_000_000_000 // max(1, count))
+        for index in range(count):
+            writer.write(
+                name,
+                serialize_message(message),
+                1_000_000_000 + index * interval_ns,
+            )
+    if hasattr(writer, 'close'):
+        writer.close()
 
 
 def _record_dry_run(tmp_path: Path, run_id: str = 'stand_01') -> tuple[Path, Path, Path]:

--- a/lidarslam/test/test_autoware_map_runner_script.py
+++ b/lidarslam/test/test_autoware_map_runner_script.py
@@ -89,6 +89,26 @@ def _write_metadata(tmp_path: Path, bag_name: str, topics: list[tuple[str, str, 
     return bag_dir
 
 
+def _compatible_pointcloud_inspection(
+    _bag_path: Path,
+    topic: str,
+    _storage_id: str,
+) -> dict:
+    return {
+        'status': 'inspected',
+        'topic': topic,
+        'fields': [
+            {'name': 'x', 'datatype': 7, 'count': 1},
+            {'name': 'y', 'datatype': 7, 'count': 1},
+            {'name': 'z', 'datatype': 7, 'count': 1},
+            {'name': 'time', 'datatype': 7, 'count': 1},
+        ],
+        'rko_lio_compatible': True,
+        'timestamp_field': 'time',
+        'reason': "RKO-LIO-compatible per-point timestamp field 'time' was found.",
+    }
+
+
 def test_runner_script_supports_profiles_and_viewers():
     script = SCRIPT_PATH.read_text(encoding='utf-8')
 
@@ -1160,7 +1180,7 @@ def test_runner_rejects_incompatible_profile_with_available_hint(tmp_path: Path)
         'profile is not compatible with this bag: pointcloud_gnss_smoke'
         in result.stderr
     )
-    assert 'Available profiles: rko_lio_graph_public_path' in result.stderr
+    assert 'Available profiles: none' in result.stderr
     assert 'Traceback' not in result.stderr
 
 
@@ -1260,6 +1280,7 @@ def test_runner_prefers_mid360_preset_for_livox_bag(tmp_path: Path):
         profile_id=None,
         output_dir=tmp_path / 'out',
         verify_map=True,
+        pointcloud_inspector=_compatible_pointcloud_inspection,
     )
 
     assert plan['profile_id'] == 'rko_lio_graph_mid360_preset'
@@ -1288,6 +1309,7 @@ def test_public_plan_pins_both_installed_parameter_files(tmp_path: Path):
         profile_id=None,
         output_dir=tmp_path / 'out',
         verify_map=True,
+        pointcloud_inspector=_compatible_pointcloud_inspection,
     )
 
     command = ' '.join(plan['command'])

--- a/scripts/check_installed_product_cli.py
+++ b/scripts/check_installed_product_cli.py
@@ -8,10 +8,9 @@ import json
 import os
 from pathlib import Path
 import shutil
+import struct
 import subprocess
 import tempfile
-
-import yaml
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -62,34 +61,50 @@ def _require_success(
 
 
 def _write_bag_fixture(path: Path) -> None:
-    path.mkdir()
-    payload = {
-        'rosbag2_bagfile_information': {
-            'duration': {'nanoseconds': 2_000_000_000},
-            'message_count': 220,
-            'storage_identifier': 'sqlite3',
-            'topics_with_message_count': [
-                {
-                    'topic_metadata': {
-                        'name': '/points',
-                        'type': 'sensor_msgs/msg/PointCloud2',
-                    },
-                    'message_count': 20,
-                },
-                {
-                    'topic_metadata': {
-                        'name': '/imu',
-                        'type': 'sensor_msgs/msg/Imu',
-                    },
-                    'message_count': 200,
-                },
-            ],
-        },
-    }
-    (path / 'metadata.yaml').write_text(
-        yaml.safe_dump(payload),
-        encoding='utf-8',
+    import rosbag2_py
+    from rclpy.serialization import serialize_message
+    from sensor_msgs.msg import Imu, PointCloud2, PointField
+
+    def topic_metadata(topic_id: int, name: str, msg_type: str):
+        kwargs = {
+            'name': name,
+            'type': msg_type,
+            'serialization_format': 'cdr',
+        }
+        try:
+            return rosbag2_py.TopicMetadata(id=topic_id, **kwargs)
+        except TypeError:  # Humble TopicMetadata predates the numeric id
+            return rosbag2_py.TopicMetadata(**kwargs)
+
+    writer = rosbag2_py.SequentialWriter()
+    writer.open(
+        rosbag2_py.StorageOptions(uri=str(path), storage_id='sqlite3'),
+        rosbag2_py.ConverterOptions('', ''),
     )
+    writer.create_topic(
+        topic_metadata(0, '/points', 'sensor_msgs/msg/PointCloud2')
+    )
+    writer.create_topic(topic_metadata(1, '/imu', 'sensor_msgs/msg/Imu'))
+
+    points = PointCloud2()
+    points.header.frame_id = 'lidar'
+    points.height = 1
+    points.width = 1
+    points.fields = [
+        PointField(name='x', offset=0, datatype=PointField.FLOAT32, count=1),
+        PointField(name='y', offset=4, datatype=PointField.FLOAT32, count=1),
+        PointField(name='z', offset=8, datatype=PointField.FLOAT32, count=1),
+        PointField(name='time', offset=12, datatype=PointField.FLOAT32, count=1),
+    ]
+    points.is_bigendian = False
+    points.point_step = 16
+    points.row_step = 16
+    points.data = list(struct.pack('<ffff', 1.0, 2.0, 3.0, 0.0))
+    points.is_dense = True
+    writer.write('/points', serialize_message(points), 1_000_000_000)
+    writer.write('/imu', serialize_message(Imu()), 1_000_000_001)
+    if hasattr(writer, 'close'):
+        writer.close()
 
 
 def validate_install(prefix: Path) -> None:

--- a/scripts/mid360_robot_sample_bag.py
+++ b/scripts/mid360_robot_sample_bag.py
@@ -3,10 +3,10 @@
 
 from __future__ import annotations
 
-import math
-import shutil
 from dataclasses import asdict, dataclass
+import math
 from pathlib import Path
+import shutil
 from typing import Any
 
 import numpy as np
@@ -215,10 +215,10 @@ class Mid360SampleBagWriter:
     def _build_pointcloud(self, typestore: Any, stamp_ns: int, sequence_index: int) -> Any:
         PointField = typestore.types['sensor_msgs/msg/PointField']
         PointCloud2 = typestore.types['sensor_msgs/msg/PointCloud2']
-        point_step = 16
+        point_step = 20
         row_step = point_step * self._config.point_count
         data = np.zeros(row_step, dtype=np.uint8)
-        points = data.view(dtype=np.float32).reshape(self._config.point_count, 4)
+        points = data.view(dtype=np.float32).reshape(self._config.point_count, 5)
         phase = sequence_index * 0.1
         for point_index in range(self._config.point_count):
             angle = (2.0 * math.pi * point_index / self._config.point_count) + phase
@@ -227,6 +227,10 @@ class Mid360SampleBagWriter:
             points[point_index, 1] = radius * math.sin(angle)
             points[point_index, 2] = 0.2 + 0.01 * (point_index % 11)
             points[point_index, 3] = float((sequence_index + point_index) % 255) / 255.0
+            points[point_index, 4] = (
+                point_index
+                / (self._config.point_count * self._config.pointcloud_rate_hz)
+            )
 
         return PointCloud2(
             header=self._build_header(typestore, stamp_ns, self._config.lidar_frame),
@@ -237,6 +241,7 @@ class Mid360SampleBagWriter:
                 PointField(name='y', offset=4, datatype=PointField.FLOAT32, count=1),
                 PointField(name='z', offset=8, datatype=PointField.FLOAT32, count=1),
                 PointField(name='intensity', offset=12, datatype=PointField.FLOAT32, count=1),
+                PointField(name='time', offset=16, datatype=PointField.FLOAT32, count=1),
             ],
             is_bigendian=False,
             point_step=point_step,

--- a/scripts/preflight_autoware_map_bag.py
+++ b/scripts/preflight_autoware_map_bag.py
@@ -208,15 +208,11 @@ def inspect_pointcloud_record(
         from rclpy.serialization import deserialize_message
         from sensor_msgs.msg import PointCloud2
     except ImportError as exc:
-        return {
-            **base,
-            'status': 'unavailable',
-            'reason': (
-                'PointCloud2 record inspection is unavailable in this environment: '
-                f'{exc}. Source a ROS 2 installation with rosbag2_py, rclpy, and '
-                'sensor_msgs before selecting an RKO-LIO profile.'
-            ),
-        }
+        return _inspect_pointcloud_record_with_rosbags(
+            bag_path,
+            topic,
+            ros_import_error=exc,
+        )
 
     try:
         reader = rosbag2_py.SequentialReader()
@@ -253,6 +249,81 @@ def inspect_pointcloud_record(
             **base,
             'status': 'error',
             'reason': f'Failed to inspect PointCloud2 record on {topic}: {exc}',
+        }
+
+    return {
+        **base,
+        'status': 'empty',
+        'reason': f'No PointCloud2 record was found on selected topic {topic}.',
+    }
+
+
+def _inspect_pointcloud_record_with_rosbags(
+    bag_path: Path,
+    topic: str,
+    ros_import_error: ImportError,
+) -> dict[str, Any]:
+    """Use the pure-Python rosbags reader when ROS Python bindings are absent."""
+    base = {
+        'topic': topic,
+        'fields': [],
+        'rko_lio_compatible': None,
+        'timestamp_field': None,
+    }
+    try:
+        from rosbags.highlevel import AnyReader
+        from rosbags.typesys import Stores, get_typestore
+    except ImportError as rosbags_error:
+        return {
+            **base,
+            'status': 'unavailable',
+            'reason': (
+                'PointCloud2 record inspection is unavailable: ROS 2 Python '
+                f'bindings failed to import ({ros_import_error}); the rosbags '
+                f'fallback also failed to import ({rosbags_error}). Source ROS 2 '
+                'or install the Python rosbags package before selecting an '
+                'RKO-LIO profile.'
+            ),
+        }
+
+    try:
+        typestore = get_typestore(Stores.LATEST)
+        with AnyReader(
+            [bag_path],
+            default_typestore=typestore,
+        ) as reader:
+            connections = [
+                connection
+                for connection in reader.connections
+                if connection.topic == topic and connection.msgtype == POINTCLOUD2
+            ]
+            for connection, _, serialized in reader.messages(
+                connections=connections,
+            ):
+                message = reader.deserialize(serialized, connection.msgtype)
+                fields = [
+                    {
+                        'name': field.name,
+                        'datatype': int(field.datatype),
+                        'count': int(field.count),
+                    }
+                    for field in message.fields
+                ]
+                assessment = assess_pointcloud_fields(fields)
+                return {
+                    **base,
+                    **assessment,
+                    'status': 'inspected',
+                    'fields': fields,
+                }
+    except Exception as exc:
+        return {
+            **base,
+            'status': 'error',
+            'reason': (
+                f'Failed to inspect PointCloud2 record on {topic} with rosbags: '
+                f'{exc}'
+            ),
         }
 
     return {

--- a/scripts/preflight_autoware_map_bag.py
+++ b/scripts/preflight_autoware_map_bag.py
@@ -2,13 +2,13 @@
 """Preflight a rosbag2 for Autoware-compatible map authoring workflows."""
 
 import argparse
+from dataclasses import asdict, dataclass
 import json
+from pathlib import Path
 import shlex
 import sys
 import textwrap
-from dataclasses import asdict, dataclass
-from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 import yaml
 
@@ -21,8 +21,17 @@ TFMESSAGE = 'tf2_msgs/msg/TFMessage'
 GSOF49 = 'applanix_msgs/msg/NavigationSolutionGsof49'
 GSOF50 = 'applanix_msgs/msg/NavigationPerformanceGsof50'
 VELOCITY_REPORT = 'autoware_auto_vehicle_msgs/msg/VelocityReport'
-SCHEMA_VERSION = 1
-SCHEMA_URI = 'https://rsasaki0109.github.io/lidar_slam_ros2/schemas/preflight-v1.schema.json'
+SCHEMA_VERSION = 2
+SCHEMA_URI = 'https://rsasaki0109.github.io/lidar_slam_ros2/schemas/preflight-v2.schema.json'
+POINT_FIELD_UINT32 = 6
+POINT_FIELD_FLOAT32 = 7
+POINT_FIELD_FLOAT64 = 8
+RKO_TIMESTAMP_FIELDS = ('t', 'timestamp', 'time', 'stamps')
+RKO_TIMESTAMP_DATATYPES = (
+    POINT_FIELD_UINT32,
+    POINT_FIELD_FLOAT32,
+    POINT_FIELD_FLOAT64,
+)
 
 PROFILE_HELP = (
     (
@@ -116,6 +125,143 @@ def _best_topic(records: list[TopicRecord], msg_type: str) -> TopicRecord | None
     return grouped[0] if grouped else None
 
 
+def assess_pointcloud_fields(fields: list[dict[str, Any]]) -> dict[str, Any]:
+    """Assess whether PointCloud2 fields satisfy RKO-LIO's reader contract."""
+    normalized = [
+        {
+            'name': str(field.get('name', '')),
+            'datatype': int(field.get('datatype', 0)),
+            'count': int(field.get('count', 0)),
+        }
+        for field in fields
+    ]
+    by_name = {field['name']: field for field in normalized}
+
+    invalid_xyz = [
+        name
+        for name in ('x', 'y', 'z')
+        if name not in by_name
+        or by_name[name]['datatype'] != POINT_FIELD_FLOAT32
+        or by_name[name]['count'] <= 0
+    ]
+    if invalid_xyz:
+        return {
+            'rko_lio_compatible': False,
+            'timestamp_field': None,
+            'reason': (
+                'RKO-LIO requires x, y, and z PointCloud2 fields with FLOAT32 '
+                f'datatype and positive count; invalid or missing: {", ".join(invalid_xyz)}.'
+            ),
+        }
+
+    timestamp_candidates = [
+        by_name[name] for name in RKO_TIMESTAMP_FIELDS if name in by_name
+    ]
+    for field in timestamp_candidates:
+        if (
+            field['datatype'] in RKO_TIMESTAMP_DATATYPES
+            and field['count'] > 0
+        ):
+            return {
+                'rko_lio_compatible': True,
+                'timestamp_field': field['name'],
+                'reason': (
+                    f'RKO-LIO-compatible per-point timestamp field '
+                    f'{field["name"]!r} was found.'
+                ),
+            }
+
+    expected = '/'.join(RKO_TIMESTAMP_FIELDS)
+    if timestamp_candidates:
+        return {
+            'rko_lio_compatible': False,
+            'timestamp_field': None,
+            'reason': (
+                f'PointCloud2 timestamp field must be one of {expected}, have '
+                'positive count, and use UINT32, FLOAT32, or FLOAT64.'
+            ),
+        }
+    return {
+        'rko_lio_compatible': False,
+        'timestamp_field': None,
+        'reason': (
+            'PointCloud2 has no per-point timestamp field required for '
+            f'RKO-LIO deskewing (expected {expected}).'
+        ),
+    }
+
+
+def inspect_pointcloud_record(
+    bag_path: Path,
+    topic: str,
+    storage_id: str,
+) -> dict[str, Any]:
+    """Read the first selected PointCloud2 record and inspect its fields."""
+    base = {
+        'topic': topic,
+        'fields': [],
+        'rko_lio_compatible': None,
+        'timestamp_field': None,
+    }
+    try:
+        import rosbag2_py
+        from rclpy.serialization import deserialize_message
+        from sensor_msgs.msg import PointCloud2
+    except ImportError as exc:
+        return {
+            **base,
+            'status': 'unavailable',
+            'reason': (
+                'PointCloud2 record inspection is unavailable in this environment: '
+                f'{exc}. Source a ROS 2 installation with rosbag2_py, rclpy, and '
+                'sensor_msgs before selecting an RKO-LIO profile.'
+            ),
+        }
+
+    try:
+        reader = rosbag2_py.SequentialReader()
+        reader.open(
+            rosbag2_py.StorageOptions(
+                uri=str(bag_path),
+                storage_id=storage_id,
+            ),
+            rosbag2_py.ConverterOptions('', ''),
+        )
+        reader.set_filter(rosbag2_py.StorageFilter(topics=[topic]))
+        while reader.has_next():
+            record_topic, serialized, _ = reader.read_next()
+            if record_topic != topic:
+                continue
+            message = deserialize_message(serialized, PointCloud2)
+            fields = [
+                {
+                    'name': field.name,
+                    'datatype': field.datatype,
+                    'count': field.count,
+                }
+                for field in message.fields
+            ]
+            assessment = assess_pointcloud_fields(fields)
+            return {
+                **base,
+                **assessment,
+                'status': 'inspected',
+                'fields': fields,
+            }
+    except Exception as exc:  # rosbag2 storage plugins expose backend-specific errors
+        return {
+            **base,
+            'status': 'error',
+            'reason': f'Failed to inspect PointCloud2 record on {topic}: {exc}',
+        }
+
+    return {
+        **base,
+        'status': 'empty',
+        'reason': f'No PointCloud2 record was found on selected topic {topic}.',
+    }
+
+
 def summarize_bag(bag_path: Path) -> dict[str, Any]:
     """Summarize a rosbag2 in terms of map-authoring inputs."""
     bag_info = load_bag_metadata(bag_path)
@@ -132,7 +278,10 @@ def summarize_bag(bag_path: Path) -> dict[str, Any]:
             'applanix_gsof49': [asdict(item) for item in _topic_group(topic_records, GSOF49)],
             'applanix_gsof50': [asdict(item) for item in _topic_group(topic_records, GSOF50)],
             'tf': [asdict(item) for item in _topic_group(topic_records, TFMESSAGE)],
-            'velocity_report': [asdict(item) for item in _topic_group(topic_records, VELOCITY_REPORT)],
+            'velocity_report': [
+                asdict(item)
+                for item in _topic_group(topic_records, VELOCITY_REPORT)
+            ],
         },
     }
 
@@ -156,12 +305,24 @@ def build_recommendations(summary: dict[str, Any]) -> list[dict[str, Any]]:
     capabilities = summary['capabilities']
     recommendations: list[dict[str, Any]] = []
 
-    best_pointcloud = summary['topics']['pointcloud2'][0] if summary['topics']['pointcloud2'] else None
+    best_pointcloud = (
+        summary['topics']['pointcloud2'][0]
+        if summary['topics']['pointcloud2'] else None
+    )
     best_imu = summary['topics']['imu'][0] if summary['topics']['imu'] else None
     best_navsat = summary['topics']['navsatfix'][0] if summary['topics']['navsatfix'] else None
-    best_packet = summary['topics']['velodyne_scan'][0] if summary['topics']['velodyne_scan'] else None
-    best_gsof49 = summary['topics']['applanix_gsof49'][0] if summary['topics']['applanix_gsof49'] else None
-    best_gsof50 = summary['topics']['applanix_gsof50'][0] if summary['topics']['applanix_gsof50'] else None
+    best_packet = (
+        summary['topics']['velodyne_scan'][0]
+        if summary['topics']['velodyne_scan'] else None
+    )
+    best_gsof49 = (
+        summary['topics']['applanix_gsof49'][0]
+        if summary['topics']['applanix_gsof49'] else None
+    )
+    best_gsof50 = (
+        summary['topics']['applanix_gsof50'][0]
+        if summary['topics']['applanix_gsof50'] else None
+    )
     bag_path_lower = bag_path.lower()
 
     def looks_like_livox_mid360() -> bool:
@@ -170,7 +331,12 @@ def build_recommendations(summary: dict[str, Any]) -> list[dict[str, Any]]:
             topic_names.extend(item['name'].lower() for item in summary['topics'][key])
         return 'mid360' in bag_path_lower or any('livox' in name for name in topic_names)
 
-    if capabilities['has_pointcloud2'] and capabilities['has_imu']:
+    pointcloud_inspection = summary['pointcloud_inspection']
+    if (
+        capabilities['has_pointcloud2']
+        and capabilities['has_imu']
+        and pointcloud_inspection['rko_lio_compatible'] is True
+    ):
         command = textwrap.dedent(
             f"""\
             ros2 launch lidarslam rko_lio_slam.launch.py \\
@@ -191,6 +357,10 @@ def build_recommendations(summary: dict[str, Any]) -> list[dict[str, Any]]:
             'why': [
                 f"PointCloud2 is available on {best_pointcloud['name']}",
                 f"Imu is available on {best_imu['name']}",
+                (
+                    'The first PointCloud2 record has RKO-LIO-compatible '
+                    f"per-point timestamps in {pointcloud_inspection['timestamp_field']!r}."
+                ),
                 'This is the main maintained map-authoring path in the repository.',
             ],
             'command': command,
@@ -212,12 +382,22 @@ def build_recommendations(summary: dict[str, Any]) -> list[dict[str, Any]]:
                 'priority': 95,
                 'label': 'RKO-LIO + graph_based_slam MID360/Livox preset',
                 'why': [
-                    f"PointCloud2 topic {best_pointcloud['name']} looks like a Livox/MID360 source",
-                    'The repository tracks a tuned MID360 graph/backend YAML for this sensor family.',
+                    (
+                        f"PointCloud2 topic {best_pointcloud['name']} looks like "
+                        'a Livox/MID360 source'
+                    ),
+                    (
+                        'The repository tracks a tuned MID360 graph/backend YAML '
+                        'for this sensor family.'
+                    ),
                 ],
                 'command': tuned_command,
                 'notes': [
-                    'Use this when the bag is a Livox/MID360-style dataset and you want the tracked tuned preset instead of the generic default.',
+                    (
+                        'Use this when the bag is a Livox/MID360-style dataset and '
+                        'you want the tracked tuned preset instead of the generic '
+                        'default.'
+                    ),
                 ],
             })
 
@@ -237,7 +417,10 @@ def build_recommendations(summary: dict[str, Any]) -> list[dict[str, Any]]:
             'why': [
                 f"PointCloud2 is available on {best_pointcloud['name']}",
                 f"NavSatFix is available on {best_navsat['name']}",
-                'This wrapper produces a verified pointcloud map with GNSS-enabled backend constraints.',
+                (
+                    'This wrapper produces a verified pointcloud map with '
+                    'GNSS-enabled backend constraints.'
+                ),
             ],
             'command': command,
             'notes': [],
@@ -260,7 +443,10 @@ def build_recommendations(summary: dict[str, Any]) -> list[dict[str, Any]]:
             'why': [
                 f"VelodyneScan is available on {best_packet['name']}",
                 f"Applanix GSOF49 is available on {best_gsof49['name']}",
-                'This wrapper converts packet and Applanix data into the maintained pointcloud-map path.',
+                (
+                    'This wrapper converts packet and Applanix data into the '
+                    'maintained pointcloud-map path.'
+                ),
             ],
             'command': command,
             'notes': [],
@@ -269,9 +455,30 @@ def build_recommendations(summary: dict[str, Any]) -> list[dict[str, Any]]:
     return sorted(recommendations, key=lambda item: item['priority'], reverse=True)
 
 
-def build_preflight_payload(bag_path: Path) -> dict[str, Any]:
+def build_preflight_payload(
+    bag_path: Path,
+    pointcloud_inspector: Callable[[Path, str, str], dict[str, Any]] | None = None,
+) -> dict[str, Any]:
     """Create the machine-readable preflight result."""
     summary = summarize_bag(bag_path)
+    if summary['topics']['pointcloud2']:
+        topic = summary['topics']['pointcloud2'][0]['name']
+        bag_info = load_bag_metadata(bag_path)
+        inspector = pointcloud_inspector or inspect_pointcloud_record
+        summary['pointcloud_inspection'] = inspector(
+            bag_path,
+            topic,
+            str(bag_info.get('storage_identifier', '')),
+        )
+    else:
+        summary['pointcloud_inspection'] = {
+            'status': 'not_applicable',
+            'topic': None,
+            'fields': [],
+            'rko_lio_compatible': None,
+            'timestamp_field': None,
+            'reason': 'No PointCloud2 topic was found.',
+        }
     recommendations = build_recommendations(summary)
     bag_q = _safe_quote(summary['bag_path'])
     advisory = []
@@ -295,8 +502,21 @@ def build_preflight_payload(bag_path: Path) -> dict[str, Any]:
         })
 
     missing = []
-    if not summary['capabilities']['has_pointcloud2'] and not summary['capabilities']['has_velodyne_scan']:
+    if (
+        not summary['capabilities']['has_pointcloud2']
+        and not summary['capabilities']['has_velodyne_scan']
+    ):
         missing.append('No PointCloud2 or VelodyneScan topic was found.')
+    inspection = summary['pointcloud_inspection']
+    if (
+        summary['capabilities']['has_pointcloud2']
+        and summary['capabilities']['has_imu']
+        and inspection['rko_lio_compatible'] is not True
+    ):
+        missing.append(
+            f"PointCloud2 topic {inspection['topic']} is not verified as compatible "
+            f"with RKO-LIO: {inspection['reason']}"
+        )
     if not recommendations:
         if not summary['capabilities']['has_imu']:
             missing.append('No Imu topic was found for the main RKO-LIO public path.')
@@ -354,7 +574,7 @@ def render_text_report(payload: dict[str, Any]) -> str:
     lines = [
         'Autoware-Compatible Map Preflight',
         f"bag: {summary['bag_path']}",
-        f"duration: {duration_text}",
+        f'duration: {duration_text}',
         f"messages: {summary['message_count']}",
         '',
         'Detected inputs:',
@@ -367,6 +587,12 @@ def render_text_report(payload: dict[str, Any]) -> str:
         f"  TF/TF_STATIC: {_format_topic_list(summary['topics']['tf'])}",
         f"  VelocityReport: {_format_topic_list(summary['topics']['velocity_report'])}",
     ]
+    inspection = summary['pointcloud_inspection']
+    if inspection['status'] != 'not_applicable':
+        lines.append(
+            '  PointCloud2 record: '
+            f"{inspection['status']} ({inspection['reason']})"
+        )
 
     if recommendations:
         primary = recommendations[0]

--- a/scripts/run_autoware_map_from_bag.py
+++ b/scripts/run_autoware_map_from_bag.py
@@ -200,9 +200,13 @@ def build_execution_plan(
     profile_id: str | None,
     output_dir: Path,
     verify_map: bool,
+    pointcloud_inspector=None,
 ) -> dict[str, object]:
     preflight = _load_script_module('preflight_autoware_map_bag.py', 'preflight_autoware_map_bag')
-    payload = preflight.build_preflight_payload(bag_path)
+    payload = preflight.build_preflight_payload(
+        bag_path,
+        pointcloud_inspector=pointcloud_inspector,
+    )
     selected_profile = _select_profile(payload, profile_id)
 
     recommendations = {item['id']: item for item in payload['recommendations']}

--- a/scripts/smoke_mid360_robot_runbook.sh
+++ b/scripts/smoke_mid360_robot_runbook.sh
@@ -9,15 +9,16 @@ Usage:
 Smoke-test the Jetson MID-360 robot runbook without starting SLAM.
 
 Options:
-  --work-dir <dir>       Temporary working directory for the fake bag
+  --work-dir <dir>       Temporary working directory for the synthetic bag
   --output-dir <dir>     Output directory for readiness and run-plan files
   --profile <file>       Robot profile YAML (default: configs/mid360_robot/livox_mid360_default.yaml)
   --keep-work-dir        Do not delete the temporary working directory
   --help                 Show this help
 
-The smoke creates a metadata-only rosbag2 directory with /livox/lidar,
-/livox/imu, and /tf_static, then runs profile validation, recording dry-run,
-post-recording check, readiness, and map dry-run. It does not launch ROS or SLAM.
+The smoke creates a synthetic rosbag2 with /livox/lidar, /livox/imu, and
+/tf_static records, then runs profile validation, recording dry-run,
+post-recording check, readiness, and map dry-run. It does not launch ROS or
+SLAM. The Python rosbags package is required.
 EOF
   exit 1
 }
@@ -85,42 +86,16 @@ cleanup() {
 }
 trap cleanup EXIT
 
-mkdir -p "$BAG_DIR" "$OUTPUT_DIR"
-
-python3 - "$BAG_DIR/metadata.yaml" <<'PY'
-from pathlib import Path
-import sys
-
-import yaml
-
-metadata_path = Path(sys.argv[1])
-topics = [
-    ('/livox/lidar', 'sensor_msgs/msg/PointCloud2', 50),
-    ('/livox/imu', 'sensor_msgs/msg/Imu', 500),
-    ('/tf_static', 'tf2_msgs/msg/TFMessage', 1),
-]
-metadata = {
-    'rosbag2_bagfile_information': {
-        'duration': {'nanoseconds': 5_000_000_000},
-        'message_count': sum(count for _, _, count in topics),
-        'topics_with_message_count': [
-            {
-                'topic_metadata': {
-                    'name': name,
-                    'type': msg_type,
-                    'serialization_format': 'cdr',
-                    'offered_qos_profiles': '',
-                },
-                'message_count': count,
-            }
-            for name, msg_type, count in topics
-        ],
-    },
-}
-metadata_path.write_text(yaml.safe_dump(metadata), encoding='utf-8')
-PY
+mkdir -p "$RECORD_ROOT" "$OUTPUT_DIR"
 
 cd "$REPO_ROOT"
+
+python3 scripts/generate_mid360_robot_sample_bag.py "$BAG_DIR" \
+  --duration-sec 5 \
+  --pointcloud-rate-hz 10 \
+  --imu-rate-hz 100 \
+  --point-count 16 \
+  --force >/dev/null
 
 python3 scripts/validate_mid360_robot_profile.py "$PROFILE" >/dev/null
 
@@ -178,15 +153,24 @@ done
 python3 - "$OUTPUT_DIR/mid360_robot_readiness.json" <<'PY'
 from pathlib import Path
 import json
+import math
 import sys
 
 payload = json.loads(Path(sys.argv[1]).read_text(encoding='utf-8'))
 if payload.get('status') != 'PASS':
     raise SystemExit(f"readiness status is not PASS: {payload.get('status')}")
 diagnostics = payload.get('bag_diagnostics', {}).get('topics', {})
-if diagnostics.get('pointcloud', {}).get('metadata_rate_hz') != 10.0:
+if not math.isclose(
+    diagnostics.get('pointcloud', {}).get('metadata_rate_hz', 0.0),
+    10.0,
+    rel_tol=0.02,
+):
     raise SystemExit('pointcloud metadata rate check missing or incorrect')
-if diagnostics.get('imu', {}).get('metadata_rate_hz') != 100.0:
+if not math.isclose(
+    diagnostics.get('imu', {}).get('metadata_rate_hz', 0.0),
+    100.0,
+    rel_tol=0.02,
+):
     raise SystemExit('imu metadata rate check missing or incorrect')
 PY
 
@@ -201,5 +185,5 @@ if payload.get('status') != 'PASS':
 PY
 
 echo "MID-360 robot runbook smoke: PASS"
-echo "  fake_bag:   $BAG_DIR"
+echo "  sample_bag: $BAG_DIR"
 echo "  output_dir: $OUTPUT_DIR"


### PR DESCRIPTION
## Summary
- inspect the first selected PointCloud2 record before recommending RKO-LIO
- publish preflight schema v2 with field-level evidence and actionable refusal reasons
- make synthetic MID-360 bags RKO-compatible and exercise real rosbag fixtures in product tests

## Validation
- real incompatible bag: doctor returns no recommendation; run --dry-run exits 2 without output
- targeted pytest: 74 passed plus MID-360 fixture coverage
- default CI aggregate after focused correction: 2431 tests, 0 failures, 125 skipped
- ament_flake8, git diff --check, JSON Schema Draft 7, and mkdocs --strict pass