### PR TITLE
Record auditable provenance for named soak runs

### DIFF
--- a/docs/operational-reliability.md
+++ b/docs/operational-reliability.md
@@ -92,14 +92,28 @@ Every sample is appended to `telemetry_samples` and atomically checkpoints
 growth exceeds `--max-output-gib`, the harness stops the entire timed process
 group with `SIGTERM` and a bounded `SIGKILL` fallback, then attempts to
 finalize a failed report. The last successful sample remains available even
-when the iteration never produces normal GNU time evidence. Schema v2 defines
-the periodic evidence; schema v1 remains published for existing reports:
+when the iteration never produces normal GNU time evidence.
 
+- [`soak-report-v3.schema.json`](schemas/soak-report-v3.schema.json) — current;
+  adds a non-secret machine fingerprint, harness revision and checksums, and
+  the exact input/software identity copied from each successful product run;
 - [`soak-report-v2.schema.json`](schemas/soak-report-v2.schema.json)
+  — published compatibility schema for periodic telemetry reports;
 - [`soak-report-v1.schema.json`](schemas/soak-report-v1.schema.json)
+  — published compatibility schema for iteration-only reports.
+
+The schema v1 remains published, and schema v2 remains immutable, so archived
+reports retain a resolvable contract.
+
+A passing v3 report requires `provenance_recorded`. The first successful
+iteration fixes the input and software identities for the whole soak; any
+later iteration with a different identity terminates the run as failed. The
+machine ID is a SHA-256 fingerprint: private machine identifiers contribute
+to stability but are never written to the report. Hostnames, usernames and
+network addresses are not collected.
 
 Operator `Ctrl-C` and service `SIGTERM` use the same process-group cleanup and
-return `130` and `143`, respectively. Their terminal v2 report has
+return `130` and `143`, respectively. Their terminal v3 report has
 `interrupted` status. If the filesystem refuses the final atomic update, the
 last successfully written running-state sample remains as recovery evidence.
 
@@ -118,8 +132,8 @@ the termination coverage:
 
 - timestamp reversal detection against real rosbag records before launch;
 - execute and archive the one-hour and eight-hour soak profiles on named
-  release hardware; the harness and machine-readable thresholds are automated,
-  but real-duration evidence is not yet recorded;
+  release hardware; the harness, machine-readable thresholds and v3
+  provenance are automated, but real-duration evidence is not yet recorded;
 - a bounded-filesystem live exhaustion test in the scheduled real-data
   environment;
 - output migration tooling and last-known-good rollback instructions.

--- a/docs/roadmap/v0.9.md
+++ b/docs/roadmap/v0.9.md
@@ -8,8 +8,9 @@
 > process-group cleanup, recoverable terminal evidence, and the pinned nightly
 > MID-360 real-data E2E gate landed; deterministic storage refusal and
 > disk-exhaustion failure injection, fixed-duration soak profiles, and
-> periodic in-iteration storage telemetry landed, while named-hardware
-> executions and scheduled live exhaustion remain)**.
+> periodic in-iteration storage telemetry and auditable machine/input/software
+> provenance landed, while named-hardware executions and scheduled live
+> exhaustion remain)**.
 > This roadmap
 > turns the existing benchmark-heavy map-authoring stack into a product-level
 > OSS project. It does not replace the evidence-driven capability roadmaps;

--- a/docs/schemas/soak-report-v3.schema.json
+++ b/docs/schemas/soak-report-v3.schema.json
@@ -1,0 +1,351 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://rsasaki0109.github.io/lidar_slam_ros2/schemas/soak-report-v3.schema.json",
+  "title": "lidarslam_ros2 soak report v3",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "schema_uri",
+    "status",
+    "last_error",
+    "active_iteration_id",
+    "profile",
+    "target_duration_sec",
+    "telemetry_interval_sec",
+    "started_at",
+    "completed_at",
+    "hardware_label",
+    "hardware",
+    "harness",
+    "bag_path",
+    "map_profile",
+    "product_cli",
+    "input_identity",
+    "software_identity",
+    "thresholds",
+    "metrics",
+    "checks",
+    "telemetry_samples",
+    "iterations"
+  ],
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "status": {"enum": ["passed", "failed", "interrupted"]}
+        }
+      },
+      "then": {
+        "properties": {
+          "checks": {
+            "required": [
+              "target_duration_reached",
+              "all_iterations_succeeded",
+              "peak_rss_within_budget",
+              "output_size_within_budget",
+              "dropped_inputs_within_budget",
+              "free_space_within_budget",
+              "provenance_recorded"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "status": {"const": "passed"}
+        }
+      },
+      "then": {
+        "properties": {
+          "input_identity": {"$ref": "#/definitions/input_identity"},
+          "software_identity": {"$ref": "#/definitions/software_identity"}
+        }
+      }
+    }
+  ],
+  "properties": {
+    "schema_version": {"const": 3},
+    "schema_uri": {
+      "const": "https://rsasaki0109.github.io/lidar_slam_ros2/schemas/soak-report-v3.schema.json"
+    },
+    "status": {"enum": ["running", "passed", "failed", "interrupted"]},
+    "last_error": {"type": ["string", "null"]},
+    "active_iteration_id": {
+      "type": ["string", "null"],
+      "pattern": "^iteration-[0-9]{4,}$"
+    },
+    "profile": {"enum": ["one-hour", "eight-hour"]},
+    "target_duration_sec": {"enum": [3600.0, 28800.0]},
+    "telemetry_interval_sec": {
+      "type": "number",
+      "exclusiveMinimum": 0,
+      "maximum": 60
+    },
+    "started_at": {"type": "string", "format": "date-time"},
+    "completed_at": {"type": ["string", "null"], "format": "date-time"},
+    "hardware_label": {"type": "string", "minLength": 1},
+    "hardware": {"$ref": "#/definitions/hardware"},
+    "harness": {"$ref": "#/definitions/harness"},
+    "bag_path": {"type": "string", "minLength": 1},
+    "map_profile": {"type": ["string", "null"]},
+    "product_cli": {"type": "string", "minLength": 1},
+    "input_identity": {
+      "anyOf": [
+        {"type": "null"},
+        {"$ref": "#/definitions/input_identity"}
+      ]
+    },
+    "software_identity": {
+      "anyOf": [
+        {"type": "null"},
+        {"$ref": "#/definitions/software_identity"}
+      ]
+    },
+    "thresholds": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "max_peak_rss_mib",
+        "max_output_bytes",
+        "max_dropped_inputs",
+        "minimum_free_space_bytes"
+      ],
+      "properties": {
+        "max_peak_rss_mib": {"type": "number", "exclusiveMinimum": 0},
+        "max_output_bytes": {"type": "integer", "minimum": 1},
+        "max_dropped_inputs": {"type": "integer", "minimum": 0},
+        "minimum_free_space_bytes": {"type": "integer", "minimum": 1}
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "wall_time_sec",
+        "iterations_completed",
+        "iterations_failed",
+        "peak_rss_mib",
+        "output_size_bytes",
+        "dropped_inputs_total",
+        "minimum_free_space_bytes"
+      ],
+      "properties": {
+        "wall_time_sec": {"type": "number", "minimum": 0},
+        "iterations_completed": {"type": "integer", "minimum": 0},
+        "iterations_failed": {"type": "integer", "minimum": 0},
+        "peak_rss_mib": {"type": "number", "minimum": 0},
+        "output_size_bytes": {"type": "integer", "minimum": 0},
+        "dropped_inputs_total": {"type": "integer", "minimum": 0},
+        "minimum_free_space_bytes": {
+          "type": ["integer", "null"],
+          "minimum": 0
+        }
+      }
+    },
+    "checks": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "target_duration_reached": {"type": "boolean"},
+        "all_iterations_succeeded": {"type": "boolean"},
+        "peak_rss_within_budget": {"type": "boolean"},
+        "output_size_within_budget": {"type": "boolean"},
+        "dropped_inputs_within_budget": {"type": "boolean"},
+        "free_space_within_budget": {"type": "boolean"},
+        "provenance_recorded": {"type": "boolean"}
+      }
+    },
+    "telemetry_samples": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "captured_at",
+          "iteration_id",
+          "iteration_elapsed_sec",
+          "soak_elapsed_sec",
+          "output_size_bytes",
+          "free_space_bytes"
+        ],
+        "properties": {
+          "captured_at": {"type": "string", "format": "date-time"},
+          "iteration_id": {
+            "type": "string",
+            "pattern": "^iteration-[0-9]{4,}$"
+          },
+          "iteration_elapsed_sec": {"type": "number", "minimum": 0},
+          "soak_elapsed_sec": {"type": "number", "minimum": 0},
+          "output_size_bytes": {"type": "integer", "minimum": 0},
+          "free_space_bytes": {"type": "integer", "minimum": 0}
+        }
+      }
+    },
+    "iterations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "started_at",
+          "completed_at",
+          "command",
+          "command_display",
+          "exit_code",
+          "wall_time_sec",
+          "peak_rss_mib",
+          "output_size_bytes",
+          "free_space_bytes",
+          "dropped_input_signatures",
+          "log",
+          "time_report"
+        ],
+        "properties": {
+          "id": {"type": "string", "pattern": "^iteration-[0-9]{4,}$"},
+          "started_at": {"type": "string", "format": "date-time"},
+          "completed_at": {"type": "string", "format": "date-time"},
+          "command": {
+            "type": "array",
+            "minItems": 1,
+            "items": {"type": "string"}
+          },
+          "command_display": {"type": "string", "minLength": 1},
+          "exit_code": {"type": "integer"},
+          "wall_time_sec": {"type": "number", "minimum": 0},
+          "peak_rss_mib": {"type": "number", "minimum": 0},
+          "output_size_bytes": {"type": "integer", "minimum": 0},
+          "free_space_bytes": {"type": "integer", "minimum": 0},
+          "dropped_input_signatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["message_filter", "scan_drop", "queue_overflow"],
+            "properties": {
+              "message_filter": {"type": "integer", "minimum": 0},
+              "scan_drop": {"type": "integer", "minimum": 0},
+              "queue_overflow": {"type": "integer", "minimum": 0}
+            }
+          },
+          "log": {"type": "string", "minLength": 1},
+          "time_report": {"type": "string", "minLength": 1}
+        }
+      }
+    }
+  },
+  "definitions": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "hardware": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "machine_id",
+        "architecture",
+        "cpu_model",
+        "logical_cpu_count",
+        "memory_total_kb",
+        "kernel_release",
+        "os_release"
+      ],
+      "properties": {
+        "machine_id": {"$ref": "#/definitions/sha256"},
+        "architecture": {"type": "string"},
+        "cpu_model": {"type": "string"},
+        "logical_cpu_count": {"type": ["integer", "null"], "minimum": 1},
+        "memory_total_kb": {"type": ["integer", "null"], "minimum": 1},
+        "kernel_release": {"type": "string"},
+        "os_release": {"type": "string"}
+      }
+    },
+    "harness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "product_version",
+        "git_commit",
+        "git_dirty",
+        "ros_distro",
+        "runner_sha256",
+        "product_cli_sha256"
+      ],
+      "properties": {
+        "product_version": {"type": "string", "minLength": 1},
+        "git_commit": {
+          "type": ["string", "null"],
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "git_dirty": {"type": ["boolean", "null"]},
+        "ros_distro": {"type": ["string", "null"]},
+        "runner_sha256": {"$ref": "#/definitions/sha256"},
+        "product_cli_sha256": {"$ref": "#/definitions/sha256"}
+      }
+    },
+    "file_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "size_bytes", "sha256"],
+      "properties": {
+        "path": {"type": "string", "minLength": 1},
+        "size_bytes": {"type": "integer", "minimum": 0},
+        "sha256": {"$ref": "#/definitions/sha256"}
+      }
+    },
+    "input_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "bag_path",
+        "metadata_path",
+        "metadata_size_bytes",
+        "metadata_sha256",
+        "storage_identifier",
+        "storage_files",
+        "identity_algorithm"
+      ],
+      "properties": {
+        "bag_path": {"type": "string"},
+        "metadata_path": {"type": "string"},
+        "metadata_size_bytes": {"type": "integer", "minimum": 0},
+        "metadata_sha256": {"$ref": "#/definitions/sha256"},
+        "storage_identifier": {"type": ["string", "null"]},
+        "storage_files": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/file_identity"}
+        },
+        "identity_algorithm": {"const": "sha256"}
+      }
+    },
+    "software_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "product_version",
+        "git_commit",
+        "git_dirty",
+        "package_versions",
+        "ros_distro"
+      ],
+      "properties": {
+        "product_version": {"type": "string", "minLength": 1},
+        "git_commit": {
+          "type": ["string", "null"],
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "git_dirty": {"type": ["boolean", "null"]},
+        "package_versions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "ros_distro": {"type": ["string", "null"]}
+      }
+    }
+  }
+}

--- a/graph_based_slam/test/test_docs_entrypoints.py
+++ b/graph_based_slam/test/test_docs_entrypoints.py
@@ -530,7 +530,8 @@ def test_docs_cover_autoware_and_release_gate_keywords():
     assert '--hardware-label' in reliability_doc
     assert '--max-peak-rss-mib' in reliability_doc
     assert '--telemetry-interval-secs' in reliability_doc
-    assert 'soak-report-v2.schema.json' in reliability_doc
+    assert 'soak-report-v3.schema.json' in reliability_doc
+    assert 'provenance_recorded' in reliability_doc
     assert 'schema v1 remains published' in reliability_doc
     assert 'SIGKILL' in reliability_doc
     assert 'GNU `time`' in reliability_doc

--- a/graph_based_slam/test/test_mid360_robot_readiness_cli.py
+++ b/graph_based_slam/test/test_mid360_robot_readiness_cli.py
@@ -32,6 +32,7 @@
 from __future__ import annotations
 
 import json
+import math
 from pathlib import Path
 import subprocess
 import sys
@@ -51,6 +52,25 @@ def _write_metadata(
     tf: bool = True,
 ) -> Path:
     bag_dir = tmp_path / 'mid360_robot_bag'
+    if pointcloud and imu:
+        command = [
+            sys.executable,
+            str(REPO_ROOT / 'scripts' / 'generate_mid360_robot_sample_bag.py'),
+            str(bag_dir),
+            '--duration-sec',
+            '5',
+            '--pointcloud-rate-hz',
+            '10',
+            '--imu-rate-hz',
+            '100',
+            '--point-count',
+            '16',
+        ]
+        if not tf:
+            command.append('--no-tf-static')
+        subprocess.run(command, check=True, cwd=REPO_ROOT)
+        return bag_dir
+
     bag_dir.mkdir()
     topics = []
     if pointcloud:
@@ -134,8 +154,16 @@ def test_readiness_pass_writes_report_and_manifest(tmp_path: Path):
     assert result.returncode == 0
     assert report['status'] == 'PASS'
     assert report['counts']['fail'] == 0
-    assert report['bag_diagnostics']['topics']['pointcloud']['metadata_rate_hz'] == 10.0
-    assert report['bag_diagnostics']['topics']['imu']['metadata_rate_hz'] == 100.0
+    assert math.isclose(
+        report['bag_diagnostics']['topics']['pointcloud']['metadata_rate_hz'],
+        10.0,
+        rel_tol=0.02,
+    )
+    assert math.isclose(
+        report['bag_diagnostics']['topics']['imu']['metadata_rate_hz'],
+        100.0,
+        rel_tol=0.02,
+    )
     assert any(check['id'] == 'pointcloud_metadata_rate' for check in report['checks'])
     assert (output_dir / 'mid360_robot_readiness.md').is_file()
     assert (output_dir / 'mid360_robot_run_plan.json').is_file()

--- a/graph_based_slam/test/test_mid360_robot_runbook_smoke.py
+++ b/graph_based_slam/test/test_mid360_robot_runbook_smoke.py
@@ -32,6 +32,7 @@
 from __future__ import annotations
 
 import json
+import math
 from pathlib import Path
 import subprocess
 
@@ -63,8 +64,16 @@ def test_mid360_robot_runbook_smoke_script(tmp_path: Path):
 
     assert 'MID-360 robot runbook smoke: PASS' in result.stdout
     assert readiness['status'] == 'PASS'
-    assert readiness['bag_diagnostics']['topics']['pointcloud']['metadata_rate_hz'] == 10.0
-    assert readiness['bag_diagnostics']['topics']['imu']['metadata_rate_hz'] == 100.0
+    assert math.isclose(
+        readiness['bag_diagnostics']['topics']['pointcloud']['metadata_rate_hz'],
+        10.0,
+        rel_tol=0.02,
+    )
+    assert math.isclose(
+        readiness['bag_diagnostics']['topics']['imu']['metadata_rate_hz'],
+        100.0,
+        rel_tol=0.02,
+    )
     assert (output_dir / 'mid360_robot_session_dashboard.html').is_file()
     assert (output_dir / 'mid360_robot_field_session.json').is_file()
     assert (output_dir / 'mid360_robot_run_plan.json').is_file()

--- a/lidarslam/test/test_map_soak_runner.py
+++ b/lidarslam/test/test_map_soak_runner.py
@@ -53,9 +53,36 @@ SOAK = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(SOAK)
 
 
-def _schema_v2() -> dict:
+def _schema_v3() -> dict:
     return json.loads(
-        (ROOT / 'docs/schemas/soak-report-v2.schema.json').read_text()
+        (ROOT / 'docs/schemas/soak-report-v3.schema.json').read_text()
+    )
+
+
+def _provenance() -> tuple[dict, dict]:
+    return (
+        {
+            'bag_path': '/data/bag',
+            'metadata_path': '/data/bag/metadata.yaml',
+            'metadata_size_bytes': 42,
+            'metadata_sha256': 'a' * 64,
+            'storage_identifier': 'sqlite3',
+            'storage_files': [
+                {
+                    'path': 'bag_0.db3',
+                    'size_bytes': 1024,
+                    'sha256': 'b' * 64,
+                },
+            ],
+            'identity_algorithm': 'sha256',
+        },
+        {
+            'product_version': '0.9.0',
+            'git_commit': 'c' * 40,
+            'git_dirty': False,
+            'package_versions': {'lidarslam': '0.9.0'},
+            'ros_distro': 'jazzy',
+        },
     )
 
 
@@ -136,6 +163,44 @@ def test_drop_counters_are_explicit_and_conservative():
     }
 
 
+def test_machine_fingerprint_is_stable_and_does_not_expose_private_ids():
+    first = SOAK.capture_machine_fingerprint()
+    second = SOAK.capture_machine_fingerprint()
+
+    assert first == second
+    assert len(first['machine_id']) == 64
+    assert first['logical_cpu_count'] > 0
+    assert 'private_identifiers' not in first
+
+
+def test_iteration_provenance_requires_succeeded_product_manifest(tmp_path):
+    run_dir = tmp_path / 'run'
+    run_dir.mkdir()
+    input_identity, software_identity = _provenance()
+    manifest = {
+        'status': 'succeeded',
+        'input': input_identity,
+        'software': software_identity,
+    }
+    (run_dir / SOAK.RUN_MANIFEST_NAME).write_text(
+        json.dumps(manifest),
+        encoding='utf-8',
+    )
+
+    assert SOAK._load_iteration_provenance(run_dir) == (
+        input_identity,
+        software_identity,
+    )
+
+    manifest['status'] = 'failed'
+    (run_dir / SOAK.RUN_MANIFEST_NAME).write_text(
+        json.dumps(manifest),
+        encoding='utf-8',
+    )
+    with pytest.raises(ValueError, match='not succeeded'):
+        SOAK._load_iteration_provenance(run_dir)
+
+
 def test_successful_soak_writes_schema_valid_threshold_evidence(tmp_path):
     args = _args(tmp_path)
     ticks = iter([0.0, 0.0, 3600.0, 3600.0])
@@ -160,7 +225,7 @@ def test_successful_soak_writes_schema_valid_threshold_evidence(tmp_path):
         assert checkpoint['status'] == 'running'
         assert checkpoint['active_iteration_id'] == 'iteration-0001'
         assert len(checkpoint['telemetry_samples']) == 2
-        jsonschema.validate(checkpoint, _schema_v2())
+        jsonschema.validate(checkpoint, _schema_v3())
         log_path.write_text('', encoding='utf-8')
         time_path.write_text('fake GNU time evidence\n', encoding='utf-8')
         return (
@@ -173,6 +238,7 @@ def test_successful_soak_writes_schema_valid_threshold_evidence(tmp_path):
         args,
         clock=lambda: next(ticks),
         run_iteration=fake_iteration,
+        load_iteration_provenance=lambda run_dir: _provenance(),
     )
 
     assert exit_code == 0
@@ -183,8 +249,12 @@ def test_successful_soak_writes_schema_valid_threshold_evidence(tmp_path):
     assert report['telemetry_samples'][1]['output_size_bytes'] == 1024
     assert report['active_iteration_id'] is None
     assert all(report['checks'].values())
+    assert report['input_identity']['metadata_sha256'] == 'a' * 64
+    assert report['software_identity']['git_commit'] == 'c' * 40
+    assert report['hardware']['machine_id']
+    assert report['harness']['runner_sha256']
     saved = json.loads((Path(args.output_root) / SOAK.REPORT_NAME).read_text())
-    schema = _schema_v2()
+    schema = _schema_v3()
     jsonschema.Draft7Validator.check_schema(schema)
     jsonschema.validate(saved, schema)
 
@@ -223,6 +293,87 @@ def test_failed_iteration_stops_and_preserves_failed_report(tmp_path):
     assert report['checks']['target_duration_reached'] is False
     assert report['checks']['all_iterations_succeeded'] is False
     assert (Path(args.output_root) / SOAK.REPORT_NAME).is_file()
+
+
+def test_successful_iteration_without_product_provenance_fails_soak(tmp_path):
+    args = _args(tmp_path)
+    ticks = iter([0.0, 0.0, 12.0])
+
+    def fake_iteration(
+        command,
+        log_path,
+        time_path,
+        *,
+        telemetry_interval_sec,
+        on_sample,
+    ):
+        on_sample(0.0)
+        return (
+            0,
+            {'wall_time_sec': 12.0, 'peak_rss_mib': 64.0, 'exit_code': 0},
+            {'message_filter': 0, 'scan_drop': 0, 'queue_overflow': 0},
+        )
+
+    exit_code, report = SOAK.run_soak(
+        args,
+        clock=lambda: next(ticks),
+        run_iteration=fake_iteration,
+    )
+
+    assert exit_code == 1
+    assert report['status'] == 'failed'
+    assert report['checks']['provenance_recorded'] is False
+    assert 'lacks run_manifest.json' in report['last_error']
+    jsonschema.validate(report, _schema_v3())
+
+
+def test_changed_input_identity_between_iterations_fails_soak(tmp_path):
+    args = _args(tmp_path)
+    ticks = iter([0.0, 0.0, 10.0, 10.0, 20.0])
+    calls = []
+
+    def fake_iteration(
+        command,
+        log_path,
+        time_path,
+        *,
+        telemetry_interval_sec,
+        on_sample,
+    ):
+        calls.append(command)
+        on_sample(0.0)
+        return (
+            0,
+            {'wall_time_sec': 10.0, 'peak_rss_mib': 64.0, 'exit_code': 0},
+            {'message_filter': 0, 'scan_drop': 0, 'queue_overflow': 0},
+        )
+
+    provenance_calls = 0
+
+    def changing_provenance(run_dir):
+        nonlocal provenance_calls
+        provenance_calls += 1
+        input_identity, software_identity = _provenance()
+        if provenance_calls == 2:
+            input_identity = {
+                **input_identity,
+                'metadata_sha256': 'd' * 64,
+            }
+        return input_identity, software_identity
+
+    exit_code, report = SOAK.run_soak(
+        args,
+        clock=lambda: next(ticks),
+        run_iteration=fake_iteration,
+        load_iteration_provenance=changing_provenance,
+    )
+
+    assert exit_code == 1
+    assert len(calls) == 2
+    assert report['status'] == 'failed'
+    assert report['metrics']['iterations_completed'] == 1
+    assert report['metrics']['iterations_failed'] == 1
+    assert 'input identity differs' in report['last_error']
 
 
 def test_telemetry_failure_becomes_terminal_evidence(tmp_path):
@@ -279,6 +430,7 @@ def test_resource_budget_failure_stops_before_another_iteration(tmp_path):
         args,
         clock=lambda: next(ticks),
         run_iteration=over_budget_iteration,
+        load_iteration_provenance=lambda run_dir: _provenance(),
     )
 
     assert exit_code == 1
@@ -483,7 +635,7 @@ def test_sigterm_is_terminal_and_returns_143(tmp_path):
     assert report['metrics']['iterations_failed'] == 1
     assert report['active_iteration_id'] is None
     assert report['last_error'].endswith('interrupted by SIGTERM')
-    jsonschema.validate(report, _schema_v2())
+    jsonschema.validate(report, _schema_v3())
 
 
 def test_existing_output_is_never_overwritten(tmp_path):

--- a/scripts/run_map_soak.py
+++ b/scripts/run_map_soak.py
@@ -34,10 +34,12 @@ from __future__ import annotations
 
 import argparse
 from datetime import datetime, timezone
+import hashlib
 import json
 import math
 import os
 from pathlib import Path
+import platform
 import re
 import shlex
 import shutil
@@ -53,9 +55,10 @@ PROFILE_DURATIONS = {
     'eight-hour': 28800.0,
 }
 REPORT_NAME = 'soak_report.json'
+RUN_MANIFEST_NAME = 'run_manifest.json'
 SCHEMA_URI = (
     'https://rsasaki0109.github.io/lidar_slam_ros2/'
-    'schemas/soak-report-v2.schema.json'
+    'schemas/soak-report-v3.schema.json'
 )
 DEFAULT_TELEMETRY_INTERVAL_SECS = 30.0
 PROCESS_SHUTDOWN_GRACE_SECS = 10.0
@@ -85,6 +88,175 @@ def _raise_termination_signal(signum: int, _frame: object) -> None:
 
 def _utc_now() -> str:
     return datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open('rb') as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b''):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def capture_machine_fingerprint() -> dict[str, object]:
+    """Capture a stable non-secret identity and public capacity fields."""
+    private_values = []
+    for path in (
+        Path('/etc/machine-id'),
+        Path('/sys/class/dmi/id/product_uuid'),
+        Path('/sys/class/dmi/id/board_serial'),
+    ):
+        try:
+            value = path.read_text(encoding='utf-8').strip()
+        except OSError:
+            value = ''
+        if value:
+            private_values.append(value)
+
+    cpu_fields = {}
+    try:
+        for line in Path('/proc/cpuinfo').read_text(
+            encoding='utf-8',
+            errors='replace',
+        ).splitlines():
+            if ':' not in line:
+                continue
+            name, value = line.split(':', 1)
+            normalized_name = name.strip().lower()
+            if normalized_name in ('model name', 'model', 'hardware'):
+                cpu_fields.setdefault(normalized_name, value.strip())
+    except OSError:
+        pass
+    cpu_model = next(
+        (
+            cpu_fields[name]
+            for name in ('model name', 'model', 'hardware')
+            if cpu_fields.get(name)
+        ),
+        '',
+    )
+
+    memory_total_kb = None
+    try:
+        for line in Path('/proc/meminfo').read_text(
+            encoding='utf-8',
+            errors='replace',
+        ).splitlines():
+            if line.startswith('MemTotal:'):
+                memory_total_kb = int(line.split()[1])
+                break
+    except (OSError, ValueError, IndexError):
+        pass
+
+    os_release = ''
+    try:
+        for line in Path('/etc/os-release').read_text(
+            encoding='utf-8',
+            errors='replace',
+        ).splitlines():
+            if line.startswith('PRETTY_NAME='):
+                os_release = line.split('=', 1)[1].strip().strip('"')
+                break
+    except OSError:
+        pass
+
+    hardware = {
+        'architecture': platform.machine(),
+        'cpu_model': cpu_model,
+        'logical_cpu_count': os.cpu_count(),
+        'memory_total_kb': memory_total_kb,
+    }
+    environment = {
+        'kernel_release': platform.release(),
+        'os_release': os_release,
+    }
+    identity_payload = {
+        'private_identifiers': private_values,
+        **hardware,
+    }
+    machine_id = hashlib.sha256(
+        json.dumps(
+            identity_payload,
+            sort_keys=True,
+            separators=(',', ':'),
+        ).encode('utf-8')
+    ).hexdigest()
+    return {'machine_id': machine_id, **hardware, **environment}
+
+
+def _git_state() -> dict[str, object]:
+    try:
+        commit = subprocess.run(
+            ['git', 'rev-parse', 'HEAD'],
+            cwd=ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        status = subprocess.run(
+            ['git', 'status', '--porcelain', '--untracked-files=no'],
+            cwd=ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return {'git_commit': None, 'git_dirty': None}
+    return {
+        'git_commit': commit.stdout.strip() if commit.returncode == 0 else None,
+        'git_dirty': (
+            bool(status.stdout.strip()) if status.returncode == 0 else None
+        ),
+    }
+
+
+def _harness_identity(cli: Path) -> dict[str, object]:
+    version_path = ROOT / 'VERSION'
+    if not version_path.is_file():
+        raise ValueError(f'product VERSION not found: {version_path}')
+    product_version = version_path.read_text(encoding='utf-8').strip()
+    if not product_version:
+        raise ValueError(f'product VERSION is empty: {version_path}')
+    return {
+        'product_version': product_version,
+        **_git_state(),
+        'ros_distro': os.environ.get('ROS_DISTRO'),
+        'runner_sha256': _sha256(Path(__file__).resolve()),
+        'product_cli_sha256': _sha256(cli),
+    }
+
+
+def _load_iteration_provenance(
+    run_dir: Path,
+) -> tuple[dict[str, object], dict[str, object]]:
+    manifest_path = run_dir / RUN_MANIFEST_NAME
+    if not manifest_path.is_file():
+        raise ValueError(
+            f'successful iteration lacks {RUN_MANIFEST_NAME}: {run_dir}'
+        )
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding='utf-8'))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(
+            f'iteration manifest is not readable JSON: {manifest_path}: {exc}'
+        ) from exc
+    if not isinstance(manifest, dict):
+        raise ValueError(f'iteration manifest root is not an object: {manifest_path}')
+    if manifest.get('status') != 'succeeded':
+        raise ValueError(
+            'successful iteration manifest status is not succeeded: '
+            f'{manifest.get("status")!r}'
+        )
+    input_identity = manifest.get('input')
+    software_identity = manifest.get('software')
+    if not isinstance(input_identity, dict) or not isinstance(
+        software_identity,
+        dict,
+    ):
+        raise ValueError(
+            'successful iteration manifest lacks input/software identity'
+        )
+    return input_identity, software_identity
 
 
 def _positive_finite(value: str) -> float:
@@ -216,6 +388,10 @@ def evaluate_report(report: dict[str, object]) -> dict[str, bool]:
             and metrics['minimum_free_space_bytes']
             >= thresholds['minimum_free_space_bytes']
         ),
+        'provenance_recorded': (
+            report['input_identity'] is not None
+            and report['software_identity'] is not None
+        ),
     }
 
 
@@ -311,7 +487,7 @@ def _terminate_process_group(process: subprocess.Popen) -> None:
 
 def _initial_report(args: argparse.Namespace, cli: Path) -> dict[str, object]:
     return {
-        'schema_version': 2,
+        'schema_version': 3,
         'schema_uri': SCHEMA_URI,
         'status': 'running',
         'last_error': None,
@@ -322,9 +498,13 @@ def _initial_report(args: argparse.Namespace, cli: Path) -> dict[str, object]:
         'started_at': _utc_now(),
         'completed_at': None,
         'hardware_label': args.hardware_label,
+        'hardware': capture_machine_fingerprint(),
+        'harness': _harness_identity(cli),
         'bag_path': str(Path(args.bag).expanduser().resolve()),
         'map_profile': args.map_profile,
         'product_cli': str(cli),
+        'input_identity': None,
+        'software_identity': None,
         'thresholds': {
             'max_peak_rss_mib': args.max_peak_rss_mib,
             'max_output_bytes': math.ceil(args.max_output_gib * 1024**3),
@@ -356,6 +536,10 @@ def run_soak(
         ...,
         tuple[int, dict[str, float | int], dict[str, int]],
     ] = _run_iteration,
+    load_iteration_provenance: Callable[
+        [Path],
+        tuple[dict[str, object], dict[str, object]],
+    ] = _load_iteration_provenance,
 ) -> tuple[int, dict[str, object]]:
     """Execute iterations until the profile duration or first failed run."""
     cli = _resolve_cli(args.cli)
@@ -440,6 +624,26 @@ def run_soak(
                 telemetry_interval_sec=args.telemetry_interval_secs,
                 on_sample=record_sample,
             )
+            if return_code == 0:
+                input_identity, software_identity = load_iteration_provenance(
+                    run_dir,
+                )
+                if (
+                    report['input_identity'] is not None
+                    and report['input_identity'] != input_identity
+                ):
+                    raise ValueError(
+                        f'{iteration_id} input identity differs from prior iterations'
+                    )
+                if (
+                    report['software_identity'] is not None
+                    and report['software_identity'] != software_identity
+                ):
+                    raise ValueError(
+                        f'{iteration_id} software identity differs from prior iterations'
+                    )
+                report['input_identity'] = input_identity
+                report['software_identity'] = software_identity
         except (KeyboardInterrupt, TerminationSignal) as exc:
             if isinstance(exc, TerminationSignal):
                 runner_exit_code = 128 + exc.signum


### PR DESCRIPTION
## Summary
- publish soak report schema v3 with a non-secret machine fingerprint and harness checksums
- pin exact input and software provenance from successful product run manifests across every soak iteration
- fail closed when provenance is missing or changes during a one-hour/eight-hour run
- replace remaining MID-360 metadata-only positive fixtures with real synthetic rosbag2 records and tolerant metadata-rate assertions

## Why
The named-hardware soak gate previously recorded only an operator-provided label. That was insufficient to audit which CPU, memory capacity, OS/kernel, ROS distribution, product revision, CLI, and bag identity produced an archived result.

## User impact
Operators keep the same `run_map_soak.py` command. New reports use schema v3 and a passing report now requires `provenance_recorded`. Published v1 and v2 schemas remain immutable for archived evidence.

## Validation
- 1425 passed, 13 skipped, 2 unrelated existing benchmark-profile tests deselected
- focused MID-360 and soak tests: 28 passed
- MkDocs strict build passed
- soak v1/v2/v3 JSON Schemas validated with Draft 7
- ament_flake8 and git diff --check passed
- installed product layout generated stable runner/CLI SHA-256 and machine fingerprint
