### PR TITLE
Route Docker demo through the golden CLI

### DIFF
--- a/graph_based_slam/test/test_docker_demo_script.py
+++ b/graph_based_slam/test/test_docker_demo_script.py
@@ -54,13 +54,13 @@ def test_demo_selects_nested_directory_that_contains_metadata(tmp_path: Path):
     stub_dir = tmp_path / 'bin'
     stub_dir.mkdir()
     capture_path = tmp_path / 'runner_args.txt'
-    bash_stub = stub_dir / 'bash'
-    bash_stub.write_text(
+    cli_stub = stub_dir / 'lidarslam-map'
+    cli_stub.write_text(
         '#!/bin/sh\n'
         'printf "%s\\n" "$@" > "$DEMO_TEST_CAPTURE"\n',
         encoding='utf-8',
     )
-    bash_stub.chmod(0o755)
+    cli_stub.chmod(0o755)
 
     env = os.environ.copy()
     env.update(
@@ -82,5 +82,20 @@ def test_demo_selects_nested_directory_that_contains_metadata(tmp_path: Path):
     assert result.returncode == 0, result.stderr
     assert f'bag: {bag_dir}' in result.stdout
     runner_args = capture_path.read_text(encoding='utf-8').splitlines()
-    assert runner_args[0].endswith('/scripts/run_rko_lio_graph_autoware_dogfood.sh')
-    assert runner_args[runner_args.index('--bag') + 1] == str(bag_dir)
+    assert runner_args[:2] == ['run', str(bag_dir)]
+    assert runner_args[runner_args.index('--profile') + 1] == (
+        'rko_lio_graph_mid360_preset'
+    )
+    assert runner_args[runner_args.index('--output-dir') + 1] == str(
+        tmp_path / 'output'
+    )
+
+
+def test_demo_delegates_to_versioned_product_contract():
+    script = DEMO_SCRIPT.read_text(encoding='utf-8')
+
+    assert 'lidarslam-map run "${bag_dir}"' in script
+    assert '--profile rko_lio_graph_mid360_preset' in script
+    assert 'run_manifest.json' in script
+    assert 'verify_autoware_map.log' in script
+    assert 'run_rko_lio_graph_autoware_dogfood.sh' not in script

--- a/scripts/run_docker_demo.sh
+++ b/scripts/run_docker_demo.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 # One-command SLAM demo: download a public Livox MID-360 driving bag
-# (Zenodo 14841855, Koide, CC-BY 4.0, 517 MB zip) and run the flagship
-# RKO-LIO + graph_based_slam pipeline headless, saving an Autoware-ready
-# map (map.pcd, pointcloud_map/ tiles, map_projector_info.yaml) and the
-# corrected trajectory (traj_corrected.tum).
+# (Zenodo 14841855, Koide, CC-BY 4.0, 517 MB zip) and run the installed
+# golden-path CLI with the tracked MID-360 profile. The CLI saves and verifies
+# an Autoware-ready map and records the versioned run/diagnosis contracts.
 #
 # Designed as the default command of the ghcr.io/rsasaki0109/lidar_slam_ros2
 # image, but works on any host with the workspace built and sourced:
@@ -45,16 +44,10 @@ fi
 }
 echo "   bag: ${bag_dir}"
 
-echo "== [2/2] RKO-LIO + graph_based_slam (headless, offline) =="
-bash "${REPO_ROOT}/scripts/run_rko_lio_graph_autoware_dogfood.sh" \
-  --bag "${bag_dir}" \
-  --lidar-topic /livox/lidar --imu-topic /livox/imu \
-  --base-frame livox_frame --lidar-frame livox_frame --imu-frame livox_frame \
-  --rko-param "${REPO_ROOT}/lidarslam/param/rko_lio_mid360.yaml" \
-  --lidarslam-param "${REPO_ROOT}/lidarslam/param/lidarslam_mid360_rko_graph.yaml" \
-  --wait-for-offline-completion --skip-viewer \
-  --output-dir "${OUT_DIR}" \
-  --run-name mid360_demo
+echo "== [2/2] verified golden-path map run (headless, offline) =="
+lidarslam-map run "${bag_dir}" \
+  --profile rko_lio_graph_mid360_preset \
+  --output-dir "${OUT_DIR}"
 
 echo
 echo "== demo finished =="
@@ -63,3 +56,6 @@ echo "  map.pcd                  downsampled point-cloud map"
 echo "  pointcloud_map/          Autoware map tiles (+ metadata)"
 echo "  map_projector_info.yaml  Autoware projector info (local)"
 echo "  traj_corrected.tum       loop-closed trajectory (TUM format)"
+echo "  verify_autoware_map.log  Autoware compatibility result"
+echo "  run_manifest.json        versioned execution evidence"
+echo "  autoware_map_diagnosis.* actionable diagnosis"


### PR DESCRIPTION
## Summary

- delegate the official Docker default to `lidarslam-map run` with the tracked MID-360 profile
- make Docker-demo success produce the same versioned manifest, diagnosis, verification, atomic-output, and storage-preflight contract as own-bag runs
- extend the wrapper regression test to lock the unified command surface

## Why

The fresh-environment trial found that the demo generated a usable map but bypassed the Product Contract: it did not emit `run_manifest.json`, `verify_autoware_map.log`, or the diagnosis JSON/Markdown artifacts. The installed CLI already supports this exact public input, so the wrapper can delegate instead of maintaining a parallel execution path.

## Candidate E2E

Humble image digest `sha256:782b5d92794f03fedc272c0ee632bca23a429769d05d3d481fc652a9f35df809` with only this candidate wrapper mounted read-only:

- execution: 83.53 seconds
- profile: `rko_lio_graph_mid360_preset`
- run manifest: schema v2, `succeeded`
- lifecycle: `complete`, runner exit 0
- diagnosis: `success`
- verification: `PASS 8 / WARN 0 / FAIL 0`
- 577 corrected poses, 365 point-cloud tiles, 42 lanelets
- atomic finalization completed with no `.partial` sibling

## Validation

- `bash -n scripts/run_docker_demo.sh`
- `python3 -m pytest graph_based_slam/test/test_docker_demo_script.py graph_based_slam/test/test_docs_entrypoints.py -q` (11 passed)
- `git diff --check`