### PR TITLE
Organize the product CLI option surface

### DIFF
--- a/docs/golden-path-cli.md
+++ b/docs/golden-path-cli.md
@@ -96,6 +96,27 @@ With `--no-verify-map`, inspect `output.diagnosis_status` separately;
 `runtime_failed`, or `incomplete`. Add `--write` to create the Markdown and
 JSON diagnosis artifacts in the output directory.
 
+## Option tiers
+
+The command help groups options by operator intent. Existing option names
+remain compatible; the tiers make the stable beginner surface distinct from
+viewer plumbing and safety overrides.
+
+| Tier | Options | Use |
+| --- | --- | --- |
+| Doctor output | `doctor --json` | Emit the versioned preflight contract for automation |
+| Map selection and output | `run --profile`, `run --output-dir` | Select a maintained profile or an explicit artifact directory |
+| Safety and lifecycle | `run --min-free-space-gib`, `run --dry-run`, `run --resume` | Refuse unsafe starts, inspect a plan, or finish terminal post-processing |
+| Viewer | `run --viewer {none,autoware,foxglove}` | Open an optional viewer after a successful run |
+| Advanced viewer | `run --autoware-core-dir`, `run --work-dir`, `run --viewer-run-dir`, `run --viewer-rebuild`, `run --auto-exit-secs` | Control viewer build/runtime details; these require a non-`none` viewer |
+| Advanced safety override | `run --no-verify-map` | Diagnostic-only run without required map verification; success does not claim verification |
+| Inspection context/output | `inspect --bag`, `inspect --json`, `inspect --write` | Add source-bag context, choose machine output, or persist diagnosis files |
+
+Viewer-specific options that would otherwise be ignored are rejected with exit
+code `2`. In particular, `--autoware-core-dir` requires
+`--viewer autoware`; the other advanced viewer options require either
+`--viewer autoware` or `--viewer foxglove`.
+
 ## Versioned JSON contracts
 
 Automation should select the schema using `schema_version` and `schema_uri`;

--- a/graph_based_slam/test/test_lidarslam_product_cli.py
+++ b/graph_based_slam/test/test_lidarslam_product_cli.py
@@ -119,6 +119,51 @@ def test_global_help_version_and_usage_contract():
     assert 'unknown command: unknown' in unknown_result.stderr
 
 
+def test_subcommand_help_uses_product_names_and_option_groups():
+    doctor = _run('doctor', '--help')
+    run = _run('run', '--help')
+    inspect = _run('inspect', '--help')
+
+    assert doctor.returncode == run.returncode == inspect.returncode == 0
+    assert 'usage: lidarslam doctor' in doctor.stdout
+    assert 'usage: lidarslam run' in run.stdout
+    assert 'usage: lidarslam inspect' in inspect.stdout
+    assert 'python3 scripts/' not in doctor.stdout
+    assert 'python3 scripts/' not in run.stdout
+    assert 'python3 scripts/' not in inspect.stdout
+    assert 'map selection and output:' in run.stdout
+    assert 'safety and lifecycle:' in run.stdout
+    assert 'viewer:' in run.stdout
+    assert 'advanced viewer options:' in run.stdout
+    assert 'advanced safety overrides:' in run.stdout
+
+
+def test_run_rejects_viewer_options_that_would_be_ignored(tmp_path: Path):
+    missing_bag = tmp_path / 'missing'
+
+    no_viewer = _run('run', str(missing_bag), '--viewer-rebuild')
+    assert no_viewer.returncode == 2
+    expected_error = (
+        '--viewer-rebuild requires --viewer autoware or --viewer foxglove'
+    )
+    assert expected_error in no_viewer.stderr
+    assert 'rosbag2 directory does not exist' not in no_viewer.stderr
+
+    wrong_viewer = _run(
+        'run',
+        str(missing_bag),
+        '--viewer',
+        'foxglove',
+        '--autoware-core-dir',
+        '/tmp/autoware',
+    )
+    assert wrong_viewer.returncode == 2
+    assert (
+        '--autoware-core-dir requires --viewer autoware'
+        in wrong_viewer.stderr
+    )
+
+
 def test_doctor_emits_machine_readable_preflight(tmp_path: Path):
     bag = tmp_path / 'sample_bag'
     _write_bag_metadata(bag)

--- a/lidarslam/test/test_autoware_map_runner_script.py
+++ b/lidarslam/test/test_autoware_map_runner_script.py
@@ -145,6 +145,10 @@ def test_runner_help_is_user_facing():
     assert '--output-dir <dir>' in result.stdout
     assert '--min-free-space-gib <GiB>' in result.stdout
     assert '--resume' in result.stdout
+    assert 'map selection and output:' in result.stdout
+    assert 'safety and lifecycle:' in result.stdout
+    assert 'advanced viewer options:' in result.stdout
+    assert 'advanced safety overrides:' in result.stdout
 
 
 def test_storage_preflight_records_budget_and_refuses_low_space(

--- a/scripts/diagnose_autoware_map_run.py
+++ b/scripts/diagnose_autoware_map_run.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from pathlib import Path
 import re
 import sys
@@ -333,6 +334,10 @@ def validate_run_dir(run_dir: Path) -> None:
 
 
 def _help_epilog() -> str:
+    command = os.environ.get(
+        'LIDARSLAM_CLI_COMMAND',
+        'python3 scripts/diagnose_autoware_map_run.py',
+    )
     return '\n'.join([
         'The input must be the map workflow output directory.',
         'Pass output/autoware_map_authoring_<bag>_<timestamp>, not its pointcloud_map/ child.',
@@ -345,18 +350,16 @@ def _help_epilog() -> str:
         '  map_projector_info.yaml',
         '',
         'Examples:',
-        '  python3 scripts/diagnose_autoware_map_run.py output/my_map_run',
-        '  python3 scripts/diagnose_autoware_map_run.py output/my_map_run --write',
-        (
-            '  python3 scripts/diagnose_autoware_map_run.py output/my_map_run '
-            '--bag /path/to/rosbag2'
-        ),
-        '  python3 scripts/diagnose_autoware_map_run.py output/my_map_run --json',
+        f'  {command} output/my_map_run',
+        f'  {command} output/my_map_run --write',
+        f'  {command} output/my_map_run --bag /path/to/rosbag2',
+        f'  {command} output/my_map_run --json',
     ])
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
+        prog=os.environ.get('LIDARSLAM_CLI_COMMAND'),
         description=(
             'Diagnose an Autoware-compatible map workflow output directory and '
             'suggest the next command.'

--- a/scripts/lidarslam_cli.py
+++ b/scripts/lidarslam_cli.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 import subprocess
 import sys
@@ -23,7 +24,7 @@ EX_SOFTWARE = 70
 
 def command_name() -> str:
     """Return the source or installed command spelling."""
-    configured = __import__('os').environ.get('LIDARSLAM_CLI_NAME')
+    configured = os.environ.get('LIDARSLAM_CLI_NAME')
     if configured:
         return configured
     return './scripts/lidarslam'
@@ -98,7 +99,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         return EX_USAGE
 
     try:
-        completed = subprocess.run(command_argv(command, args), check=False)
+        child_env = os.environ.copy()
+        child_env['LIDARSLAM_CLI_COMMAND'] = f'{command_name()} {command}'
+        completed = subprocess.run(
+            command_argv(command, args),
+            check=False,
+            env=child_env,
+        )
     except (OSError, RuntimeError) as exc:
         print(f'error: failed to start {command}: {exc}', file=sys.stderr)
         return EX_SOFTWARE

--- a/scripts/preflight_autoware_map_bag.py
+++ b/scripts/preflight_autoware_map_bag.py
@@ -4,6 +4,7 @@
 import argparse
 from dataclasses import asdict, dataclass
 import json
+import os
 from pathlib import Path
 import shlex
 import sys
@@ -746,6 +747,15 @@ def _profile_help_text() -> str:
 
 
 def _help_epilog() -> str:
+    command = os.environ.get(
+        'LIDARSLAM_CLI_COMMAND',
+        'python3 scripts/preflight_autoware_map_bag.py',
+    )
+    product_command = (
+        command.rsplit(' ', 1)[0]
+        if 'LIDARSLAM_CLI_COMMAND' in os.environ
+        else 'lidarslam-map'
+    )
     return '\n'.join([
         'The input must be the rosbag2 directory that contains metadata.yaml.',
         'Pass /path/to/rosbag2, not /path/to/rosbag2_0.db3.',
@@ -753,15 +763,16 @@ def _help_epilog() -> str:
         _profile_help_text(),
         '',
         'Typical commands:',
-        '  python3 scripts/preflight_autoware_map_bag.py /path/to/rosbag2',
-        '  python3 scripts/preflight_autoware_map_bag.py /path/to/rosbag2 --json',
-        '  bash scripts/run_autoware_map_beginner.sh /path/to/rosbag2 --dry-run',
+        f'  {command} /path/to/rosbag2',
+        f'  {command} /path/to/rosbag2 --json',
+        f'  {product_command} run /path/to/rosbag2 --dry-run',
     ])
 
 
 def parse_args() -> argparse.Namespace:
     """Parse CLI arguments."""
     parser = argparse.ArgumentParser(
+        prog=os.environ.get('LIDARSLAM_CLI_COMMAND'),
         description=(
             'Inspect a rosbag2 directory and suggest the shortest supported '
             'Autoware-compatible map workflow.'

--- a/scripts/run_autoware_map_from_bag.py
+++ b/scripts/run_autoware_map_from_bag.py
@@ -969,6 +969,10 @@ def _profile_help_text() -> str:
 
 
 def _help_epilog() -> str:
+    command = os.environ.get(
+        'LIDARSLAM_CLI_COMMAND',
+        'python3 scripts/run_autoware_map_from_bag.py',
+    )
     return '\n'.join([
         'The input must be the rosbag2 directory that contains metadata.yaml.',
         'Pass /path/to/rosbag2, not /path/to/rosbag2_0.db3.',
@@ -983,21 +987,16 @@ def _help_epilog() -> str:
         '  run_manifest.json',
         '',
         'Examples:',
-        '  python3 scripts/run_autoware_map_from_bag.py /path/to/rosbag2 --dry-run',
-        (
-            '  python3 scripts/run_autoware_map_from_bag.py /path/to/rosbag2 '
-            '--output-dir output/my_map'
-        ),
-        (
-            '  python3 scripts/run_autoware_map_from_bag.py /path/to/rosbag2 '
-            '--output-dir output/my_map --resume'
-        ),
-        '  python3 scripts/run_autoware_map_from_bag.py /path/to/rosbag2 --viewer foxglove',
+        f'  {command} /path/to/rosbag2 --dry-run',
+        f'  {command} /path/to/rosbag2 --output-dir output/my_map',
+        f'  {command} /path/to/rosbag2 --output-dir output/my_map --resume',
+        f'  {command} /path/to/rosbag2 --viewer foxglove',
     ])
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
+        prog=os.environ.get('LIDARSLAM_CLI_COMMAND'),
         description=(
             'Inspect a rosbag2 directory, choose a supported Autoware-compatible '
             'map workflow, and write map artifacts under output/ by default.'
@@ -1010,13 +1009,14 @@ def parse_args() -> argparse.Namespace:
         metavar='rosbag2_dir',
         help='Directory containing metadata.yaml.',
     )
-    parser.add_argument(
+    map_options = parser.add_argument_group('map selection and output')
+    map_options.add_argument(
         '--profile',
         choices=PROFILE_CHOICES,
         metavar='<id>',
         help='Force a compatible profile instead of the default recommendation.',
     )
-    parser.add_argument(
+    map_options.add_argument(
         '--output-dir',
         metavar='<dir>',
         help=(
@@ -1024,7 +1024,8 @@ def parse_args() -> argparse.Namespace:
             'output/autoware_map_authoring_<bag>_<timestamp>.'
         ),
     )
-    parser.add_argument(
+    safety_options = parser.add_argument_group('safety and lifecycle')
+    safety_options.add_argument(
         '--min-free-space-gib',
         type=_minimum_free_space_gib,
         default=DEFAULT_MIN_FREE_SPACE_GIB,
@@ -1034,42 +1035,12 @@ def parse_args() -> argparse.Namespace:
             f'reserve (default: {DEFAULT_MIN_FREE_SPACE_GIB:g} GiB).'
         ),
     )
-    parser.add_argument(
-        '--viewer',
-        choices=['none', 'autoware', 'foxglove'],
-        default='none',
-        help='Open the saved map after the run (default: none).',
-    )
-    parser.add_argument(
-        '--autoware-core-dir',
-        help='autoware_core checkout used by the Docker viewer.',
-    )
-    parser.add_argument(
-        '--work-dir',
-        help='Runtime workspace directory for Autoware/Foxglove viewers.',
-    )
-    parser.add_argument('--viewer-run-dir', help='Existing built viewer runtime to reuse.')
-    parser.add_argument(
-        '--viewer-rebuild',
-        action='store_true',
-        help='Rebuild the viewer runtime before opening.',
-    )
-    parser.add_argument(
-        '--auto-exit-secs',
-        type=int,
-        help='Auto-close the viewer after N seconds.',
-    )
-    parser.add_argument(
-        '--no-verify-map',
-        action='store_true',
-        help='Skip verify_autoware_map.py in smoke wrappers.',
-    )
-    parser.add_argument(
+    safety_options.add_argument(
         '--dry-run',
         action='store_true',
         help='Print the selected command without executing it.',
     )
-    parser.add_argument(
+    safety_options.add_argument(
         '--resume',
         action='store_true',
         help=(
@@ -1077,11 +1048,78 @@ def parse_args() -> argparse.Namespace:
             'terminal schema-v2 run; the map workflow is never re-executed.'
         ),
     )
+    viewer_options = parser.add_argument_group('viewer')
+    viewer_options.add_argument(
+        '--viewer',
+        choices=['none', 'autoware', 'foxglove'],
+        default='none',
+        help='Open the saved map after the run (default: none).',
+    )
+    advanced_viewer_options = parser.add_argument_group(
+        'advanced viewer options'
+    )
+    advanced_viewer_options.add_argument(
+        '--autoware-core-dir',
+        help='autoware_core checkout used by the Docker viewer.',
+    )
+    advanced_viewer_options.add_argument(
+        '--work-dir',
+        help='Runtime workspace directory for Autoware/Foxglove viewers.',
+    )
+    advanced_viewer_options.add_argument(
+        '--viewer-run-dir',
+        help='Existing built viewer runtime to reuse.',
+    )
+    advanced_viewer_options.add_argument(
+        '--viewer-rebuild',
+        action='store_true',
+        help='Rebuild the viewer runtime before opening.',
+    )
+    advanced_viewer_options.add_argument(
+        '--auto-exit-secs',
+        type=int,
+        help='Auto-close the viewer after N seconds.',
+    )
+    advanced_overrides = parser.add_argument_group(
+        'advanced safety overrides'
+    )
+    advanced_overrides.add_argument(
+        '--no-verify-map',
+        action='store_true',
+        help=(
+            'Disable required map verification for diagnostics. A successful '
+            'workflow exit will not claim that verification ran.'
+        ),
+    )
     return parser.parse_args()
+
+
+def validate_option_combinations(args: argparse.Namespace) -> None:
+    """Reject viewer options that would otherwise be silently ignored."""
+    viewer_specific = (
+        ('--autoware-core-dir', args.autoware_core_dir),
+        ('--work-dir', args.work_dir),
+        ('--viewer-run-dir', args.viewer_run_dir),
+        ('--viewer-rebuild', args.viewer_rebuild),
+        ('--auto-exit-secs', args.auto_exit_secs is not None),
+    )
+    if args.autoware_core_dir and args.viewer != 'autoware':
+        raise ValueError('--autoware-core-dir requires --viewer autoware')
+    active = [name for name, enabled in viewer_specific if enabled]
+    if args.viewer == 'none' and active:
+        joined = ', '.join(active)
+        raise ValueError(
+            f'{joined} requires --viewer autoware or --viewer foxglove'
+        )
 
 
 def main() -> int:
     args = parse_args()
+    try:
+        validate_option_combinations(args)
+    except ValueError as exc:
+        print(f'error: {exc}', file=sys.stderr)
+        return 2
     if args.resume and args.dry_run:
         print('error: --resume cannot be combined with --dry-run', file=sys.stderr)
         return 2


### PR DESCRIPTION
## Summary

- group `run` options by operator intent without renaming or removing flags
- render `doctor`, `run`, and `inspect` help with the invoked product command instead of internal Python helper names
- reject viewer-only options that would otherwise be silently ignored
- document the option tiers and lock the behavior with CLI/help tests

## Option groups

- map selection and output
- safety and lifecycle
- viewer
- advanced viewer options
- advanced safety overrides

`--no-verify-map` remains compatible but is now explicitly described as a diagnostic safety override. `--autoware-core-dir` requires the Autoware viewer; other viewer runtime options require a non-`none` viewer. Invalid combinations exit 2 before bag validation.

## Validation

After rebasing onto Docker golden-CLI merge `706b3af`:

- `source /opt/ros/jazzy/setup.bash && python3 -m pytest graph_based_slam/test/test_lidarslam_product_cli.py lidarslam/test/test_autoware_map_runner_script.py graph_based_slam/test/test_docs_entrypoints.py graph_based_slam/test/test_docker_demo_script.py -q` (54 passed)
- `python3 -m mkdocs build --strict`
- `python3 -m compileall -q` on the four CLI modules
- `git diff --check`