### PR TITLE
Fix Docker demo nested bag discovery

### DIFF
--- a/graph_based_slam/test/test_docker_demo_script.py
+++ b/graph_based_slam/test/test_docker_demo_script.py
@@ -1,0 +1,86 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Regression tests for the one-command Docker demo."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEMO_SCRIPT = REPO_ROOT / 'scripts' / 'run_docker_demo.sh'
+BAG_NAME = 'rosbag2_2024_04_16-14_17_01'
+
+
+def test_demo_selects_nested_directory_that_contains_metadata(tmp_path: Path):
+    data_dir = tmp_path / 'datasets'
+    outer_dir = data_dir / 'driving_slam_mid360' / 'extracted' / BAG_NAME
+    bag_dir = outer_dir / BAG_NAME
+    bag_dir.mkdir(parents=True)
+    (bag_dir / 'metadata.yaml').write_text(
+        'rosbag2_bagfile_information: {}\n',
+        encoding='utf-8',
+    )
+
+    stub_dir = tmp_path / 'bin'
+    stub_dir.mkdir()
+    capture_path = tmp_path / 'runner_args.txt'
+    bash_stub = stub_dir / 'bash'
+    bash_stub.write_text(
+        '#!/bin/sh\n'
+        'printf "%s\\n" "$@" > "$DEMO_TEST_CAPTURE"\n',
+        encoding='utf-8',
+    )
+    bash_stub.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            'DEMO_DATA_DIR': str(data_dir),
+            'DEMO_OUTPUT_DIR': str(tmp_path / 'output'),
+            'DEMO_TEST_CAPTURE': str(capture_path),
+            'PATH': f'{stub_dir}:{env["PATH"]}',
+        }
+    )
+    result = subprocess.run(
+        ['/bin/bash', str(DEMO_SCRIPT)],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert f'bag: {bag_dir}' in result.stdout
+    runner_args = capture_path.read_text(encoding='utf-8').splitlines()
+    assert runner_args[0].endswith('/scripts/run_rko_lio_graph_autoware_dogfood.sh')
+    assert runner_args[runner_args.index('--bag') + 1] == str(bag_dir)

--- a/scripts/run_docker_demo.sh
+++ b/scripts/run_docker_demo.sh
@@ -20,13 +20,24 @@ DATA_DIR="${DEMO_DATA_DIR:-${REPO_ROOT}/datasets/mid360_public}"
 OUT_DIR="${DEMO_OUTPUT_DIR:-${REPO_ROOT}/output/mid360_demo}"
 BAG_NAME="rosbag2_2024_04_16-14_17_01"
 
+find_demo_bag() {
+  local metadata_path
+  metadata_path="$(
+    find "${DATA_DIR}" -type f \
+      -path "*/${BAG_NAME}/metadata.yaml" \
+      -print -quit 2>/dev/null
+  )"
+  [[ -n "${metadata_path}" ]] || return 1
+  dirname "${metadata_path}"
+}
+
 echo "== [1/2] demo data: Driving SLAM Test with Livox MID360 =="
 echo "   (Koide, Zenodo DOI 10.5281/zenodo.14841855, CC-BY 4.0)"
-bag_dir="$(find "${DATA_DIR}" -type d -name "${BAG_NAME}" 2>/dev/null | head -n 1 || true)"
+bag_dir="$(find_demo_bag || true)"
 if [[ -z "${bag_dir}" ]]; then
   python3 "${REPO_ROOT}/scripts/download_mid360_robot_public_dataset.py" \
     --dataset driving_slam_mid360 --dataset-root "${DATA_DIR}"
-  bag_dir="$(find "${DATA_DIR}" -type d -name "${BAG_NAME}" | head -n 1)"
+  bag_dir="$(find_demo_bag || true)"
 fi
 [[ -n "${bag_dir}" && -f "${bag_dir}/metadata.yaml" ]] || {
   echo "error: demo bag not found under ${DATA_DIR}" >&2


### PR DESCRIPTION
## Summary

- select the demo rosbag by its `metadata.yaml` instead of the first matching directory name
- handle the public dataset extractor's same-name outer/inner directory layout
- add a regression test that reproduces the clean-room failure

## Clean-room reproduction

The README one-command demo on Humble image digest `sha256:782b5d92794f03fedc272c0ee632bca23a429769d05d3d481fc652a9f35df809` downloaded and verified the 517.1 MB archive, then exited with `error: demo bag not found` because the outer extraction directory was selected before the inner rosbag2 directory containing `metadata.yaml`.

## Candidate E2E evidence

The same image with only the candidate script mounted read-only selected the inner bag and completed the full headless workflow:

- 577 corrected poses and 2,687 raw poses
- 127 MB output with 365 point-cloud tiles
- 42 Lanelet2 lanelets
- independent `verify_autoware_map.py`: `PASS 8 / WARN 0 / FAIL 0`

## Validation

- `bash -n scripts/run_docker_demo.sh`
- `python3 -m pytest graph_based_slam/test/test_docker_demo_script.py graph_based_slam/test/test_docs_entrypoints.py -q` (10 passed)
- `git diff --check`