### PR TITLE
fix(bench): enforce reference-frame release provenance

### DIFF
--- a/graph_based_slam/test/test_ours_competitive_benchmark_runner.py
+++ b/graph_based_slam/test/test_ours_competitive_benchmark_runner.py
@@ -99,6 +99,21 @@ def test_rko_base_pose_contract_uses_body_not_lidar_lever_arm(tmp_path):
     }
 
 
+def test_rko_pose_contract_prefers_generic_reference_point(tmp_path):
+    metadata = tmp_path / 'reference.json'
+    metadata.write_text(json.dumps({
+        'reference_point_frame': 'base_center',
+        'imu_to_reference_translation_m': {
+            'x': -0.073, 'y': -0.023, 'z': -0.172},
+        'imu_to_prism_translation_m': {'x': 9, 'y': 9, 'z': 9},
+    }))
+    assert RUNNER.base_to_prism_contract(metadata) == {
+        'source_frame': 'imu',
+        'target_frame': 'base_center',
+        'offset_m': {'x': -0.073, 'y': -0.023, 'z': -0.172},
+    }
+
+
 def test_ntu_rko_lidar_to_base_is_inverse_of_glim_lidar_from_imu():
     rko = yaml.safe_load((
         ROOT / 'lidarslam/param/rko_lio_ntu_viral_direct_visual.yaml').read_text())

--- a/graph_based_slam/test/test_rko_lio_benchmark_tools.py
+++ b/graph_based_slam/test/test_rko_lio_benchmark_tools.py
@@ -37,6 +37,7 @@ import math
 from pathlib import Path
 import struct
 import subprocess
+import sys
 
 import yaml
 
@@ -44,6 +45,7 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[2]
 REFERENCE_SCRIPT = REPO_ROOT / 'scripts' / 'generate_ntu_viral_tnp01_reference.py'
 WRITE_METRICS_SCRIPT = REPO_ROOT / 'scripts' / 'write_rko_lio_benchmark_metrics.py'
+sys.path.insert(0, str(REPO_ROOT / 'scripts'))
 
 
 def _load_module(path: Path, name: str):
@@ -56,6 +58,8 @@ def _load_module(path: Path, name: str):
 
 
 REFERENCE_MODULE = _load_module(REFERENCE_SCRIPT, 'generate_ntu_viral_tnp01_reference')
+WRITE_METRICS_MODULE = _load_module(
+    WRITE_METRICS_SCRIPT, 'write_rko_lio_benchmark_metrics')
 
 
 def _write_binary_xyz_pcd(path, points):
@@ -157,6 +161,17 @@ def test_reference_parser_derives_existing_prism_offset(tmp_path):
     )
 
 
+def test_metrics_writer_prefers_generic_reference_offset():
+    metadata = {
+        'imu_to_reference_translation_m': {'x': 1, 'y': 2, 'z': 3},
+        'imu_to_prism_translation_m': {'x': 9, 'y': 9, 'z': 9},
+    }
+    assert WRITE_METRICS_MODULE._trajectory_offset(metadata, 'imu') == {
+        'x': 1, 'y': 2, 'z': 3}
+    assert WRITE_METRICS_MODULE._infer_reference_kind(
+        'rtk_slam_construction_seq1_gt', {}) == 'ground_truth'
+
+
 def test_write_rko_lio_metrics_generates_compatible_metrics_json(tmp_path):
     """The metrics writer should emit a report-consumable metrics.json."""
     bag_dir = tmp_path / 'bag'
@@ -164,11 +179,13 @@ def test_write_rko_lio_metrics_generates_compatible_metrics_json(tmp_path):
     (bag_dir / 'metadata.yaml').write_text(
         '\n'.join([
             'rosbag2_bagfile_information:',
+            '  storage_identifier: sqlite3',
             '  duration:',
             '    nanoseconds: 2000000000',
         ]),
         encoding='utf-8',
     )
+    (bag_dir / 'data.db3').write_bytes(b'synthetic bag payload')
     out_dir = tmp_path / 'bench'
     out_dir.mkdir()
     _create_map_bundle(out_dir)
@@ -246,6 +263,10 @@ def test_write_rko_lio_metrics_generates_compatible_metrics_json(tmp_path):
             'body',
             '--wall-sec',
             '1.0',
+            '--runtime-artifact',
+            'test_runtime=/bin/true',
+            '--benchmark-harness',
+            str(WRITE_METRICS_SCRIPT),
         ],
         capture_output=True,
         text=True,
@@ -268,6 +289,11 @@ def test_write_rko_lio_metrics_generates_compatible_metrics_json(tmp_path):
     assert metrics['rko_lio']['available'] is True
     assert metrics['rko_lio']['trajectory_source_frame'] == 'body'
     assert metrics['rko_lio']['prism_offset_m']['x'] == -0.293656
+    assert metrics['schema_version'] == 1
+    assert metrics['reference']['kind'] == 'ground_truth'
+    assert metrics['provenance']['input']['bag']['identity_algorithm'] == 'sha256'
+    assert metrics['provenance']['software']['runtime_artifacts'][0][
+        'label'] == 'test_runtime'
 
 
 def test_write_lo_metrics_sets_scanmatcher_payload(tmp_path):

--- a/graph_based_slam/test/test_rko_lio_graph_benchmark_script.py
+++ b/graph_based_slam/test/test_rko_lio_graph_benchmark_script.py
@@ -77,6 +77,22 @@ def test_trajectory_only_mode_uses_full_dump_as_explicit_passthrough():
     assert 'cp "${BACKEND_TUMS[0]}" "$RAW_TUM"' in script
 
 
+def test_reference_offset_failure_is_not_masked_by_process_substitution():
+    script = BENCHMARK_SCRIPT.read_text(encoding='utf-8')
+    assert 'if ! PRISM_TRANSFORM_OUTPUT="$(python3' in script
+    assert 'reference frame-offset contract is invalid' in script
+    assert 'readarray -t PRISM_TRANSFORM <<<"$PRISM_TRANSFORM_OUTPUT"' in script
+    assert 'base/body/imu_to_reference_translation_m' in script
+
+
+def test_release_provenance_identifies_runtime_and_harness():
+    script = BENCHMARK_SCRIPT.read_text(encoding='utf-8')
+    assert '--benchmark-harness "${BASH_SOURCE[0]}"' in script
+    assert '--runtime-artifact "rko_lio_offline_node=' in script
+    assert '--runtime-artifact "graph_based_slam_node=' in script
+    assert '--parameter-file "$RKO_PARAM"' in script
+
+
 def test_quiet_completion_requires_substantial_bag_progress():
     """Require both near-end and minimum-progress quiet-completion guards."""
     script = BENCHMARK_SCRIPT.read_text(encoding='utf-8')

--- a/graph_based_slam/test/test_rtk_slam_reference.py
+++ b/graph_based_slam/test/test_rtk_slam_reference.py
@@ -197,6 +197,10 @@ def test_generated_reference_scores_as_ground_truth(tmp_path):
     assert meta['source'] == 'rtk_slam_test_gt'
     assert meta['kind'] == 'ground_truth'
     assert meta['checkpoint_count'] == 12
+    assert meta['reference_point_frame'] == 'base_center'
+    assert meta['imu_to_reference_translation_m'] == {
+        'x': -0.073, 'y': -0.023, 'z': -0.172}
+    assert 'calib/calib.yaml' in meta['reference_translation_source']
 
     # Build an estimate that differs from GT by a pure rigid translation, which
     # SE(3) alignment removes -> RMSE ~ 0 over the sparse checkpoint set.

--- a/scripts/generate_rtk_slam_reference.py
+++ b/scripts/generate_rtk_slam_reference.py
@@ -33,6 +33,11 @@ from pathlib import Path
 REQUIRED_COLUMNS = ('point_id', 'easting', 'northing', 'height', 'env', 'timestamp')
 _NUMERIC_REQUIRED = ('easting', 'northing', 'height', 'timestamp')
 
+# Official RTK-SLAM calibration: the public evaluation expects trajectory
+# positions at the robot base center, while RKO-LIO's identity-extrinsic
+# benchmark preset reports the IMU origin.
+IMU_TO_REFERENCE_TRANSLATION_M = (-0.073, -0.023, -0.172)
+
 
 def parse_checkpoints(text: str) -> list[dict]:
     """Parse RTK-SLAM checkpoint CSV text into a list of dicts (by column name)."""
@@ -124,6 +129,13 @@ def build_reference(csv_path: Path, sequence: str) -> tuple[list[str], dict]:
         ),
         'sequence': sequence,
         'frame': 'local_enu_from_utm',
+        'reference_point_frame': 'base_center',
+        'imu_to_reference_translation_m': dict(
+            zip('xyz', IMU_TO_REFERENCE_TRANSLATION_M)
+        ),
+        'reference_translation_source': (
+            'RTK-SLAM calib/calib.yaml reference_offsets.base_center'
+        ),
         'units': 'meters',
         'local_origin_utm': origin,
         'checkpoint_count': len(local),

--- a/scripts/run_ours_competitive_benchmark.py
+++ b/scripts/run_ours_competitive_benchmark.py
@@ -76,16 +76,20 @@ def visual_sensor_contract(rko_param: Path, camera_topic: str) -> dict[str, Any]
 def base_to_prism_contract(reference_meta: Path) -> dict[str, Any]:
     metadata = json.loads(reference_meta.read_text())
     for frame in ('base', 'body', 'imu'):
-        offset = metadata.get(f'{frame}_to_prism_translation_m')
-        if isinstance(offset, dict) and all(axis in offset for axis in 'xyz'):
-            return {
-                'source_frame': frame,
-                'target_frame': 'leica_prism',
-                'offset_m': {axis: float(offset[axis]) for axis in 'xyz'},
-            }
+        for suffix in ('reference', 'prism'):
+            offset = metadata.get(f'{frame}_to_{suffix}_translation_m')
+            if isinstance(offset, dict) and all(axis in offset for axis in 'xyz'):
+                return {
+                    'source_frame': frame,
+                    'target_frame': metadata.get(
+                        'reference_point_frame',
+                        'leica_prism' if suffix == 'prism' else 'reference_point'),
+                    'offset_m': {axis: float(offset[axis]) for axis in 'xyz'},
+                }
     raise ValueError(
         'RKO-LIO trajectory is base-frame pose but reference metadata lacks '
-        'base/body/imu_to_prism_translation_m')
+        'base/body/imu_to_reference_translation_m (or legacy '
+        '*_to_prism_translation_m)')
 
 
 def run_once(args: argparse.Namespace, output: Path, index: int,

--- a/scripts/run_rko_lio_graph_benchmark.sh
+++ b/scripts/run_rko_lio_graph_benchmark.sh
@@ -579,6 +579,39 @@ else
   [[ -f "$REFERENCE_META" ]] || die "--skip-reference-gen set but reference meta not found: $REFERENCE_META (pass --reference-meta, e.g. an empty '{}' JSON if no prism-offset metadata applies)"
 fi
 
+# Validate the scoring-frame contract before starting a potentially multi-hour
+# replay. Command substitution preserves the Python exit status; process
+# substitution would silently turn a malformed contract into an empty array.
+if ! PRISM_TRANSFORM_OUTPUT="$(python3 - "$REFERENCE_META" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+meta = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+for frame in ("base", "body", "imu"):
+    for suffix in ("reference", "prism"):
+        offset = meta.get(f"{frame}_to_{suffix}_translation_m")
+        if offset is not None:
+            print(frame)
+            print(offset["x"])
+            print(offset["y"])
+            print(offset["z"])
+            raise SystemExit(0)
+else:
+    raise SystemExit(
+        "RKO-LIO trajectory is base-frame pose, but reference metadata lacks "
+        "base/body/imu_to_reference_translation_m (or legacy "
+        "*_to_prism_translation_m)")
+PY
+)"; then
+  die "reference frame-offset contract is invalid"
+fi
+readarray -t PRISM_TRANSFORM <<<"$PRISM_TRANSFORM_OUTPUT"
+if [[ "${#PRISM_TRANSFORM[@]}" -ne 4 ]]; then
+  die "reference frame-offset contract must contain a frame and xyz translation"
+fi
+PRISM_SOURCE_FRAME="${PRISM_TRANSFORM[0]}"
+
 echo "Running RKO-LIO benchmark"
 echo "  bag:            $BAG_PATH"
 echo "  reference_tum:  $REFERENCE_TUM"
@@ -705,28 +738,6 @@ elif [[ ! -s "$CORRECTED_TUM" ]]; then
   die "corrected trajectory missing after map_save"
 fi
 
-readarray -t PRISM_TRANSFORM < <(python3 - "$REFERENCE_META" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-meta = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
-for frame in ("base", "body", "imu"):
-    offset = meta.get(f"{frame}_to_prism_translation_m")
-    if offset is not None:
-        print(frame)
-        print(offset["x"])
-        print(offset["y"])
-        print(offset["z"])
-        break
-else:
-    raise SystemExit(
-        "RKO-LIO trajectory is base-frame pose, but reference metadata lacks "
-        "base/body/imu_to_prism_translation_m")
-PY
-)
-PRISM_SOURCE_FRAME="${PRISM_TRANSFORM[0]}"
-
 python3 "${SCRIPT_DIR}/apply_tum_frame_offset.py" \
   --in "$RAW_TUM" \
   --out "$RAW_TUM_PRISM" \
@@ -783,6 +794,11 @@ METRICS_ARGS=(
   --started-at "$STARTED_AT"
   --started-at-unix "$STARTED_AT_UNIX"
   --wall-sec "$BENCH_WALL_SEC"
+  --parameter-file "$LIDARSLAM_PARAM"
+  --parameter-file "$RKO_PARAM"
+  --benchmark-harness "${BASH_SOURCE[0]}"
+  --runtime-artifact "rko_lio_offline_node=$(ros2 pkg prefix rko_lio)/lib/rko_lio/offline_node"
+  --runtime-artifact "graph_based_slam_node=$(ros2 pkg prefix graph_based_slam)/lib/graph_based_slam/graph_based_slam_node"
 )
 if [[ -n "$REFERENCE_SOURCE" ]]; then
   METRICS_ARGS+=(--reference-source "$REFERENCE_SOURCE")

--- a/scripts/write_rko_lio_benchmark_metrics.py
+++ b/scripts/write_rko_lio_benchmark_metrics.py
@@ -8,6 +8,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+from benchmark_provenance import bag_identity, file_identity, software_identity
+
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 VERIFY_SCRIPT = REPO_ROOT / 'scripts' / 'verify_autoware_map.py'
@@ -111,6 +113,26 @@ def _fmt_path(path: Path | None) -> str:
     return str(path) if path is not None else ''
 
 
+def _trajectory_offset(metadata: dict[str, Any], frame: str) -> dict[str, Any] | None:
+    """Return the generic reference-point offset, with legacy prism fallback."""
+    return (
+        metadata.get(f'{frame}_to_reference_translation_m')
+        or metadata.get(f'{frame}_to_prism_translation_m')
+    )
+
+
+def _infer_reference_kind(source: str, metadata: dict[str, Any]) -> str:
+    explicit = metadata.get('kind')
+    if explicit:
+        return str(explicit)
+    lowered = source.strip().lower()
+    if 'gt' in lowered or 'ground_truth' in lowered:
+        return 'ground_truth'
+    if 'glim' in lowered or 'cross' in lowered:
+        return 'cross_validation'
+    return 'unknown'
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description=(
@@ -210,6 +232,24 @@ def main() -> int:
         help='Output metrics path (default: <out-dir>/metrics.json)',
     )
     parser.add_argument(
+        '--parameter-file',
+        action='append',
+        default=[],
+        help='Effective parameter file to identify; repeat for multiple files.',
+    )
+    parser.add_argument(
+        '--runtime-artifact',
+        action='append',
+        default=[],
+        metavar='LABEL=PATH',
+        help='Runtime executable/library to identify; repeat for multiple artifacts.',
+    )
+    parser.add_argument(
+        '--benchmark-harness',
+        default='',
+        help='Benchmark wrapper/script to identify for release provenance.',
+    )
+    parser.add_argument(
         '--pipeline',
         default='rko_lio',
         choices=('rko_lio', 'lo', 'small_gicp'),
@@ -278,8 +318,9 @@ def main() -> int:
 
     bag_duration_sec = _bag_duration_seconds(bag_path / 'metadata.yaml')
     reference_meta_data = _read_reference_meta(reference_meta) if reference_meta else {}
-    trajectory_offset = reference_meta_data.get(
-        f'{args.trajectory_source_frame}_to_prism_translation_m')
+    trajectory_offset = _trajectory_offset(
+        reference_meta_data, args.trajectory_source_frame)
+    reference_source = reference_meta_data.get('source', args.reference_source)
     raw_ape = _parse_ape_report(raw_ape_path)
     corrected_ape = _parse_ape_report(corrected_ape_path)
     map_verify = _verify_map(out_dir / 'pointcloud_map')
@@ -307,6 +348,11 @@ def main() -> int:
         }
 
     metrics: dict[str, Any] = {
+        'schema_version': 1,
+        'schema_uri': (
+            'https://rsasaki0109.github.io/lidar_slam_ros2/'
+            'schemas/benchmark-metrics-v1.schema.json'
+        ),
         'started_at': args.started_at or None,
         'started_at_unix': args.started_at_unix,
         'pipeline': args.pipeline,
@@ -317,7 +363,8 @@ def main() -> int:
         'imu_topic': args.imu_topic,
         'frames': frames,
         'reference': {
-            'source': reference_meta_data.get('source', args.reference_source),
+            'source': reference_source,
+            'kind': _infer_reference_kind(reference_source, reference_meta_data),
             'tum_path': str(reference_tum),
             'topic': reference_meta_data.get('topic', '/leica/pose/relative'),
             'meta_path': _fmt_path(reference_meta),
@@ -413,6 +460,39 @@ def main() -> int:
             'raw_ape': raw_ape,
         },
     }
+
+    if args.runtime_artifact:
+        runtime_artifacts: list[tuple[str, Path]] = []
+        for value in args.runtime_artifact:
+            label, separator, path = value.partition('=')
+            if not separator or not label or not path:
+                parser.error('--runtime-artifact must be LABEL=PATH')
+            runtime_artifacts.append(
+                (label, Path(path).expanduser().resolve()))
+        parameter_files = [
+            Path(path).expanduser().resolve()
+            for path in (
+                args.parameter_file
+                or [str(lidarslam_param), str(rko_param)]
+            )
+        ]
+        harness_path = (
+            Path(args.benchmark_harness).expanduser().resolve()
+            if args.benchmark_harness else Path(__file__).resolve()
+        )
+        metrics['provenance'] = {
+            'input': {
+                'bag': bag_identity(bag_path),
+                'reference_trajectory': file_identity(reference_tum),
+            },
+            'software': software_identity(
+                REPO_ROOT,
+                parameter_files=parameter_files,
+                runtime_artifacts=runtime_artifacts,
+                benchmark_harness=harness_path,
+                metrics_writer=Path(__file__).resolve(),
+            ),
+        }
 
     metrics_path.parent.mkdir(parents=True, exist_ok=True)
     metrics_path.write_text(


### PR DESCRIPTION
## What changed

- encode the official RTK-SLAM IMU-to-base-center scoring offset in generated reference metadata
- accept generic `*_to_reference_translation_m` contracts while preserving legacy prism metadata
- validate the frame-offset contract before starting long RKO-LIO bag replay
- record release-grade bag, trajectory, Git, parameter, harness, writer, and runtime-artifact provenance in RKO benchmark metrics
- add regression coverage for the generic reference contract, fail-closed shell behavior, and provenance payload

## Why

The v0.9 RTK-SLAM construction_seq1 run completed sensor replay and map generation, then failed during scoring because the generated reference metadata omitted the official evaluation-point offset. Process substitution also masked the Python validation failure until an empty Bash array was indexed. Separately, this benchmark path did not emit the clean provenance required by the release profiles.

## Impact

Malformed scoring metadata now fails before a potentially multi-hour replay. RTK-SLAM trajectories are evaluated at the official base-center point, and successful RKO benchmark outputs can satisfy the same reproducibility contract as other release evidence.

## Validation

- focused benchmark/reference suite: 31 passed
- graph_based_slam Python suite: 1332 passed, 13 skipped; 8 environment-only failures were rerun after sourcing ROS 2 Jazzy
- ROS-dependent rerun: 13 passed
- `bash -n scripts/run_rko_lio_graph_benchmark.sh`
- `python3 -m py_compile` for changed Python scripts
- `git diff --check`
