### PR TITLE
Improve Docker first-run progress and output ownership

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # lidarslam_ros2 — prebuilt SLAM workspace + one-command demo.
 #
-#   docker run --rm -v "$PWD/lidarslam_output:/lidarslam_ws/output" \
+#   mkdir -p "$PWD/lidarslam_output"
+#   docker run --rm \
+#     -e LIDARSLAM_HOST_UID="$(id -u)" -e LIDARSLAM_HOST_GID="$(id -g)" \
+#     -v "$PWD/lidarslam_output:/lidarslam_ws/output" \
 #     ghcr.io/rsasaki0109/lidar_slam_ros2:humble
 #
 # The default command downloads a public Livox MID-360 driving bag

--- a/README.md
+++ b/README.md
@@ -62,14 +62,14 @@ defines the maintained surface; see [Distribution](docs/distribution.md) for ins
 ### Try it with Docker (one command, no build)
 
 ```bash
-docker run --rm -v "$PWD/lidarslam_output:/lidarslam_ws/output" \
+mkdir -p "$PWD/lidarslam_output"
+docker run --rm -e LIDARSLAM_HOST_UID="$(id -u)" -e LIDARSLAM_HOST_GID="$(id -g)" \
+  -v "$PWD/lidarslam_output:/lidarslam_ws/output" \
   ghcr.io/rsasaki0109/lidar_slam_ros2:humble
 ```
 
-This downloads a public 517 MB Livox MID-360 bag and runs the full headless
-pipeline. The Autoware bundle and `traj_corrected.tum` appear under
-`./lidarslam_output/mid360_demo/`; the [quickstart](docs/getting-started.md)
-shows caching and interactive-shell options.
+This runs the 517 MB MID-360 demo with periodic progress and writes `lidarslam_output/mid360_demo/`.
+UID/GID returns it to the Linux user; see [Getting Started](docs/getting-started.md) for other platforms.
 
 ### Build from source
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -130,6 +130,26 @@ The version examples illustrate the tag contract; use a tag listed on the
 GitHub Releases page. Convenience tags are intentionally moving, so recording
 their current digest is mandatory when they are used in evaluation evidence.
 
+### Bind-mounted output ownership
+
+The default demo starts as container root so it can use the prebuilt workspace
+and its internal dataset cache. On Linux, pass the invoking UID and GID to
+return the dedicated output mount to the host user when the demo exits:
+
+```bash
+mkdir -p "$PWD/lidarslam_output"
+docker run --rm \
+  -e LIDARSLAM_HOST_UID="$(id -u)" \
+  -e LIDARSLAM_HOST_GID="$(id -g)" \
+  -v "$PWD/lidarslam_output:/lidarslam_ws/output" \
+  ghcr.io/rsasaki0109/lidar_slam_ros2:humble
+```
+
+Both variables are required together and must be numeric. The demo changes the
+owner of the dedicated output mount, the requested run directory and any
+failed `.partial` or post-processing lock sidecar; unrelated sibling contents
+are not changed.
+
 ## Profile-specific extras
 
 The flagship PointCloud2 + IMU profile is complete after the recursive source

--- a/docs/evidence/docker-first-map-2026-07-28.md
+++ b/docs/evidence/docker-first-map-2026-07-28.md
@@ -128,18 +128,21 @@ Selected final artifact identities:
 | `pointcloud_map/pointcloud_map_metadata.yaml` | `d92eeefc4b068c2cf121bb7664851a2fb03b5a100dd43c2e56347dc541355710` |
 | `traj_corrected.tum` | `001afc405f18b36c9aefb17983ca985da734fed7b2358e9d2d20c7a678eb0338` |
 
-## Findings that remain open
+## Findings and follow-up
 
-- The first 517.1 MB download has no periodic progress display between start
-  and completion. On the trial network this looked idle for several minutes.
-- Files written to the bind mount are owned by container UID/GID `0:0`.
-  They are readable on the host but inconvenient to remove or modify without
-  an ownership-aware Docker invocation or post-run handling.
+- The trial image had no periodic progress display during the first 517.1 MB
+  download. The current downloader reports bytes, percentage and transfer rate
+  at time or byte intervals.
+- The trial image left bind-mounted files owned by container UID/GID `0:0`.
+  The current Docker demo accepts an explicit host UID/GID pair and restores
+  the dedicated output mount, run directory, `.partial` output and lock sidecar
+  on both successful and failed exits.
 - A moving convenience tag is appropriate for evaluation, but evidence and
   deployment must continue to record an immutable digest.
 - This trial covers one amd64 host and Humble image. It does not replace the
   Jazzy gate, source-workspace usability trial, arm64 evaluation, or three
   independent-user first-map reports.
 
-These findings do not invalidate the generated map, but progress visibility
-and host-file ownership remain onboarding work before v1.0.
+The original findings do not invalidate the generated map. Progress visibility
+and host-file ownership were closed as onboarding issues; the platform and
+independent-user coverage gaps remain before v1.0.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,10 +7,27 @@ to a working map.
 
 | You have | Run |
 | --- | --- |
-| Docker only, no ROS 2 workspace | `docker run --rm -v "$PWD/lidarslam_output:/lidarslam_ws/output" ghcr.io/rsasaki0109/lidar_slam_ros2:humble` |
+| Docker only, no ROS 2 workspace | Follow [Docker First Map](#docker-first-map-no-ros-2-workspace) below |
 | A rosbag2 directory and a built workspace | `lidarslam-map run /path/to/rosbag2 --output-dir "$PWD/output/my_map"` |
 | A bag, but you are not sure which topics it has | `lidarslam-map doctor /path/to/rosbag2` |
 | You want the fixed public demo dataset | `bash scripts/download_ntu_viral_tnp01.sh && bash scripts/run_autoware_quickstart.sh` |
+
+## Docker First Map (No ROS 2 Workspace)
+
+```bash
+mkdir -p "$PWD/lidarslam_output"
+docker run --rm \
+  -e LIDARSLAM_HOST_UID="$(id -u)" \
+  -e LIDARSLAM_HOST_GID="$(id -g)" \
+  -v "$PWD/lidarslam_output:/lidarslam_ws/output" \
+  ghcr.io/rsasaki0109/lidar_slam_ros2:humble
+```
+
+The first run downloads the tracked 517 MB MID-360 bag and prints periodic
+byte, percentage and transfer-rate updates. The map is written to
+`lidarslam_output/mid360_demo`. On Linux, the two ownership variables make the
+container return the output directory to your user even if the run fails.
+Omit them on platforms where Docker already maps bind-mount ownership.
 
 ## 1. Build The Workspace
 

--- a/docs/product-contract.md
+++ b/docs/product-contract.md
@@ -48,7 +48,7 @@ launch files are advanced, benchmark, migration, or research interfaces.
 
 | Goal | Official command | Contract |
 | --- | --- | --- |
-| Try the fixed public demo without a ROS workspace | `docker run --rm -v "$PWD/lidarslam_output:/lidarslam_ws/output" ghcr.io/rsasaki0109/lidar_slam_ros2:humble` | Downloads the tracked MID-360 demo and writes a headless map bundle |
+| Try the fixed public demo without a ROS workspace | [Docker First Map](getting-started.md#docker-first-map-no-ros-2-workspace) | Downloads the tracked MID-360 demo with progress and writes a user-owned headless map bundle |
 | Map your own compatible rosbag2 | `lidarslam-map run <rosbag2_dir> --output-dir <dir>` | Preflights the bag, selects a compatible maintained profile, runs headless, verifies and diagnoses the output |
 | Reproduce the fixed source-workspace quickstart | `bash scripts/download_ntu_viral_tnp01.sh && bash scripts/run_autoware_quickstart.sh` | Runs the tracked NTU VIRAL path and opens the bounded viewer flow |
 

--- a/graph_based_slam/test/test_docker_demo_script.py
+++ b/graph_based_slam/test/test_docker_demo_script.py
@@ -99,3 +99,30 @@ def test_demo_delegates_to_versioned_product_contract():
     assert 'run_manifest.json' in script
     assert 'verify_autoware_map.log' in script
     assert 'run_rko_lio_graph_autoware_dogfood.sh' not in script
+    assert 'LIDARSLAM_HOST_UID' in script
+    assert 'LIDARSLAM_HOST_GID' in script
+    assert 'chown -R "${HOST_UID}:${HOST_GID}" "${target}"' in script
+    assert '.postprocess.lock' in script
+
+
+def test_demo_rejects_incomplete_host_ownership_contract(tmp_path: Path):
+    env = os.environ.copy()
+    env.update(
+        {
+            'DEMO_DATA_DIR': str(tmp_path / 'datasets'),
+            'DEMO_OUTPUT_DIR': str(tmp_path / 'output' / 'mid360_demo'),
+            'LIDARSLAM_HOST_UID': str(os.getuid()),
+        }
+    )
+    env.pop('LIDARSLAM_HOST_GID', None)
+
+    result = subprocess.run(
+        ['/bin/bash', str(DEMO_SCRIPT)],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert 'set both LIDARSLAM_HOST_UID and LIDARSLAM_HOST_GID' in result.stderr

--- a/graph_based_slam/test/test_docs_entrypoints.py
+++ b/graph_based_slam/test/test_docs_entrypoints.py
@@ -444,6 +444,10 @@ def test_docs_cover_autoware_and_release_gate_keywords():
     assert 'lidarslam-map doctor' in getting_started_doc
     assert 'lidarslam-map run' in getting_started_doc
     assert 'lidarslam-map inspect' in getting_started_doc
+    assert 'LIDARSLAM_HOST_UID' in getting_started_doc
+    assert 'LIDARSLAM_HOST_GID' in getting_started_doc
+    assert 'periodic' in getting_started_doc
+    assert 'Bind-mounted output ownership' in distribution_doc
     assert 'Creative Commons Attribution 4.0' in real_data_e2e_doc
     first_map_evidence = DOCKER_FIRST_MAP_EVIDENCE_DOC.read_text(encoding='utf-8')
     assert 'FINAL_' not in first_map_evidence

--- a/graph_based_slam/test/test_mid360_robot_public_datasets.py
+++ b/graph_based_slam/test/test_mid360_robot_public_datasets.py
@@ -32,6 +32,7 @@
 from __future__ import annotations
 
 import hashlib
+import io
 import json
 from pathlib import Path
 import subprocess
@@ -44,6 +45,7 @@ SCRIPT_DIR = REPO_ROOT / 'scripts'
 DOWNLOAD_SCRIPT = SCRIPT_DIR / 'download_mid360_robot_public_dataset.py'
 sys.path.insert(0, str(SCRIPT_DIR))
 
+import mid360_robot_public_datasets as public_datasets  # noqa: E402
 from mid360_robot_public_datasets import (  # noqa: E402
     get_public_dataset,
     public_dataset_registry,
@@ -52,6 +54,54 @@ from mid360_robot_public_datasets import (  # noqa: E402
     PublicDatasetIntake,
     PublicDatasetIntakeOptions,
 )
+
+
+def test_stream_download_reports_periodic_progress(monkeypatch):
+    data = b'x' * (3 * 1024 * 1024)
+    response = io.BytesIO(data)
+    response.headers = {'Content-Length': str(len(data))}
+    output = io.BytesIO()
+    progress = io.StringIO()
+    monkeypatch.setattr(public_datasets, 'DOWNLOAD_PROGRESS_BYTES', 1024 * 1024)
+
+    intake = PublicDatasetIntake(REPO_ROOT, progress_stream=progress)
+    intake._stream_download(
+        PublicDatasetFile(
+            id='fixture',
+            filename='fixture.zip',
+            url='file://fixture',
+        ),
+        response,
+        output,
+        hashlib.md5(),
+    )
+
+    lines = progress.getvalue().splitlines()
+    assert lines[0] == 'Downloading fixture.zip: 0 B / 3.0 MiB (0.0%)'
+    assert sum(line.startswith('Downloading fixture.zip:') for line in lines) == 4
+    assert lines[-1].startswith('Downloaded fixture.zip: 3.0 MiB / 3.0 MiB (100.0%)')
+    assert output.getvalue() == data
+
+
+def test_stream_download_reports_when_time_interval_elapses(monkeypatch):
+    data = b'x' * (2 * 1024 * 1024)
+    response = io.BytesIO(data)
+    response.headers = {}
+    progress = io.StringIO()
+    clock = iter((0.0, 6.0, 6.0, 6.0))
+    monkeypatch.setattr(public_datasets, 'DOWNLOAD_PROGRESS_BYTES', len(data) * 2)
+    monkeypatch.setattr(public_datasets.time, 'monotonic', lambda: next(clock))
+
+    PublicDatasetIntake(REPO_ROOT, progress_stream=progress)._stream_download(
+        PublicDatasetFile(id='fixture', filename='fixture.zip', url='file://fixture'),
+        response,
+        io.BytesIO(),
+        hashlib.md5(),
+    )
+
+    lines = progress.getvalue().splitlines()
+    assert 'Downloading fixture.zip: 1.0 MiB, 170.7 KiB/s' in lines
+    assert lines[-1].startswith('Downloaded fixture.zip: 2.0 MiB, 341.3 KiB/s')
 
 
 def test_public_dataset_registry_contains_recommended_mid360_sources():

--- a/scripts/mid360_robot_public_datasets.py
+++ b/scripts/mid360_robot_public_datasets.py
@@ -7,12 +7,14 @@ import hashlib
 import json
 import shlex
 import shutil
+import sys
+import time
 import urllib.request
 import zipfile
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, BinaryIO, TextIO
 
 import yaml
 
@@ -21,6 +23,9 @@ from mid360_robot_tools import payload_to_json
 
 PUBLIC_DATASET_INTAKE_JSON = 'mid360_robot_public_dataset_intake.json'
 PUBLIC_DATASET_INTAKE_MARKDOWN = 'mid360_robot_public_dataset_intake.md'
+DOWNLOAD_CHUNK_BYTES = 1024 * 1024
+DOWNLOAD_PROGRESS_BYTES = 32 * 1024 * 1024
+DOWNLOAD_PROGRESS_INTERVAL_SEC = 5.0
 
 
 @dataclass(frozen=True)
@@ -233,9 +238,11 @@ class PublicDatasetIntake:
         self,
         repo_root: Path,
         registry: dict[str, PublicDataset] | None = None,
+        progress_stream: TextIO | None = sys.stderr,
     ) -> None:
         self._repo_root = repo_root
         self._registry = registry or PUBLIC_MID360_DATASETS
+        self._progress_stream = progress_stream
 
     def build_plan(self, options: PublicDatasetIntakeOptions) -> dict[str, Any]:
         """Build a reproducible intake plan without touching the network."""
@@ -396,15 +403,105 @@ class PublicDatasetIntake:
             part_path.unlink()
         md5 = hashlib.md5()
         with urllib.request.urlopen(file_record.url) as response, part_path.open('wb') as output:
-            while True:
-                chunk = response.read(1024 * 1024)
-                if not chunk:
-                    break
-                md5.update(chunk)
-                output.write(chunk)
+            self._stream_download(file_record, response, output, md5)
         part_path.replace(archive_path)
         messages.append(f'Downloaded {archive_path} with md5 {md5.hexdigest()}.')
         return True
+
+    def _stream_download(
+        self,
+        file_record: PublicDatasetFile,
+        response: BinaryIO,
+        output: BinaryIO,
+        md5: Any,
+    ) -> None:
+        total_bytes = self._response_content_length(response)
+        started_at = time.monotonic()
+        last_report_at = started_at
+        last_report_bytes = 0
+        downloaded_bytes = 0
+        self._print_download_progress(file_record, downloaded_bytes, total_bytes, 0.0)
+
+        while True:
+            chunk = response.read(DOWNLOAD_CHUNK_BYTES)
+            if not chunk:
+                break
+            md5.update(chunk)
+            output.write(chunk)
+            downloaded_bytes += len(chunk)
+            now = time.monotonic()
+            if (
+                now - last_report_at >= DOWNLOAD_PROGRESS_INTERVAL_SEC
+                or downloaded_bytes - last_report_bytes >= DOWNLOAD_PROGRESS_BYTES
+            ):
+                self._print_download_progress(
+                    file_record,
+                    downloaded_bytes,
+                    total_bytes,
+                    now - started_at,
+                )
+                last_report_at = now
+                last_report_bytes = downloaded_bytes
+
+        elapsed_sec = time.monotonic() - started_at
+        self._print_download_progress(
+            file_record,
+            downloaded_bytes,
+            total_bytes,
+            elapsed_sec,
+            complete=True,
+        )
+
+    @staticmethod
+    def _response_content_length(response: BinaryIO) -> int | None:
+        headers = getattr(response, 'headers', None)
+        if headers is None:
+            return None
+        value = headers.get('Content-Length')
+        try:
+            length = int(value)
+        except (TypeError, ValueError):
+            return None
+        return length if length >= 0 else None
+
+    def _print_download_progress(
+        self,
+        file_record: PublicDatasetFile,
+        downloaded_bytes: int,
+        total_bytes: int | None,
+        elapsed_sec: float,
+        *,
+        complete: bool = False,
+    ) -> None:
+        if self._progress_stream is None:
+            return
+        downloaded = self._format_bytes(downloaded_bytes)
+        if total_bytes:
+            percent = min(100.0, downloaded_bytes * 100.0 / total_bytes)
+            amount = f'{downloaded} / {self._format_bytes(total_bytes)} ({percent:.1f}%)'
+        else:
+            amount = downloaded
+        speed = ''
+        if elapsed_sec > 0 and downloaded_bytes > 0:
+            speed = f', {self._format_bytes(int(downloaded_bytes / elapsed_sec))}/s'
+        state = 'Downloaded' if complete else 'Downloading'
+        print(
+            f'{state} {file_record.filename}: {amount}{speed}',
+            file=self._progress_stream,
+            flush=True,
+        )
+
+    @staticmethod
+    def _format_bytes(value: int) -> str:
+        amount = float(value)
+        units = ('B', 'KiB', 'MiB', 'GiB', 'TiB')
+        for unit in units:
+            if amount < 1024.0 or unit == units[-1]:
+                if unit == 'B':
+                    return f'{int(amount)} {unit}'
+                return f'{amount:.1f} {unit}'
+            amount /= 1024.0
+        raise AssertionError('unreachable')
 
     @staticmethod
     def _verify_md5(archive_path: Path, expected_md5: str) -> None:

--- a/scripts/run_docker_demo.sh
+++ b/scripts/run_docker_demo.sh
@@ -12,12 +12,69 @@
 # Environment overrides:
 #   DEMO_DATA_DIR    dataset cache directory (default: <repo>/datasets/mid360_public)
 #   DEMO_OUTPUT_DIR  output directory        (default: <repo>/output/mid360_demo)
+#   LIDARSLAM_HOST_UID/GID
+#                    optional numeric owner for the output mount; set both
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DATA_DIR="${DEMO_DATA_DIR:-${REPO_ROOT}/datasets/mid360_public}"
 OUT_DIR="${DEMO_OUTPUT_DIR:-${REPO_ROOT}/output/mid360_demo}"
 BAG_NAME="rosbag2_2024_04_16-14_17_01"
+HOST_UID="${LIDARSLAM_HOST_UID:-}"
+HOST_GID="${LIDARSLAM_HOST_GID:-}"
+
+if [[ -n "${HOST_UID}" || -n "${HOST_GID}" ]]; then
+  if [[ -z "${HOST_UID}" || -z "${HOST_GID}" ]]; then
+    echo "error: set both LIDARSLAM_HOST_UID and LIDARSLAM_HOST_GID" >&2
+    exit 2
+  fi
+  if [[ ! "${HOST_UID}" =~ ^[0-9]+$ || ! "${HOST_GID}" =~ ^[0-9]+$ ]]; then
+    echo "error: LIDARSLAM_HOST_UID/GID must be numeric" >&2
+    exit 2
+  fi
+fi
+
+restore_output_ownership() {
+  local run_status="$1"
+  local output_name
+  local output_root
+  local target
+  trap - EXIT
+
+  if [[ -z "${HOST_UID}" ]]; then
+    exit "${run_status}"
+  fi
+
+  output_root="$(dirname -- "${OUT_DIR}")"
+  output_name="$(basename -- "${OUT_DIR}")"
+  if [[ -z "${output_root}" || "${output_root}" == "." || "${output_root}" == "/" ]]; then
+    echo "error: refusing ownership update for unsafe output root: ${output_root}" >&2
+    exit 1
+  fi
+
+  if [[ "${EUID}" -eq 0 ]]; then
+    if [[ -d "${output_root}" ]]; then
+      chown "${HOST_UID}:${HOST_GID}" "${output_root}"
+    fi
+    for target in \
+      "${OUT_DIR}" \
+      "${OUT_DIR}.partial" \
+      "${output_root}/.${output_name}.postprocess.lock"; do
+      if [[ -e "${target}" ]]; then
+        chown -R "${HOST_UID}:${HOST_GID}" "${target}"
+      fi
+    done
+    echo "Output ownership: ${HOST_UID}:${HOST_GID}"
+  elif [[ "$(id -u)" == "${HOST_UID}" && "$(id -g)" == "${HOST_GID}" ]]; then
+    echo "Output ownership already matches ${HOST_UID}:${HOST_GID}"
+  else
+    echo "error: cannot set output ownership without container root privileges" >&2
+    exit 1
+  fi
+  exit "${run_status}"
+}
+
+trap 'restore_output_ownership $?' EXIT
 
 find_demo_bag() {
   local metadata_path


### PR DESCRIPTION
## Summary

- report MID-360 dataset download progress every 5 seconds or 32 MiB, including bytes, percentage, and transfer rate
- let the default Docker demo restore its dedicated output mount to an explicitly supplied host UID/GID on both success and failure
- include the final output, `.partial` sibling, and post-processing lock sidecar while leaving unrelated sibling contents unchanged
- update the README, Getting Started, Distribution, Product Contract, and first-map evidence follow-up

## Why

The published-image first-map trial found two onboarding defects after correctness was established: the 517 MB download looked idle for several minutes, and bind-mounted output remained owned by container root. The latter also included a hidden post-processing lock sidecar discovered by the new container-level validation.

## User impact

The recommended Linux Docker command now prints continuous download feedback and returns generated artifacts to the invoking user. Both ownership variables are required together and validated as numeric; existing invocations remain compatible when they are omitted.

## Validation

- `python3 -m pytest -q graph_based_slam/test/test_mid360_robot_public_datasets.py graph_based_slam/test/test_docker_demo_script.py graph_based_slam/test/test_docs_entrypoints.py` — 20 passed
- `python3 -m mkdocs build --strict` — passed
- `python3 -m compileall -q scripts graph_based_slam/test` — passed
- `bash -n scripts/run_docker_demo.sh` — passed
- `git diff --check` — passed
- published Humble digest plus updated demo script, cached public MID-360 bag: schema-v2 manifest succeeded, verifier 8 pass / 0 warn / 0 fail, all output entries UID/GID 1000:1000
- intentional existing-output failure: original exit code 2 preserved and output/lock ownership mismatch count remained 0

`run_default_ci_checks.sh` reached CMake configuration locally but the host lacks `SophusConfig.cmake`; the PR's Humble/Jazzy container jobs are the authoritative full build gates.
