### PR TITLE
Bound soak iterations with timeout evidence

### DIFF
--- a/docs/operational-reliability.md
+++ b/docs/operational-reliability.md
@@ -77,15 +77,18 @@ python3 scripts/run_map_soak.py /data/bags/mid360 \
   --max-peak-rss-mib 4096 \
   --max-output-gib 40 \
   --max-dropped-inputs 0 \
+  --max-iteration-secs 300 \
+  --min-free-space-gib 100 \
   --telemetry-interval-secs 30
 ```
 
 The harness repeats complete, collision-safe map runs until the profile
 duration is reached. Each iteration records its command, exit code, GNU time
 wall duration and peak RSS, output size, remaining free space, console log and
-raw GNU time report. While an iteration is still running, it samples free
-space and cumulative output size every 30 seconds by default. The interval
-must be positive and cannot exceed 60 seconds.
+raw GNU time report. `--max-iteration-secs` is a required positive wall-time
+budget for one complete map run. While an iteration is still running, the
+harness samples free space and cumulative output size every 30 seconds by
+default. The interval must be positive and cannot exceed 60 seconds.
 
 Every sample is appended to `telemetry_samples` and atomically checkpoints
 `soak_report.json`. If free space falls below `--min-free-space-gib` or output
@@ -94,18 +97,23 @@ group with `SIGTERM` and a bounded `SIGKILL` fallback, then attempts to
 finalize a failed report. The last successful sample remains available even
 when the iteration never produces normal GNU time evidence.
 
-- [`soak-report-v3.schema.json`](schemas/soak-report-v3.schema.json) — current;
-  adds a non-secret machine fingerprint, harness revision and checksums, and
-  the exact input/software identity copied from each successful product run;
+- [`soak-report-v4.schema.json`](schemas/soak-report-v4.schema.json) — current;
+  adds the required per-iteration wall-time threshold, maximum observed
+  duration, and `iteration_duration_within_budget` terminal check;
+- [`soak-report-v3.schema.json`](schemas/soak-report-v3.schema.json)
+  — published compatibility schema containing a non-secret machine
+  fingerprint, harness revision and checksums, and the exact input/software
+  identity copied from each successful product run;
 - [`soak-report-v2.schema.json`](schemas/soak-report-v2.schema.json)
   — published compatibility schema for periodic telemetry reports;
 - [`soak-report-v1.schema.json`](schemas/soak-report-v1.schema.json)
   — published compatibility schema for iteration-only reports.
 
-The schema v1 remains published, and schema v2 remains immutable, so archived
-reports retain a resolvable contract.
+Schemas v1, v2 and v3 remain published and immutable, so archived reports
+retain a resolvable contract.
 
-A passing v3 report requires `provenance_recorded`. The first successful
+A passing v4 report requires both `provenance_recorded` and
+`iteration_duration_within_budget`. The first successful
 iteration fixes the input and software identities for the whole soak; any
 later iteration with a different identity terminates the run as failed. The
 machine ID is a SHA-256 fingerprint: private machine identifiers contribute
@@ -113,9 +121,15 @@ to stability but are never written to the report. Hostnames, usernames and
 network addresses are not collected.
 
 Operator `Ctrl-C` and service `SIGTERM` use the same process-group cleanup and
-return `130` and `143`, respectively. Their terminal v3 report has
+return `130` and `143`, respectively. Their terminal v4 report has
 `interrupted` status. If the filesystem refuses the final atomic update, the
 last successfully written running-state sample remains as recovery evidence.
+
+When an iteration reaches `--max-iteration-secs`, the harness records a final
+sample, terminates and reaps the whole timed process group, and writes a
+terminal v4 report with `failed` status. This converts a live player or mapper
+stall into bounded, machine-readable evidence instead of allowing a named
+one-hour or eight-hour profile to hang indefinitely.
 
 The drop counter is a conservative count of documented console signatures for
 message-filter drops, scan drops and queue/buffer overflow. One line can match
@@ -132,8 +146,9 @@ the termination coverage:
 
 - timestamp reversal detection against real rosbag records before launch;
 - execute and archive the one-hour and eight-hour soak profiles on named
-  release hardware; the harness, machine-readable thresholds and v3
-  provenance are automated, but real-duration evidence is not yet recorded;
+  release hardware; the harness, machine-readable thresholds, v4 provenance
+  and per-iteration timeout are automated, but real-duration evidence is not
+  yet recorded;
 - a bounded-filesystem live exhaustion test in the scheduled real-data
   environment;
 - output migration tooling and last-known-good rollback instructions.

--- a/docs/operational-reliability.md
+++ b/docs/operational-reliability.md
@@ -51,8 +51,9 @@ manifest is not replaced by truncated JSON.
 
 The runner starts the delegated workflow in a separate POSIX process group.
 For `SIGINT` and `SIGTERM`, it forwards the same signal to the entire group,
-waits up to ten seconds, then sends `SIGKILL` if the group leader has not
-exited. The leader is always reaped before terminal post-processing begins.
+waits up to ten seconds for the process group to disappear, then sends
+`SIGKILL` to any surviving group members. The leader is always reaped before
+terminal post-processing begins.
 
 An external `SIGKILL`, kernel panic, power loss, or storage device loss cannot
 be converted into a terminal manifest by user-space code. Such a run may
@@ -126,10 +127,10 @@ return `130` and `143`, respectively. Their terminal v4 report has
 last successfully written running-state sample remains as recovery evidence.
 
 When an iteration reaches `--max-iteration-secs`, the harness records a final
-sample, terminates and reaps the whole timed process group, and writes a
-terminal v4 report with `failed` status. This converts a live player or mapper
-stall into bounded, machine-readable evidence instead of allowing a named
-one-hour or eight-hour profile to hang indefinitely.
+sample, terminates the whole timed process group, reaps its leader, and writes
+a terminal v4 report with `failed` status. This converts a live player or
+mapper stall into bounded, machine-readable evidence instead of allowing a
+named one-hour or eight-hour profile to hang indefinitely.
 
 The drop counter is a conservative count of documented console signatures for
 message-filter drops, scan drops and queue/buffer overflow. One line can match

--- a/docs/operational-reliability.md
+++ b/docs/operational-reliability.md
@@ -51,9 +51,9 @@ manifest is not replaced by truncated JSON.
 
 The runner starts the delegated workflow in a separate POSIX process group.
 For `SIGINT` and `SIGTERM`, it forwards the same signal to the entire group,
-waits up to ten seconds for the process group to disappear, then sends
-`SIGKILL` to any surviving group members. The leader is always reaped before
-terminal post-processing begins.
+waits up to ten seconds for the group leader, then sends `SIGKILL` to any
+remaining group members even if the leader exited first. The leader is always
+reaped before terminal post-processing begins.
 
 An external `SIGKILL`, kernel panic, power loss, or storage device loss cannot
 be converted into a terminal manifest by user-space code. Such a run may

--- a/docs/roadmap/v0.9.md
+++ b/docs/roadmap/v0.9.md
@@ -9,7 +9,8 @@
 > MID-360 real-data E2E gate landed; deterministic storage refusal and
 > disk-exhaustion failure injection, fixed-duration soak profiles, and
 > periodic in-iteration storage telemetry and auditable machine/input/software
-> provenance landed, while named-hardware executions and scheduled live
+> provenance plus a bounded per-iteration timeout landed, while
+> named-hardware executions and scheduled live
 > exhaustion remain)**.
 > This roadmap
 > turns the existing benchmark-heavy map-authoring stack into a product-level

--- a/docs/schemas/soak-report-v4.schema.json
+++ b/docs/schemas/soak-report-v4.schema.json
@@ -1,0 +1,357 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://rsasaki0109.github.io/lidar_slam_ros2/schemas/soak-report-v4.schema.json",
+  "title": "lidarslam_ros2 soak report v4",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "schema_uri",
+    "status",
+    "last_error",
+    "active_iteration_id",
+    "profile",
+    "target_duration_sec",
+    "telemetry_interval_sec",
+    "started_at",
+    "completed_at",
+    "hardware_label",
+    "hardware",
+    "harness",
+    "bag_path",
+    "map_profile",
+    "product_cli",
+    "input_identity",
+    "software_identity",
+    "thresholds",
+    "metrics",
+    "checks",
+    "telemetry_samples",
+    "iterations"
+  ],
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "status": {"enum": ["passed", "failed", "interrupted"]}
+        }
+      },
+      "then": {
+        "properties": {
+          "checks": {
+            "required": [
+              "target_duration_reached",
+              "all_iterations_succeeded",
+              "peak_rss_within_budget",
+              "output_size_within_budget",
+              "dropped_inputs_within_budget",
+              "free_space_within_budget",
+              "iteration_duration_within_budget",
+              "provenance_recorded"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "status": {"const": "passed"}
+        }
+      },
+      "then": {
+        "properties": {
+          "input_identity": {"$ref": "#/definitions/input_identity"},
+          "software_identity": {"$ref": "#/definitions/software_identity"}
+        }
+      }
+    }
+  ],
+  "properties": {
+    "schema_version": {"const": 4},
+    "schema_uri": {
+      "const": "https://rsasaki0109.github.io/lidar_slam_ros2/schemas/soak-report-v4.schema.json"
+    },
+    "status": {"enum": ["running", "passed", "failed", "interrupted"]},
+    "last_error": {"type": ["string", "null"]},
+    "active_iteration_id": {
+      "type": ["string", "null"],
+      "pattern": "^iteration-[0-9]{4,}$"
+    },
+    "profile": {"enum": ["one-hour", "eight-hour"]},
+    "target_duration_sec": {"enum": [3600.0, 28800.0]},
+    "telemetry_interval_sec": {
+      "type": "number",
+      "exclusiveMinimum": 0,
+      "maximum": 60
+    },
+    "started_at": {"type": "string", "format": "date-time"},
+    "completed_at": {"type": ["string", "null"], "format": "date-time"},
+    "hardware_label": {"type": "string", "minLength": 1},
+    "hardware": {"$ref": "#/definitions/hardware"},
+    "harness": {"$ref": "#/definitions/harness"},
+    "bag_path": {"type": "string", "minLength": 1},
+    "map_profile": {"type": ["string", "null"]},
+    "product_cli": {"type": "string", "minLength": 1},
+    "input_identity": {
+      "anyOf": [
+        {"type": "null"},
+        {"$ref": "#/definitions/input_identity"}
+      ]
+    },
+    "software_identity": {
+      "anyOf": [
+        {"type": "null"},
+        {"$ref": "#/definitions/software_identity"}
+      ]
+    },
+    "thresholds": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "max_peak_rss_mib",
+        "max_output_bytes",
+        "max_dropped_inputs",
+        "max_iteration_sec",
+        "minimum_free_space_bytes"
+      ],
+      "properties": {
+        "max_peak_rss_mib": {"type": "number", "exclusiveMinimum": 0},
+        "max_output_bytes": {"type": "integer", "minimum": 1},
+        "max_dropped_inputs": {"type": "integer", "minimum": 0},
+        "max_iteration_sec": {"type": "number", "exclusiveMinimum": 0},
+        "minimum_free_space_bytes": {"type": "integer", "minimum": 1}
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "wall_time_sec",
+        "iterations_completed",
+        "iterations_failed",
+        "peak_rss_mib",
+        "output_size_bytes",
+        "dropped_inputs_total",
+        "max_observed_iteration_sec",
+        "minimum_free_space_bytes"
+      ],
+      "properties": {
+        "wall_time_sec": {"type": "number", "minimum": 0},
+        "iterations_completed": {"type": "integer", "minimum": 0},
+        "iterations_failed": {"type": "integer", "minimum": 0},
+        "peak_rss_mib": {"type": "number", "minimum": 0},
+        "output_size_bytes": {"type": "integer", "minimum": 0},
+        "dropped_inputs_total": {"type": "integer", "minimum": 0},
+        "max_observed_iteration_sec": {"type": "number", "minimum": 0},
+        "minimum_free_space_bytes": {
+          "type": ["integer", "null"],
+          "minimum": 0
+        }
+      }
+    },
+    "checks": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "target_duration_reached": {"type": "boolean"},
+        "all_iterations_succeeded": {"type": "boolean"},
+        "peak_rss_within_budget": {"type": "boolean"},
+        "output_size_within_budget": {"type": "boolean"},
+        "dropped_inputs_within_budget": {"type": "boolean"},
+        "free_space_within_budget": {"type": "boolean"},
+        "iteration_duration_within_budget": {"type": "boolean"},
+        "provenance_recorded": {"type": "boolean"}
+      }
+    },
+    "telemetry_samples": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "captured_at",
+          "iteration_id",
+          "iteration_elapsed_sec",
+          "soak_elapsed_sec",
+          "output_size_bytes",
+          "free_space_bytes"
+        ],
+        "properties": {
+          "captured_at": {"type": "string", "format": "date-time"},
+          "iteration_id": {
+            "type": "string",
+            "pattern": "^iteration-[0-9]{4,}$"
+          },
+          "iteration_elapsed_sec": {"type": "number", "minimum": 0},
+          "soak_elapsed_sec": {"type": "number", "minimum": 0},
+          "output_size_bytes": {"type": "integer", "minimum": 0},
+          "free_space_bytes": {"type": "integer", "minimum": 0}
+        }
+      }
+    },
+    "iterations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "started_at",
+          "completed_at",
+          "command",
+          "command_display",
+          "exit_code",
+          "wall_time_sec",
+          "peak_rss_mib",
+          "output_size_bytes",
+          "free_space_bytes",
+          "dropped_input_signatures",
+          "log",
+          "time_report"
+        ],
+        "properties": {
+          "id": {"type": "string", "pattern": "^iteration-[0-9]{4,}$"},
+          "started_at": {"type": "string", "format": "date-time"},
+          "completed_at": {"type": "string", "format": "date-time"},
+          "command": {
+            "type": "array",
+            "minItems": 1,
+            "items": {"type": "string"}
+          },
+          "command_display": {"type": "string", "minLength": 1},
+          "exit_code": {"type": "integer"},
+          "wall_time_sec": {"type": "number", "minimum": 0},
+          "peak_rss_mib": {"type": "number", "minimum": 0},
+          "output_size_bytes": {"type": "integer", "minimum": 0},
+          "free_space_bytes": {"type": "integer", "minimum": 0},
+          "dropped_input_signatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["message_filter", "scan_drop", "queue_overflow"],
+            "properties": {
+              "message_filter": {"type": "integer", "minimum": 0},
+              "scan_drop": {"type": "integer", "minimum": 0},
+              "queue_overflow": {"type": "integer", "minimum": 0}
+            }
+          },
+          "log": {"type": "string", "minLength": 1},
+          "time_report": {"type": "string", "minLength": 1}
+        }
+      }
+    }
+  },
+  "definitions": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "hardware": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "machine_id",
+        "architecture",
+        "cpu_model",
+        "logical_cpu_count",
+        "memory_total_kb",
+        "kernel_release",
+        "os_release"
+      ],
+      "properties": {
+        "machine_id": {"$ref": "#/definitions/sha256"},
+        "architecture": {"type": "string"},
+        "cpu_model": {"type": "string"},
+        "logical_cpu_count": {"type": ["integer", "null"], "minimum": 1},
+        "memory_total_kb": {"type": ["integer", "null"], "minimum": 1},
+        "kernel_release": {"type": "string"},
+        "os_release": {"type": "string"}
+      }
+    },
+    "harness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "product_version",
+        "git_commit",
+        "git_dirty",
+        "ros_distro",
+        "runner_sha256",
+        "product_cli_sha256"
+      ],
+      "properties": {
+        "product_version": {"type": "string", "minLength": 1},
+        "git_commit": {
+          "type": ["string", "null"],
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "git_dirty": {"type": ["boolean", "null"]},
+        "ros_distro": {"type": ["string", "null"]},
+        "runner_sha256": {"$ref": "#/definitions/sha256"},
+        "product_cli_sha256": {"$ref": "#/definitions/sha256"}
+      }
+    },
+    "file_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "size_bytes", "sha256"],
+      "properties": {
+        "path": {"type": "string", "minLength": 1},
+        "size_bytes": {"type": "integer", "minimum": 0},
+        "sha256": {"$ref": "#/definitions/sha256"}
+      }
+    },
+    "input_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "bag_path",
+        "metadata_path",
+        "metadata_size_bytes",
+        "metadata_sha256",
+        "storage_identifier",
+        "storage_files",
+        "identity_algorithm"
+      ],
+      "properties": {
+        "bag_path": {"type": "string"},
+        "metadata_path": {"type": "string"},
+        "metadata_size_bytes": {"type": "integer", "minimum": 0},
+        "metadata_sha256": {"$ref": "#/definitions/sha256"},
+        "storage_identifier": {"type": ["string", "null"]},
+        "storage_files": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/file_identity"}
+        },
+        "identity_algorithm": {"const": "sha256"}
+      }
+    },
+    "software_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "product_version",
+        "git_commit",
+        "git_dirty",
+        "package_versions",
+        "ros_distro"
+      ],
+      "properties": {
+        "product_version": {"type": "string", "minLength": 1},
+        "git_commit": {
+          "type": ["string", "null"],
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "git_dirty": {"type": ["boolean", "null"]},
+        "package_versions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "ros_distro": {"type": ["string", "null"]}
+      }
+    }
+  }
+}

--- a/graph_based_slam/test/test_docs_entrypoints.py
+++ b/graph_based_slam/test/test_docs_entrypoints.py
@@ -529,10 +529,13 @@ def test_docs_cover_autoware_and_release_gate_keywords():
     assert '--soak-profile one-hour' in reliability_doc
     assert '--hardware-label' in reliability_doc
     assert '--max-peak-rss-mib' in reliability_doc
+    assert '--max-iteration-secs' in reliability_doc
     assert '--telemetry-interval-secs' in reliability_doc
+    assert 'soak-report-v4.schema.json' in reliability_doc
     assert 'soak-report-v3.schema.json' in reliability_doc
+    assert 'iteration_duration_within_budget' in reliability_doc
     assert 'provenance_recorded' in reliability_doc
-    assert 'schema v1 remains published' in reliability_doc
+    assert 'Schemas v1, v2 and v3 remain published' in reliability_doc
     assert 'SIGKILL' in reliability_doc
     assert 'GNU `time`' in reliability_doc
     assert '3,600 or 28,800 seconds' in reliability_doc

--- a/lidarslam/test/test_map_soak_runner.py
+++ b/lidarslam/test/test_map_soak_runner.py
@@ -539,6 +539,50 @@ def test_iteration_callback_failure_terminates_process_group(tmp_path):
     assert time.monotonic() - started < 2.0
 
 
+def test_process_group_cleanup_kills_survivor_after_leader_exits(
+    monkeypatch,
+):
+    child_code = (
+        'import signal, time; '
+        'signal.signal(signal.SIGTERM, signal.SIG_IGN); '
+        'time.sleep(30)'
+    )
+    leader_code = (
+        'import subprocess, sys, time; '
+        f'child = subprocess.Popen([sys.executable, "-c", {child_code!r}]); '
+        'time.sleep(0.1); '
+        'print(child.pid, flush=True); '
+        'time.sleep(30)'
+    )
+    process = SOAK.subprocess.Popen(
+        [sys.executable, '-c', leader_code],
+        start_new_session=True,
+        stdout=SOAK.subprocess.PIPE,
+        text=True,
+    )
+    child_pid = int(process.stdout.readline())
+    monkeypatch.setattr(SOAK, 'PROCESS_SHUTDOWN_GRACE_SECS', 0.05)
+
+    try:
+        SOAK._terminate_process_group(process)
+        child_stat = Path(f'/proc/{child_pid}/stat')
+        deadline = time.monotonic() + 1.0
+        while child_stat.exists() and time.monotonic() < deadline:
+            if child_stat.read_text().split()[2] == 'Z':
+                break
+            time.sleep(0.01)
+        assert (
+            not child_stat.exists()
+            or child_stat.read_text().split()[2] == 'Z'
+        )
+    finally:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        process.wait()
+
+
 def test_real_iteration_emits_periodic_and_final_samples(tmp_path):
     log_path = tmp_path / 'iteration.log'
     time_path = tmp_path / 'iteration.time'

--- a/lidarslam/test/test_map_soak_runner.py
+++ b/lidarslam/test/test_map_soak_runner.py
@@ -53,9 +53,9 @@ SOAK = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(SOAK)
 
 
-def _schema_v3() -> dict:
+def _schema_v4() -> dict:
     return json.loads(
-        (ROOT / 'docs/schemas/soak-report-v3.schema.json').read_text()
+        (ROOT / 'docs/schemas/soak-report-v4.schema.json').read_text()
     )
 
 
@@ -106,6 +106,7 @@ def _args(tmp_path: Path, **overrides) -> argparse.Namespace:
         'max_peak_rss_mib': 512.0,
         'max_output_gib': 1.0,
         'max_dropped_inputs': 0,
+        'max_iteration_secs': 300.0,
         'min_free_space_gib': 0.01,
         'telemetry_interval_secs': 30.0,
     }
@@ -211,9 +212,11 @@ def test_successful_soak_writes_schema_valid_threshold_evidence(tmp_path):
         time_path,
         *,
         telemetry_interval_sec,
+        max_iteration_sec,
         on_sample,
     ):
         assert telemetry_interval_sec == 30.0
+        assert max_iteration_sec == 300.0
         on_sample(0.0)
         run_dir = Path(command[command.index('--output-dir') + 1])
         run_dir.mkdir(parents=True)
@@ -225,7 +228,7 @@ def test_successful_soak_writes_schema_valid_threshold_evidence(tmp_path):
         assert checkpoint['status'] == 'running'
         assert checkpoint['active_iteration_id'] == 'iteration-0001'
         assert len(checkpoint['telemetry_samples']) == 2
-        jsonschema.validate(checkpoint, _schema_v3())
+        jsonschema.validate(checkpoint, _schema_v4())
         log_path.write_text('', encoding='utf-8')
         time_path.write_text('fake GNU time evidence\n', encoding='utf-8')
         return (
@@ -254,7 +257,7 @@ def test_successful_soak_writes_schema_valid_threshold_evidence(tmp_path):
     assert report['hardware']['machine_id']
     assert report['harness']['runner_sha256']
     saved = json.loads((Path(args.output_root) / SOAK.REPORT_NAME).read_text())
-    schema = _schema_v3()
+    schema = _schema_v4()
     jsonschema.Draft7Validator.check_schema(schema)
     jsonschema.validate(saved, schema)
 
@@ -269,6 +272,7 @@ def test_failed_iteration_stops_and_preserves_failed_report(tmp_path):
         time_path,
         *,
         telemetry_interval_sec,
+        max_iteration_sec,
         on_sample,
     ):
         on_sample(0.0)
@@ -305,6 +309,7 @@ def test_successful_iteration_without_product_provenance_fails_soak(tmp_path):
         time_path,
         *,
         telemetry_interval_sec,
+        max_iteration_sec,
         on_sample,
     ):
         on_sample(0.0)
@@ -324,7 +329,7 @@ def test_successful_iteration_without_product_provenance_fails_soak(tmp_path):
     assert report['status'] == 'failed'
     assert report['checks']['provenance_recorded'] is False
     assert 'lacks run_manifest.json' in report['last_error']
-    jsonschema.validate(report, _schema_v3())
+    jsonschema.validate(report, _schema_v4())
 
 
 def test_changed_input_identity_between_iterations_fails_soak(tmp_path):
@@ -338,6 +343,7 @@ def test_changed_input_identity_between_iterations_fails_soak(tmp_path):
         time_path,
         *,
         telemetry_interval_sec,
+        max_iteration_sec,
         on_sample,
     ):
         calls.append(command)
@@ -386,6 +392,7 @@ def test_telemetry_failure_becomes_terminal_evidence(tmp_path):
         time_path,
         *,
         telemetry_interval_sec,
+        max_iteration_sec,
         on_sample,
     ):
         raise ValueError('GNU time report lacks fields')
@@ -416,6 +423,7 @@ def test_resource_budget_failure_stops_before_another_iteration(tmp_path):
         time_path,
         *,
         telemetry_interval_sec,
+        max_iteration_sec,
         on_sample,
     ):
         on_sample(0.0)
@@ -457,6 +465,7 @@ def test_periodic_low_space_sample_aborts_and_preserves_evidence(
         time_path,
         *,
         telemetry_interval_sec,
+        max_iteration_sec,
         on_sample,
     ):
         on_sample(4.0)
@@ -489,6 +498,7 @@ def test_periodic_output_growth_aborts_before_iteration_finishes(tmp_path):
         time_path,
         *,
         telemetry_interval_sec,
+        max_iteration_sec,
         on_sample,
     ):
         run_dir = Path(command[command.index('--output-dir') + 1])
@@ -520,6 +530,7 @@ def test_iteration_callback_failure_terminates_process_group(tmp_path):
             log_path,
             time_path,
             telemetry_interval_sec=0.01,
+            max_iteration_sec=1.0,
             on_sample=lambda elapsed: (_ for _ in ()).throw(
                 RuntimeError('stop now')
             ),
@@ -538,6 +549,7 @@ def test_real_iteration_emits_periodic_and_final_samples(tmp_path):
         log_path,
         time_path,
         telemetry_interval_sec=0.02,
+        max_iteration_sec=1.0,
         on_sample=samples.append,
     )
 
@@ -552,6 +564,63 @@ def test_real_iteration_emits_periodic_and_final_samples(tmp_path):
     assert samples[0] == 0.0
     assert len(samples) >= 3
     assert samples == sorted(samples)
+
+
+def test_real_iteration_timeout_terminates_process_group(tmp_path):
+    log_path = tmp_path / 'iteration.log'
+    time_path = tmp_path / 'iteration.time'
+    samples = []
+    started = time.monotonic()
+
+    with pytest.raises(TimeoutError, match='max_iteration_sec'):
+        SOAK._run_iteration(
+            [sys.executable, '-c', 'import time; time.sleep(30)'],
+            log_path,
+            time_path,
+            telemetry_interval_sec=30.0,
+            max_iteration_sec=0.05,
+            on_sample=samples.append,
+        )
+
+    assert time.monotonic() - started < 2.0
+    assert samples[0] == 0.0
+    assert samples[-1] >= 0.05
+
+
+def test_iteration_timeout_is_terminal_failed_evidence(tmp_path):
+    args = _args(tmp_path, max_iteration_secs=10.0)
+    ticks = iter([0.0, 0.0, 10.1])
+
+    def timed_out_iteration(
+        command,
+        log_path,
+        time_path,
+        *,
+        telemetry_interval_sec,
+        max_iteration_sec,
+        on_sample,
+    ):
+        assert max_iteration_sec == 10.0
+        on_sample(10.1)
+        raise TimeoutError(
+            'iteration exceeded max_iteration_sec (10)'
+        )
+
+    exit_code, report = SOAK.run_soak(
+        args,
+        clock=lambda: next(ticks),
+        run_iteration=timed_out_iteration,
+    )
+
+    assert exit_code == 1
+    assert report['status'] == 'failed'
+    assert report['metrics']['iterations_failed'] == 1
+    assert report['metrics']['max_observed_iteration_sec'] == 10.1
+    assert report['checks']['iteration_duration_within_budget'] is False
+    assert report['last_error'].endswith(
+        'iteration exceeded max_iteration_sec (10)'
+    )
+    jsonschema.validate(report, _schema_v4())
 
 
 def test_real_iteration_forwards_sigterm_and_restores_handler(tmp_path):
@@ -571,6 +640,7 @@ def test_real_iteration_forwards_sigterm_and_restores_handler(tmp_path):
                 log_path,
                 time_path,
                 telemetry_interval_sec=0.02,
+                max_iteration_sec=1.0,
                 on_sample=lambda elapsed: None,
             )
     finally:
@@ -591,6 +661,7 @@ def test_keyboard_interrupt_is_terminal_and_returns_130(tmp_path):
         time_path,
         *,
         telemetry_interval_sec,
+        max_iteration_sec,
         on_sample,
     ):
         on_sample(1.0)
@@ -619,6 +690,7 @@ def test_sigterm_is_terminal_and_returns_143(tmp_path):
         time_path,
         *,
         telemetry_interval_sec,
+        max_iteration_sec,
         on_sample,
     ):
         on_sample(1.0)
@@ -635,7 +707,7 @@ def test_sigterm_is_terminal_and_returns_143(tmp_path):
     assert report['metrics']['iterations_failed'] == 1
     assert report['active_iteration_id'] is None
     assert report['last_error'].endswith('interrupted by SIGTERM')
-    jsonschema.validate(report, _schema_v3())
+    jsonschema.validate(report, _schema_v4())
 
 
 def test_existing_output_is_never_overwritten(tmp_path):

--- a/scripts/run_map_soak.py
+++ b/scripts/run_map_soak.py
@@ -484,22 +484,26 @@ def _run_iteration(
 
 
 def _terminate_process_group(process: subprocess.Popen) -> None:
-    """Stop and reap the timed command and every descendant in its session."""
-    if process.poll() is not None:
-        return
+    """Stop the timed process group and reap its leader."""
+    process_group_id = process.pid
     try:
-        os.killpg(process.pid, signal.SIGTERM)
+        os.killpg(process_group_id, signal.SIGTERM)
     except ProcessLookupError:
         pass
-    try:
-        process.wait(timeout=PROCESS_SHUTDOWN_GRACE_SECS)
-        return
-    except subprocess.TimeoutExpired:
-        pass
-    try:
-        os.killpg(process.pid, signal.SIGKILL)
-    except ProcessLookupError:
-        pass
+
+    deadline = time.monotonic() + PROCESS_SHUTDOWN_GRACE_SECS
+    while time.monotonic() < deadline:
+        process.poll()
+        try:
+            os.killpg(process_group_id, 0)
+        except ProcessLookupError:
+            break
+        time.sleep(0.01)
+    else:
+        try:
+            os.killpg(process_group_id, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
     process.wait()
 
 

--- a/scripts/run_map_soak.py
+++ b/scripts/run_map_soak.py
@@ -491,19 +491,14 @@ def _terminate_process_group(process: subprocess.Popen) -> None:
     except ProcessLookupError:
         pass
 
-    deadline = time.monotonic() + PROCESS_SHUTDOWN_GRACE_SECS
-    while time.monotonic() < deadline:
-        process.poll()
-        try:
-            os.killpg(process_group_id, 0)
-        except ProcessLookupError:
-            break
-        time.sleep(0.01)
-    else:
-        try:
-            os.killpg(process_group_id, signal.SIGKILL)
-        except ProcessLookupError:
-            pass
+    try:
+        process.wait(timeout=PROCESS_SHUTDOWN_GRACE_SECS)
+    except subprocess.TimeoutExpired:
+        pass
+    try:
+        os.killpg(process_group_id, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
     process.wait()
 
 

--- a/scripts/run_map_soak.py
+++ b/scripts/run_map_soak.py
@@ -58,7 +58,7 @@ REPORT_NAME = 'soak_report.json'
 RUN_MANIFEST_NAME = 'run_manifest.json'
 SCHEMA_URI = (
     'https://rsasaki0109.github.io/lidar_slam_ros2/'
-    'schemas/soak-report-v3.schema.json'
+    'schemas/soak-report-v4.schema.json'
 )
 DEFAULT_TELEMETRY_INTERVAL_SECS = 30.0
 PROCESS_SHUTDOWN_GRACE_SECS = 10.0
@@ -388,6 +388,10 @@ def evaluate_report(report: dict[str, object]) -> dict[str, bool]:
             and metrics['minimum_free_space_bytes']
             >= thresholds['minimum_free_space_bytes']
         ),
+        'iteration_duration_within_budget': (
+            metrics['max_observed_iteration_sec']
+            <= thresholds['max_iteration_sec']
+        ),
         'provenance_recorded': (
             report['input_identity'] is not None
             and report['software_identity'] is not None
@@ -414,6 +418,7 @@ def _run_iteration(
     time_path: Path,
     *,
     telemetry_interval_sec: float,
+    max_iteration_sec: float,
     on_sample: Callable[[float], None],
     clock: Callable[[], float] = time.monotonic,
 ) -> tuple[int, dict[str, float | int], dict[str, int]]:
@@ -445,13 +450,26 @@ def _run_iteration(
             on_sample(0.0)
             last_sample_elapsed = 0.0
             while True:
+                elapsed = clock() - iteration_start
+                remaining = max_iteration_sec - elapsed
+                if remaining <= 0:
+                    on_sample(elapsed)
+                    raise TimeoutError(
+                        'iteration exceeded max_iteration_sec '
+                        f'({max_iteration_sec:g})'
+                    )
                 try:
-                    process.wait(timeout=telemetry_interval_sec)
+                    process.wait(timeout=min(telemetry_interval_sec, remaining))
                     break
                 except subprocess.TimeoutExpired:
                     elapsed = clock() - iteration_start
                     on_sample(elapsed)
                     last_sample_elapsed = elapsed
+                    if elapsed >= max_iteration_sec:
+                        raise TimeoutError(
+                            'iteration exceeded max_iteration_sec '
+                            f'({max_iteration_sec:g})'
+                        )
             final_elapsed = clock() - iteration_start
             if last_sample_elapsed is None or final_elapsed > last_sample_elapsed:
                 on_sample(final_elapsed)
@@ -487,7 +505,7 @@ def _terminate_process_group(process: subprocess.Popen) -> None:
 
 def _initial_report(args: argparse.Namespace, cli: Path) -> dict[str, object]:
     return {
-        'schema_version': 3,
+        'schema_version': 4,
         'schema_uri': SCHEMA_URI,
         'status': 'running',
         'last_error': None,
@@ -509,6 +527,7 @@ def _initial_report(args: argparse.Namespace, cli: Path) -> dict[str, object]:
             'max_peak_rss_mib': args.max_peak_rss_mib,
             'max_output_bytes': math.ceil(args.max_output_gib * 1024**3),
             'max_dropped_inputs': args.max_dropped_inputs,
+            'max_iteration_sec': args.max_iteration_secs,
             'minimum_free_space_bytes': math.ceil(
                 args.min_free_space_gib * 1024**3
             ),
@@ -520,6 +539,7 @@ def _initial_report(args: argparse.Namespace, cli: Path) -> dict[str, object]:
             'peak_rss_mib': 0.0,
             'output_size_bytes': 0,
             'dropped_inputs_total': 0,
+            'max_observed_iteration_sec': 0.0,
             'minimum_free_space_bytes': None,
         },
         'checks': {},
@@ -598,6 +618,10 @@ def run_soak(
             })
             metrics = report['metrics']
             metrics['wall_time_sec'] = soak_elapsed_sec
+            metrics['max_observed_iteration_sec'] = max(
+                metrics['max_observed_iteration_sec'],
+                iteration_elapsed_sec,
+            )
             metrics['output_size_bytes'] = output_size
             previous_minimum = metrics['minimum_free_space_bytes']
             metrics['minimum_free_space_bytes'] = (
@@ -622,6 +646,7 @@ def run_soak(
                 log_path,
                 time_path,
                 telemetry_interval_sec=args.telemetry_interval_secs,
+                max_iteration_sec=args.max_iteration_secs,
                 on_sample=record_sample,
             )
             if return_code == 0:
@@ -701,6 +726,10 @@ def run_soak(
             metrics['peak_rss_mib'],
             resources['peak_rss_mib'],
         )
+        metrics['max_observed_iteration_sec'] = max(
+            metrics['max_observed_iteration_sec'],
+            resources['wall_time_sec'],
+        )
         metrics['output_size_bytes'] = directory_size_bytes(runs_dir)
         metrics['dropped_inputs_total'] += dropped_total
         previous_minimum = metrics['minimum_free_space_bytes']
@@ -721,6 +750,7 @@ def run_soak(
             'output_size_within_budget',
             'dropped_inputs_within_budget',
             'free_space_within_budget',
+            'iteration_duration_within_budget',
         )
         failed_budget = next(
             (name for name in budget_checks if not report['checks'][name]),
@@ -770,6 +800,15 @@ def parse_args() -> argparse.Namespace:
         '--max-dropped-inputs',
         type=_nonnegative_int,
         required=True,
+    )
+    parser.add_argument(
+        '--max-iteration-secs',
+        type=_positive_finite,
+        required=True,
+        help=(
+            'Terminate the timed process group when one complete map run '
+            'exceeds this wall-time budget'
+        ),
     )
     parser.add_argument(
         '--min-free-space-gib',


### PR DESCRIPTION
## What changed

- require a positive `--max-iteration-secs` budget for every named soak run
- terminate and reap the full timed process group when an iteration stalls
- publish soak report schema v4 with the configured threshold, maximum observed duration, and a fail-closed `iteration_duration_within_budget` check
- add real-process timeout coverage, terminal-report validation, and updated operator/roadmap documentation

## Why

A real one-hour soak attempt completed 33 iterations and then stalled indefinitely during iteration 34 while the player and mapper remained alive. The existing harness bounded disk and output growth but did not bound one iteration wall time, so a nominally fixed-duration soak could hang forever.

## Impact

Operators must now choose an explicit per-iteration wall-time budget. A stall becomes a bounded failed v4 report with its final telemetry sample preserved instead of requiring manual interruption.

## Validation

- `python3 -m pytest -q lidarslam/test/test_map_soak_runner.py graph_based_slam/test/test_docs_entrypoints.py` — 32 passed
- broad graph_based_slam/lidarslam pytest suite — 1427 passed, 13 skipped, 2 known unrelated deselected
- `python3 -m mkdocs build --strict` — passed
- `git diff --check` — passed
