### PR TITLE
Document named-hardware real-data soak evidence

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,11 +240,13 @@ jobs:
         shell: bash
         run: |
           rm -rf release_bundle
-          mkdir -p release_bundle/docs/releases release_bundle/docs/social release_bundle/docs/assets release_bundle/docs/roadmap release_bundle/configs/real_data_e2e release_bundle/output release_bundle/lidarslam/images
+          mkdir -p release_bundle/docs/releases release_bundle/docs/social release_bundle/docs/assets release_bundle/docs/evidence release_bundle/docs/roadmap release_bundle/docs/schemas release_bundle/configs/real_data_e2e release_bundle/output release_bundle/lidarslam/images
           cp README.md CHANGELOG.md CONTRIBUTING.md RELEASING.md VERSION mkdocs.yml SECURITY.md SUPPORT.md CODE_OF_CONDUCT.md GOVERNANCE.md CITATION.cff release_bundle/
           cp docs/index.md docs/getting-started.md docs/product-contract.md docs/golden-path-cli.md docs/operational-reliability.md docs/real-data-e2e.md docs/distribution.md docs/rosdistro-release.md docs/autoware-map-authoring.md docs/autoware-foxglove.md docs/autoware-quickstart.md docs/workflows.md docs/benchmarking.md docs/comparison.md release_bundle/docs/
           cp configs/real_data_e2e/driving_slam_mid360_v1.json release_bundle/configs/real_data_e2e/
+          cp docs/evidence/real-data-soak-2026-07-28.md docs/evidence/real-data-soak-2026-07-28.json release_bundle/docs/evidence/
           cp docs/roadmap/v0.9.md release_bundle/docs/roadmap/
+          cp docs/schemas/*.json release_bundle/docs/schemas/
           cp -r docs/assets/. release_bundle/docs/assets/
           cp docs/social/autoware_map_authoring_post_v0.2.2.md release_bundle/docs/social/
           cp lidarslam/images/autoware_map_loader_proof.png release_bundle/lidarslam/images/

--- a/docs/evidence/real-data-soak-2026-07-28.json
+++ b/docs/evidence/real-data-soak-2026-07-28.json
@@ -1,0 +1,121 @@
+{
+  "evidence_version": 1,
+  "recorded_at": "2026-07-28",
+  "scope": "Named-hardware real-data soak evidence for the golden-path map runner",
+  "schema_uri": "../schemas/soak-report-v4.schema.json",
+  "hardware": {
+    "label": "sasaki-laptop-i5-1145G7-32GiB-jazzy-native",
+    "architecture": "x86_64",
+    "cpu_model": "11th Gen Intel(R) Core(TM) i5-1145G7 @ 2.60GHz",
+    "logical_cpu_count": 8,
+    "memory_total_kb": 32461332,
+    "os_release": "Ubuntu 24.04.4 LTS",
+    "kernel_release": "6.17.0-35-generic"
+  },
+  "software": {
+    "git_commit": "0ec55575ffc16eb008e9f24bd6c6f24700bf2f8a",
+    "git_dirty": false,
+    "product_version": "0.6.0",
+    "ros_distro": "jazzy",
+    "map_profile": "pointcloud_gnss_smoke",
+    "runner_sha256": "e9dc617e9d9bafe2348408b7bd90422538ca3048d08b3e662d8a3d038ce83657",
+    "product_cli_sha256": "1ae79c5d00313199388382a2625f3b75105241bd8c903f0763562e3cc44ccdf3"
+  },
+  "input": {
+    "description": "Istanbul bag4 uncompressed rosbag2",
+    "storage_identifier": "sqlite3",
+    "metadata_sha256": "1b9be8f18b0cbbb369c3f38549ac4c3bb7f8bb895ef417c0fbe57a0a926d2f71",
+    "metadata_size_bytes": 13238,
+    "storage_files": [
+      {
+        "path": "istanbul_bag4_0.db3",
+        "sha256": "e833a6ae89d5f0ccf0ee8d4bdde3232e7c49d04a8342db452b4ad743ef43b185",
+        "size_bytes": 1061437440
+      }
+    ]
+  },
+  "runs": [
+    {
+      "profile": "one-hour",
+      "status": "passed",
+      "started_at": "2026-07-27T21:05:50.934118Z",
+      "completed_at": "2026-07-27T22:06:29.689661Z",
+      "report_sha256": "25a677d0944fec42bc63421c67a3a055993afd6d44a1991dfe5b49b973f35a3e",
+      "checks": {
+        "all_iterations_succeeded": true,
+        "dropped_inputs_within_budget": true,
+        "free_space_within_budget": true,
+        "iteration_duration_within_budget": true,
+        "output_size_within_budget": true,
+        "peak_rss_within_budget": true,
+        "provenance_recorded": true,
+        "target_duration_reached": true
+      },
+      "metrics": {
+        "iterations_completed": 86,
+        "iterations_failed": 0,
+        "wall_time_sec": 3638.6452590459958,
+        "max_observed_iteration_sec": 43.16417389898561,
+        "peak_rss_mib": 209.3203125,
+        "output_size_bytes": 1889888063,
+        "minimum_free_space_bytes": 85689724928,
+        "dropped_inputs_total": 0,
+        "telemetry_samples": 258
+      },
+      "thresholds": {
+        "max_iteration_sec": 300.0,
+        "max_peak_rss_mib": 1024.0,
+        "max_output_bytes": 5368709120,
+        "minimum_free_space_bytes": 64424509440,
+        "max_dropped_inputs": 0
+      }
+    },
+    {
+      "profile": "eight-hour",
+      "status": "passed",
+      "started_at": "2026-07-27T22:07:07.879111Z",
+      "completed_at": "2026-07-28T06:07:42.690131Z",
+      "report_sha256": "67aace0d8521178357bdc3264acdeca57e35c414ecf9dd516b29cf9612eb1361",
+      "checks": {
+        "all_iterations_succeeded": true,
+        "dropped_inputs_within_budget": true,
+        "free_space_within_budget": true,
+        "iteration_duration_within_budget": true,
+        "output_size_within_budget": true,
+        "peak_rss_within_budget": true,
+        "provenance_recorded": true,
+        "target_duration_reached": true
+      },
+      "metrics": {
+        "iterations_completed": 671,
+        "iterations_failed": 0,
+        "wall_time_sec": 28834.114774872083,
+        "max_observed_iteration_sec": 45.73242361890152,
+        "peak_rss_mib": 210.87109375,
+        "output_size_bytes": 14553359036,
+        "minimum_free_space_bytes": 70752927744,
+        "dropped_inputs_total": 0,
+        "telemetry_samples": 2013
+      },
+      "thresholds": {
+        "max_iteration_sec": 300.0,
+        "max_peak_rss_mib": 1024.0,
+        "max_output_bytes": 32212254720,
+        "minimum_free_space_bytes": 42949672960,
+        "max_dropped_inputs": 0
+      }
+    }
+  ],
+  "verification": {
+    "schema_validated": true,
+    "same_clean_provenance_for_both_runs": true,
+    "input_hashes_match_for_both_runs": true,
+    "scoped_processes_remaining_after_eight_hour_run": 0,
+    "evidence_worktree_clean_after_eight_hour_run": true
+  },
+  "limitations": [
+    "This evidence covers one named amd64 machine, ROS 2 Jazzy, one input identity, and one map profile.",
+    "It is not a universal hardware, sensor, map-quality, or Humble performance guarantee.",
+    "The compact ledger records report hashes and audited metrics; full reports and per-iteration artifacts are retained outside the source repository."
+  ]
+}

--- a/docs/evidence/real-data-soak-2026-07-28.md
+++ b/docs/evidence/real-data-soak-2026-07-28.md
@@ -1,0 +1,78 @@
+# Named-hardware real-data soak evidence — 2026-07-28
+
+This ledger records the first completed one-hour and eight-hour executions of
+the v4 soak contract on named hardware. It is evidence for the Phase 3
+resource-measurement gate, not a universal performance claim. The compact
+machine-readable record is
+[`real-data-soak-2026-07-28.json`](real-data-soak-2026-07-28.json).
+
+## Fixed identities
+
+| Item | Recorded identity |
+| --- | --- |
+| Hardware | `sasaki-laptop-i5-1145G7-32GiB-jazzy-native`; Intel i5-1145G7, 8 logical CPUs, 32 GiB, x86_64 |
+| OS / ROS | Ubuntu 24.04.4 LTS, kernel 6.17.0-35-generic, ROS 2 Jazzy |
+| Product and harness | clean commit `0ec55575ffc16eb008e9f24bd6c6f24700bf2f8a`, product 0.6.0 |
+| Map profile | `pointcloud_gnss_smoke` |
+| Bag metadata | SHA-256 `1b9be8f18b0cbbb369c3f38549ac4c3bb7f8bb895ef417c0fbe57a0a926d2f71` |
+| Bag storage | `istanbul_bag4_0.db3`, 1,061,437,440 bytes, SHA-256 `e833a6ae89d5f0ccf0ee8d4bdde3232e7c49d04a8342db452b4ad743ef43b185` |
+
+Both reports recorded the same clean software, harness and input identities.
+The full reports were validated against
+[`soak-report-v4.schema.json`](../schemas/soak-report-v4.schema.json).
+
+## Results
+
+| Profile | Result | Iterations | Wall time | Longest iteration | Peak RSS | Output | Minimum free | Drops |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| one-hour | PASS | 86 / 86 | 3,638.645 s | 43.164 s / 300 s | 209.320 MiB / 1,024 MiB | 1,889,888,063 B / 5 GiB | 85,689,724,928 B / 60 GiB | 0 / 0 |
+| eight-hour | PASS | 671 / 671 | 28,834.115 s | 45.732 s / 300 s | 210.871 MiB / 1,024 MiB | 14,553,359,036 B / 30 GiB | 70,752,927,744 B / 40 GiB | 0 / 0 |
+
+All eight terminal checks were `true` for both runs:
+`all_iterations_succeeded`, `dropped_inputs_within_budget`,
+`free_space_within_budget`, `iteration_duration_within_budget`,
+`output_size_within_budget`, `peak_rss_within_budget`,
+`provenance_recorded`, and `target_duration_reached`.
+
+The one-hour report SHA-256 is
+`25a677d0944fec42bc63421c67a3a055993afd6d44a1991dfe5b49b973f35a3e`.
+The eight-hour report SHA-256 is
+`67aace0d8521178357bdc3264acdeca57e35c414ecf9dd516b29cf9612eb1361`.
+After the eight-hour run, no process scoped to the evidence worktree remained
+and the detached evidence worktree was clean.
+
+## Reproduction template
+
+Use the exact input represented by the hashes above, a clean checkout of the
+recorded commit, and budgets appropriate for the target machine:
+
+```bash
+python3 scripts/run_map_soak.py /data/bags/istanbul_bag4_uncompressed \
+  --output-root /data/soak/one-hour \
+  --soak-profile one-hour \
+  --hardware-label '<non-secret-machine-label>' \
+  --map-profile pointcloud_gnss_smoke \
+  --max-peak-rss-mib 1024 \
+  --max-output-gib 5 \
+  --max-dropped-inputs 0 \
+  --max-iteration-secs 300 \
+  --min-free-space-gib 60 \
+  --telemetry-interval-secs 30
+
+python3 scripts/run_map_soak.py /data/bags/istanbul_bag4_uncompressed \
+  --output-root /data/soak/eight-hour \
+  --soak-profile eight-hour \
+  --hardware-label '<non-secret-machine-label>' \
+  --map-profile pointcloud_gnss_smoke \
+  --max-peak-rss-mib 1024 \
+  --max-output-gib 30 \
+  --max-dropped-inputs 0 \
+  --max-iteration-secs 300 \
+  --min-free-space-gib 40 \
+  --telemetry-interval-secs 30
+```
+
+Do not compare a rerun to these numbers unless its input hashes, product
+commit, map profile and resource budgets are recorded. A passing soak proves
+bounded operational behavior for this configuration; map geometry quality
+remains covered by the separate real-data and release gates.

--- a/docs/operational-reliability.md
+++ b/docs/operational-reliability.md
@@ -140,16 +140,31 @@ telemetry, or exceeded RSS/output/drop budget stops the profile immediately
 and preserves failed evidence. The duration gate passes only after the full
 3,600 or 28,800 seconds have elapsed.
 
+## Named-hardware execution evidence
+
+The one-hour and eight-hour profiles were executed consecutively on
+2026-07-27/28 using one clean merged revision, one fixed rosbag2 identity and
+the named Jazzy machine
+`sasaki-laptop-i5-1145G7-32GiB-jazzy-native`. Both v4 reports passed all eight
+terminal checks.
+
+| Profile | Iterations | Wall time | Longest iteration | Peak RSS | Output | Drops |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| one-hour | 86 / 86 | 3,638.645 s | 43.164 s / 300 s | 209.320 MiB / 1,024 MiB | 1,889,888,063 B / 5 GiB | 0 / 0 |
+| eight-hour | 671 / 671 | 28,834.115 s | 45.732 s / 300 s | 210.871 MiB / 1,024 MiB | 14,553,359,036 B / 30 GiB | 0 / 0 |
+
+The [auditable evidence ledger](evidence/real-data-soak-2026-07-28.md)
+records the exact commit, input and report hashes, thresholds, free-space
+minimums, reproduction commands and scope limitations. This closes the named
+one-hour/eight-hour execution row for this hardware/input/profile combination;
+it does not establish a universal performance or map-quality guarantee.
+
 ## Open Phase 3 gates
 
 The following readiness rows remain incomplete and must not be inferred from
 the termination coverage:
 
 - timestamp reversal detection against real rosbag records before launch;
-- execute and archive the one-hour and eight-hour soak profiles on named
-  release hardware; the harness, machine-readable thresholds, v4 provenance
-  and per-iteration timeout are automated, but real-duration evidence is not
-  yet recorded;
 - a bounded-filesystem live exhaustion test in the scheduled real-data
   environment;
 - output migration tooling and last-known-good rollback instructions.

--- a/docs/roadmap/v0.9.md
+++ b/docs/roadmap/v0.9.md
@@ -9,9 +9,9 @@
 > MID-360 real-data E2E gate landed; deterministic storage refusal and
 > disk-exhaustion failure injection, fixed-duration soak profiles, and
 > periodic in-iteration storage telemetry and auditable machine/input/software
-> provenance plus a bounded per-iteration timeout landed, while
-> named-hardware executions and scheduled live
-> exhaustion remain)**.
+> provenance plus a bounded per-iteration timeout landed; named-hardware
+> one-hour and eight-hour executions passed, while scheduled live exhaustion
+> remains)**.
 > This roadmap
 > turns the existing benchmark-heavy map-authoring stack into a product-level
 > OSS project. It does not replace the evidence-driven capability roadmaps;
@@ -136,6 +136,17 @@ Deliverables:
 - nightly fixed real-bag E2E with pinned input identity;
 - output schema compatibility tests and migration tooling;
 - release rollback and last-known-good image instructions.
+
+Named-hardware status (2026-07-28): the v4 one-hour and eight-hour profiles
+passed on the recorded Jazzy i5-1145G7 machine at clean merged commit
+`0ec55575ffc16eb008e9f24bd6c6f24700bf2f8a`. The one-hour run completed
+86/86 iterations in 3,638.645 seconds; the eight-hour run completed 671/671
+iterations in 28,834.115 seconds. Both had zero documented drop signatures
+and passed their wall-time, per-iteration, RSS, output, free-space and
+provenance checks. See the
+[named-hardware evidence ledger](../evidence/real-data-soak-2026-07-28.md).
+Timestamp reversal, scheduled live exhaustion, migration tooling and rollback
+instructions remain open, so Phase 3 remains in progress.
 
 Gate:
 

--- a/graph_based_slam/test/test_docs_entrypoints.py
+++ b/graph_based_slam/test/test_docs_entrypoints.py
@@ -31,6 +31,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 
@@ -65,6 +66,12 @@ PRODUCT_CONTRACT_DOC = REPO_ROOT / 'docs' / 'product-contract.md'
 GOLDEN_PATH_CLI_DOC = REPO_ROOT / 'docs' / 'golden-path-cli.md'
 DISTRIBUTION_DOC = REPO_ROOT / 'docs' / 'distribution.md'
 OPERATIONAL_RELIABILITY_DOC = REPO_ROOT / 'docs' / 'operational-reliability.md'
+SOAK_EVIDENCE_DOC = (
+    REPO_ROOT / 'docs' / 'evidence' / 'real-data-soak-2026-07-28.md'
+)
+SOAK_EVIDENCE_JSON = (
+    REPO_ROOT / 'docs' / 'evidence' / 'real-data-soak-2026-07-28.json'
+)
 REAL_DATA_E2E_DOC = REPO_ROOT / 'docs' / 'real-data-e2e.md'
 PREFLIGHT_SCHEMA = REPO_ROOT / 'docs' / 'schemas' / 'preflight-v2.schema.json'
 DIAGNOSIS_SCHEMA = REPO_ROOT / 'docs' / 'schemas' / 'diagnosis-v1.schema.json'
@@ -126,6 +133,8 @@ def test_docs_exist_and_are_linked_from_readme():
     assert GOLDEN_PATH_CLI_DOC.is_file()
     assert DISTRIBUTION_DOC.is_file()
     assert OPERATIONAL_RELIABILITY_DOC.is_file()
+    assert SOAK_EVIDENCE_DOC.is_file()
+    assert SOAK_EVIDENCE_JSON.is_file()
     assert REAL_DATA_E2E_DOC.is_file()
     assert PREFLIGHT_SCHEMA.is_file()
     assert DIAGNOSIS_SCHEMA.is_file()
@@ -346,6 +355,9 @@ def test_release_metadata_and_core_package_versions_match():
     assert 'docs/getting-started.md' in release_workflow
     assert 'docs/golden-path-cli.md' in release_workflow
     assert 'docs/operational-reliability.md' in release_workflow
+    assert 'docs/evidence/real-data-soak-2026-07-28.md' in release_workflow
+    assert 'docs/evidence/real-data-soak-2026-07-28.json' in release_workflow
+    assert 'docs/schemas/*.json' in release_workflow
     assert 'docs/real-data-e2e.md' in release_workflow
     assert 'configs/real_data_e2e/driving_slam_mid360_v1.json' in release_workflow
     assert 'docs/distribution.md' in release_workflow
@@ -391,6 +403,10 @@ def test_release_metadata_and_core_package_versions_match():
     assert 'Golden-path CLI: golden-path-cli.md' in mkdocs_config
     assert 'Distribution and installed CLI: distribution.md' in mkdocs_config
     assert 'Operational reliability: operational-reliability.md' in mkdocs_config
+    assert (
+        'Named-hardware soak evidence: evidence/real-data-soak-2026-07-28.md'
+        in mkdocs_config
+    )
     assert 'Pinned real-data E2E: real-data-e2e.md' in mkdocs_config
     assert 'Autoware-Compatible Map Authoring: autoware-map-authoring.md' in mkdocs_config
     assert 'Autoware Foxglove: autoware-foxglove.md' in mkdocs_config
@@ -539,6 +555,21 @@ def test_docs_cover_autoware_and_release_gate_keywords():
     assert 'SIGKILL' in reliability_doc
     assert 'GNU `time`' in reliability_doc
     assert '3,600 or 28,800 seconds' in reliability_doc
+    assert '(evidence/real-data-soak-2026-07-28.md)' in reliability_doc
+    soak_evidence = SOAK_EVIDENCE_DOC.read_text(encoding='utf-8')
+    soak_ledger = json.loads(SOAK_EVIDENCE_JSON.read_text(encoding='utf-8'))
+    assert '671 / 671' in soak_evidence
+    assert '28,834.115 s' in soak_evidence
+    assert soak_ledger['evidence_version'] == 1
+    assert soak_ledger['software']['git_commit'] == (
+        '0ec55575ffc16eb008e9f24bd6c6f24700bf2f8a'
+    )
+    assert [run['profile'] for run in soak_ledger['runs']] == [
+        'one-hour',
+        'eight-hour',
+    ]
+    assert all(run['status'] == 'passed' for run in soak_ledger['runs'])
+    assert all(all(run['checks'].values()) for run in soak_ledger['runs'])
     assert '(operational-reliability.md)' in (
         PRODUCT_CONTRACT_DOC.read_text(encoding='utf-8')
     )

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
   - Product Contract: product-contract.md
   - Golden-path CLI: golden-path-cli.md
   - Operational reliability: operational-reliability.md
+  - Named-hardware soak evidence: evidence/real-data-soak-2026-07-28.md
   - Pinned real-data E2E: real-data-e2e.md
   - Distribution and installed CLI: distribution.md
   - Autoware-Compatible Map Authoring: autoware-map-authoring.md


### PR DESCRIPTION
## What changed

- add a compact JSON/Markdown ledger for the completed one-hour and eight-hour real-data soak runs
- record exact hardware, clean merged commit, input hashes, report hashes, thresholds, metrics, and scope limitations
- update operational reliability and the v0.9 roadmap to close the named-hardware execution row while leaving the remaining Phase 3 gates explicit
- publish the evidence page in MkDocs and include both evidence files in release bundles
- add documentation regression coverage for the evidence files, navigation, release packaging, profiles, commit, and passing checks

## Why

The v4 soak harness and timeout contract were already merged, but the roadmap
still correctly described real-duration named-hardware evidence as missing.
The completed 1-hour and 8-hour runs now provide that evidence and should be
auditable without committing the very large per-iteration artifacts.

## Evidence

Both runs used clean merged commit
`0ec55575ffc16eb008e9f24bd6c6f24700bf2f8a`, ROS 2 Jazzy, the same input
hashes, and the named i5-1145G7 machine.

- one-hour: 86/86 successful iterations, 3,638.645 s, 0 drops
- eight-hour: 671/671 successful iterations, 28,834.115 s, 0 drops
- all eight terminal checks passed for both reports
- schema v4 validation passed; no scoped process remained after the eight-hour run; evidence worktree remained clean

## Validation

- `python3 -m pytest lidarslam/test/test_map_soak_runner.py graph_based_slam/test/test_docs_entrypoints.py -q` (33 passed)
- `python3 -m mkdocs build --strict --site-dir /tmp/lidarslam-soak-evidence-site`
- compact ledger compared field-for-field with both authoritative reports for metrics, thresholds, and checks
- `git diff --check`

## Scope

This is evidence for one named amd64/Jazzy machine, one input identity, and
one map profile. It does not claim a universal performance, Humble, sensor,
or map-quality guarantee.
