### PR TITLE
fix(bench): require complete release replays

### DIFF
--- a/configs/mid360_robot/rko_lio_rtk_slam_mid360.yaml
+++ b/configs/mid360_robot/rko_lio_rtk_slam_mid360.yaml
@@ -1,6 +1,6 @@
 # RKO-LIO config for the public RTK-SLAM dataset (Livox MID-360 + total-station
 # ground truth; arXiv:2604.07151, CC-BY 4.0). Used to produce our own estimate
-# trajectory for the mid360_gt_rtkslam_* release profiles (v0.5).
+# trajectory for the mid360_gt_rtkslam_* release profiles.
 #
 # Topics: /livox/points (sensor_msgs/PointCloud2) + /livox/imu (200 Hz).
 # Extrinsics are identity: the gate scores the SE(3)-aligned checkpoint RMSE, so
@@ -9,7 +9,9 @@
 # deskew is OFF: the dataset's /livox/points carries a Livox `offset_time` field
 # rather than the per-point timestamp RKO-LIO deskew expects, so RKO-LIO falls
 # back to the scan header time anyway. voxel/range follow the validated MID-360
-# low-voxel preset.
+# low-voxel preset. Keep the second downsample disabled: clean full-sequence
+# validation improved Construction Hall 1 from 0.569 m to 0.321 m RMSE and the
+# seq2 holdout from 0.125 m to 0.086 m, without sequence-specific tuning.
 extrinsic_imu2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
 extrinsic_lidar2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
 initialization_phase: false
@@ -17,4 +19,4 @@ deskew: false
 voxel_size: 0.5
 min_range: 1.0
 max_range: 100.0
-double_downsample: true
+double_downsample: false

--- a/configs/mid360_robot/rko_lio_rtk_slam_mid360_outdoor.yaml
+++ b/configs/mid360_robot/rko_lio_rtk_slam_mid360_outdoor.yaml
@@ -1,10 +1,11 @@
 # RKO-LIO outdoor config for the public RTK-SLAM dataset (Stadtgarten park
 # sequences; Livox MID-360 + total-station GT; arXiv:2604.07151, CC-BY 4.0).
 #
-# Identical to rko_lio_rtk_slam_mid360.yaml (the indoor preset) except
-# double_downsample is OFF: in the sparse park scene the second downsample
-# starves ICP of correspondences and the odometry drifts to 3.9 m RMSE on
-# stadtgarten_seq2; keeping every voxel sample brings it to 0.835 m
+# The shared RTK-SLAM preset now also disables double_downsample after clean
+# Construction Hall cross-validation improved both sequences. In the sparse
+# park scene the second downsample starves ICP of correspondences and the
+# odometry drifts to 3.9 m RMSE on stadtgarten_seq2; keeping every voxel sample
+# brings it to 0.835 m
 # (median 0.327). Coarser voxels (1.0 m + 1.0 m correspondence distance)
 # scored worse (2.35 m) — keep voxel 0.5 and just stop discarding points.
 # Sweep record: docs/research/rtkslam-total-station-gt-methodology.md.

--- a/docs/schemas/benchmark-metrics-v1.schema.json
+++ b/docs/schemas/benchmark-metrics-v1.schema.json
@@ -18,6 +18,32 @@
       "const": "https://rsasaki0109.github.io/lidar_slam_ros2/schemas/benchmark-metrics-v1.schema.json"
     },
     "bag_path": {"type": "string"},
+    "completion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "reason",
+        "end_margin_sec",
+        "input_points_messages",
+        "raw_output_pose_count",
+        "raw_output_pose_ratio"
+      ],
+      "properties": {
+        "reason": {
+          "type": ["string", "null"],
+          "enum": [
+            "offline_result_dump",
+            "offline_completion_marker",
+            "trajectory_near_bag_end",
+            null
+          ]
+        },
+        "end_margin_sec": {"type": ["number", "null"], "minimum": 0},
+        "input_points_messages": {"type": ["integer", "null"], "minimum": 0},
+        "raw_output_pose_count": {"type": "integer", "minimum": 0},
+        "raw_output_pose_ratio": {"type": ["number", "null"], "minimum": 0}
+      }
+    },
     "reference": {"type": "object"},
     "lidarslam": {"type": "object"},
     "evo": {"type": "object"},

--- a/graph_based_slam/test/test_rko_lio_benchmark_tools.py
+++ b/graph_based_slam/test/test_rko_lio_benchmark_tools.py
@@ -39,6 +39,7 @@ import struct
 import subprocess
 import sys
 
+import jsonschema
 import yaml
 
 
@@ -182,6 +183,10 @@ def test_write_rko_lio_metrics_generates_compatible_metrics_json(tmp_path):
             '  storage_identifier: sqlite3',
             '  duration:',
             '    nanoseconds: 2000000000',
+            '  topics_with_message_count:',
+            '    - topic_metadata:',
+            '        name: /os1_cloud_node1/points',
+            '      message_count: 2',
         ]),
         encoding='utf-8',
     )
@@ -263,6 +268,10 @@ def test_write_rko_lio_metrics_generates_compatible_metrics_json(tmp_path):
             'body',
             '--wall-sec',
             '1.0',
+            '--completion-reason',
+            'offline_completion_marker',
+            '--completion-end-margin-secs',
+            '0.25',
             '--runtime-artifact',
             'test_runtime=/bin/true',
             '--benchmark-harness',
@@ -278,6 +287,10 @@ def test_write_rko_lio_metrics_generates_compatible_metrics_json(tmp_path):
     metrics_path = out_dir / 'metrics.json'
     assert metrics_path.is_file()
     metrics = json.loads(metrics_path.read_text(encoding='utf-8'))
+    schema = json.loads(
+        (REPO_ROOT / 'docs/schemas/benchmark-metrics-v1.schema.json').read_text(
+            encoding='utf-8'))
+    jsonschema.validate(metrics, schema)
 
     assert metrics['reference']['source'] == 'leica_prism_gt'
     assert metrics['lidarslam']['success'] is True
@@ -290,6 +303,10 @@ def test_write_rko_lio_metrics_generates_compatible_metrics_json(tmp_path):
     assert metrics['rko_lio']['trajectory_source_frame'] == 'body'
     assert metrics['rko_lio']['prism_offset_m']['x'] == -0.293656
     assert metrics['schema_version'] == 1
+    assert metrics['completion']['reason'] == 'offline_completion_marker'
+    assert metrics['completion']['input_points_messages'] == 2
+    assert metrics['completion']['raw_output_pose_count'] == 2
+    assert metrics['completion']['raw_output_pose_ratio'] == 1.0
     assert metrics['reference']['kind'] == 'ground_truth'
     assert metrics['provenance']['input']['bag']['identity_algorithm'] == 'sha256'
     assert metrics['provenance']['software']['runtime_artifacts'][0][

--- a/graph_based_slam/test/test_rko_lio_benchmark_tools.py
+++ b/graph_based_slam/test/test_rko_lio_benchmark_tools.py
@@ -40,6 +40,7 @@ import subprocess
 import sys
 
 import jsonschema
+import pytest
 import yaml
 
 
@@ -47,6 +48,8 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 REFERENCE_SCRIPT = REPO_ROOT / 'scripts' / 'generate_ntu_viral_tnp01_reference.py'
 WRITE_METRICS_SCRIPT = REPO_ROOT / 'scripts' / 'write_rko_lio_benchmark_metrics.py'
 sys.path.insert(0, str(REPO_ROOT / 'scripts'))
+
+import benchmark_provenance
 
 
 def _load_module(path: Path, name: str):
@@ -61,6 +64,38 @@ def _load_module(path: Path, name: str):
 REFERENCE_MODULE = _load_module(REFERENCE_SCRIPT, 'generate_ntu_viral_tnp01_reference')
 WRITE_METRICS_MODULE = _load_module(
     WRITE_METRICS_SCRIPT, 'write_rko_lio_benchmark_metrics')
+
+
+def test_git_provenance_explicitly_trusts_only_selected_repo(
+        monkeypatch, tmp_path: Path):
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        stdout = 'a' * 40 + '\n' if 'rev-parse' in command else ''
+        return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr='')
+
+    monkeypatch.setattr(benchmark_provenance.subprocess, 'run', fake_run)
+
+    state = benchmark_provenance._git_state(tmp_path)
+
+    expected_prefix = ['git', '-c', f'safe.directory={tmp_path}']
+    assert [call[0][:3] for call in calls] == [
+        expected_prefix, expected_prefix]
+    assert all(call[1]['cwd'] == tmp_path for call in calls)
+    assert state == {'git_commit': 'a' * 40, 'git_dirty': False}
+
+
+def test_git_provenance_rejects_unidentifiable_commit(
+        monkeypatch, tmp_path: Path):
+    def fake_run(command, **kwargs):
+        return subprocess.CompletedProcess(
+            command, 128, stdout='', stderr='dubious ownership')
+
+    monkeypatch.setattr(benchmark_provenance.subprocess, 'run', fake_run)
+
+    with pytest.raises(RuntimeError, match='dubious ownership'):
+        benchmark_provenance._git_state(tmp_path)
 
 
 def _write_binary_xyz_pcd(path, points):

--- a/graph_based_slam/test/test_rko_lio_graph_benchmark_script.py
+++ b/graph_based_slam/test/test_rko_lio_graph_benchmark_script.py
@@ -135,6 +135,20 @@ def test_rko_lio_benchmark_rejects_invalid_bool_without_usage_dump():
     assert 'Usage:' not in result.stderr
 
 
+def test_rko_lio_benchmark_rejects_unsafe_completion_margin():
+    result = _run_benchmark('--completion-end-margin-secs', 'nan')
+
+    assert result.returncode == 2
+    assert 'must be a non-negative finite number' in result.stderr
+
+
+def test_rko_lio_benchmark_rejects_non_integer_timeout():
+    result = _run_benchmark('--offline-timeout-secs', '1.5')
+
+    assert result.returncode == 2
+    assert 'offline_timeout_secs must be a positive integer' in result.stderr
+
+
 def test_rko_lio_benchmark_reports_missing_bag_without_realpath(tmp_path: Path):
     result = _run_benchmark(
         '--bag',

--- a/graph_based_slam/test/test_rko_lio_graph_benchmark_script.py
+++ b/graph_based_slam/test/test_rko_lio_graph_benchmark_script.py
@@ -97,10 +97,26 @@ def test_quiet_completion_requires_substantial_bag_progress():
     """Require both near-end and minimum-progress quiet-completion guards."""
     script = BENCHMARK_SCRIPT.read_text(encoding='utf-8')
 
-    assert 'COMPLETION_END_MARGIN_SECS=120' in script
+    assert 'COMPLETION_END_MARGIN_SECS=0.25' in script
     assert 'raw_tum_reached "$end_stamp" "$COMPLETION_END_MARGIN_SECS"' in script
     assert 'raw_tum_reached_fraction 0.8' in script
     assert '[[ -n "$end_stamp" ]]' in script
+    assert 'aborted-but-scoreable' not in script
+
+
+def test_signal_handlers_exit_instead_of_continuing_to_map_save():
+    script = BENCHMARK_SCRIPT.read_text(encoding='utf-8')
+
+    assert "trap 'on_signal 130' INT" in script
+    assert "trap 'on_signal 143' TERM" in script
+    assert 'trap cleanup EXIT INT TERM' not in script
+
+
+def test_reference_offset_preflight_requires_finite_numbers():
+    script = BENCHMARK_SCRIPT.read_text(encoding='utf-8')
+
+    assert 'math.isfinite(numeric)' in script
+    assert 'must be a finite number' in script
 
 
 def test_rko_lio_benchmark_rejects_missing_option_value_before_realpath():

--- a/scripts/benchmark_provenance.py
+++ b/scripts/benchmark_provenance.py
@@ -96,27 +96,34 @@ def bag_identity(bag_path: Path) -> dict[str, Any]:
 
 
 def _git_state(repo_root: Path) -> dict[str, Any]:
+    # CI commonly runs tests in a container while the checkout is owned by the
+    # host runner. Trust only the repository path explicitly supplied by the
+    # caller; otherwise Git's dubious-ownership guard makes valid provenance
+    # silently degrade to null.
+    git_command = ['git', '-c', f'safe.directory={repo_root}']
     commit = subprocess.run(
-        ['git', 'rev-parse', 'HEAD'],
+        [*git_command, 'rev-parse', 'HEAD'],
         cwd=repo_root,
         check=False,
         capture_output=True,
         text=True,
     )
     status = subprocess.run(
-        ['git', 'status', '--porcelain', '--untracked-files=normal'],
+        [*git_command, 'status', '--porcelain', '--untracked-files=normal'],
         cwd=repo_root,
         check=False,
         capture_output=True,
         text=True,
     )
+    if commit.returncode != 0:
+        detail = commit.stderr.strip() or 'unknown git error'
+        raise RuntimeError(f'failed to identify benchmark git commit: {detail}')
+    if status.returncode != 0:
+        detail = status.stderr.strip() or 'unknown git error'
+        raise RuntimeError(f'failed to identify benchmark git status: {detail}')
     return {
-        'git_commit': (
-            commit.stdout.strip() if commit.returncode == 0 else None
-        ),
-        'git_dirty': (
-            bool(status.stdout.strip()) if status.returncode == 0 else None
-        ),
+        'git_commit': commit.stdout.strip(),
+        'git_dirty': bool(status.stdout.strip()),
     }
 
 

--- a/scripts/release_profiles.yaml
+++ b/scripts/release_profiles.yaml
@@ -130,9 +130,9 @@ release_profiles:
     pass: 0.55
     target: 0.30
 
-  # Outdoor pair (Stadtgarten park) -- measured with the outdoor preset
+  # Outdoor pair (Stadtgarten park) -- measured with the shared dd-off preset
   # (configs/mid360_robot/rko_lio_rtk_slam_mid360_outdoor.yaml,
-  # double_downsample off; the indoor preset drifts to 3.9 m here). These are
+  # double_downsample off; the former dd-on preset drifts to 3.9 m here). These are
   # honest capability-boundary numbers for LiDAR-inertial raw odometry without
   # GNSS or loop closure (published GNSS-anchored baselines sit at ~0.07 m):
   # stadtgarten_seq2 0.835 m (median 0.327, 19 chkpt), stadtgarten_seq1

--- a/scripts/run_rko_lio_graph_benchmark.sh
+++ b/scripts/run_rko_lio_graph_benchmark.sh
@@ -68,6 +68,19 @@ parse_bool() {
   esac
 }
 
+validate_timing_options() {
+  local option value
+  for option in STARTUP_TIMEOUT_SECS SAVE_TIMEOUT_SECS OFFLINE_TIMEOUT_SECS QUIESCENCE_SECS; do
+    value="${!option}"
+    if [[ ! "$value" =~ ^[1-9][0-9]*$ ]]; then
+      fail "${option,,} must be a positive integer."
+    fi
+  done
+  if [[ ! "$COMPLETION_END_MARGIN_SECS" =~ ^([0-9]+([.][0-9]*)?|[.][0-9]+)$ ]]; then
+    fail "--completion-end-margin-secs must be a non-negative finite number."
+  fi
+}
+
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
 WS_ROOT="${REPO_ROOT}"
@@ -219,6 +232,8 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+validate_timing_options
 
 default_benchmark_bag_missing_hint() {
   cat >&2 <<EOF

--- a/scripts/run_rko_lio_graph_benchmark.sh
+++ b/scripts/run_rko_lio_graph_benchmark.sh
@@ -23,7 +23,7 @@ Options:
   --offline-timeout-secs <sec>   Max wall-clock for the offline node to finish the bag (default: 1800)
   --quiescence-secs <sec>        Treat the run as done after this many stable seconds (default: 20)
   --completion-end-margin-secs <sec>
-                                 Required trajectory proximity to bag end (default: 120)
+                                 Required trajectory proximity to bag end (default: 0.25)
   --skip-map-save                Do not call /map_save or verify the map bundle
   --skip-reference-gen           Reuse an existing reference TUM/meta without regenerating it
   --publish-static-tf BOOL       static_transform_publisher (default: true)
@@ -99,7 +99,7 @@ RUN_NAME=""
 STARTUP_TIMEOUT_SECS=30
 SAVE_TIMEOUT_SECS=60
 QUIESCENCE_SECS=20
-COMPLETION_END_MARGIN_SECS=120
+COMPLETION_END_MARGIN_SECS=0.25
 # Max wall-clock to wait for the offline node to finish replaying the bag.
 # Long / compute-heavy sequences (e.g. dense indoor MID-360) can process well
 # below real time; raise this so the run is not cut off mid-bag.
@@ -314,6 +314,7 @@ LAUNCH_PID=""
 LAUNCH_PGID=""
 RAW_LOGGER_PID=""
 CORRECTED_LOGGER_PID=""
+COMPLETION_REASON=""
 
 cleanup() {
   terminate_pid "$RAW_LOGGER_PID"
@@ -324,7 +325,17 @@ cleanup() {
     terminate_pid "$LAUNCH_PID"
   fi
 }
-trap cleanup EXIT INT TERM
+
+on_signal() {
+  local exit_code="$1"
+  trap - EXIT INT TERM
+  cleanup
+  exit "$exit_code"
+}
+
+trap cleanup EXIT
+trap 'on_signal 130' INT
+trap 'on_signal 143' TERM
 
 terminate_pid() {
   local pid="${1:-}"
@@ -483,24 +494,26 @@ wait_for_offline_completion() {
   local last_signature=""
   local stable_since=0
   local deadline=$((SECONDS + timeout_secs))
-  # Primary completion signal: the raw trajectory has reached the bag end and
-  # gone quiet. Quiescence alone is NOT enough — buffered TUM writes can stall
-  # for tens of seconds mid-run and fake completion. A long stall (10x the
-  # quiescence window) is still accepted as a crash/abort fallback.
+  # Primary completion signal: the offline node records successful completion.
+  # A trajectory that reaches the actual bag end and goes quiet is the fallback
+  # for runtimes without that marker. Quiescence or process exit alone is never
+  # enough: buffered TUM writes can pause for tens of seconds mid-run.
   local end_stamp=""
   end_stamp="$(bag_end_stamp 2>/dev/null)" || end_stamp=""
-  local stall_secs=$((QUIESCENCE_SECS * 10))
 
   while (( SECONDS < deadline )); do
     if [[ -s "$RKO_RESULT_TUM" ]]; then
+      COMPLETION_REASON="offline_result_dump"
       return 0
     fi
     if offline_completion_recorded; then
+      COMPLETION_REASON="offline_completion_marker"
       return 0
     fi
 
     if [[ -n "$LAUNCH_PID" ]] && ! kill -0 "$LAUNCH_PID" 2>/dev/null; then
-      return 0
+      echo "Offline launch exited without a completion marker or result dump." >&2
+      return 1
     fi
 
     local current_signature
@@ -510,17 +523,11 @@ wait_for_offline_completion() {
         stable_since=$SECONDS
       fi
       if (( SECONDS - stable_since >= QUIESCENCE_SECS )); then
-        # Some generic bags retain non-LiDAR topics after the sensor stream,
-        # so the historical default is 120 s. Competitive profiles set a
-        # dataset-specific tight margin and record it in their provenance.
         if [[ -n "$end_stamp" ]] && \
           raw_tum_reached "$end_stamp" "$COMPLETION_END_MARGIN_SECS" && \
           raw_tum_reached_fraction 0.8; then
           echo "Trajectory reached the bag end and stayed quiet for ${QUIESCENCE_SECS}s; treating benchmark run as complete"
-          return 0
-        fi
-        if (( SECONDS - stable_since >= stall_secs )); then
-          echo "Warning: trajectory stalled for ${stall_secs}s before the bag end; treating benchmark run as aborted-but-scoreable" >&2
+          COMPLETION_REASON="trajectory_near_bag_end"
           return 0
         fi
       fi
@@ -584,6 +591,7 @@ fi
 # substitution would silently turn a malformed contract into an empty array.
 if ! PRISM_TRANSFORM_OUTPUT="$(python3 - "$REFERENCE_META" <<'PY'
 import json
+import math
 import sys
 from pathlib import Path
 
@@ -592,10 +600,26 @@ for frame in ("base", "body", "imu"):
     for suffix in ("reference", "prism"):
         offset = meta.get(f"{frame}_to_{suffix}_translation_m")
         if offset is not None:
+            if not isinstance(offset, dict):
+                raise SystemExit(f"{frame} offset must be an object with finite xyz values")
+            values = []
+            for axis in ("x", "y", "z"):
+                value = offset.get(axis)
+                if isinstance(value, bool):
+                    raise SystemExit(f"{frame} offset {axis} must be a finite number")
+                try:
+                    numeric = float(value)
+                except (TypeError, ValueError):
+                    raise SystemExit(
+                        f"{frame} offset {axis} must be a finite number"
+                    ) from None
+                if not math.isfinite(numeric):
+                    raise SystemExit(f"{frame} offset {axis} must be a finite number")
+                values.append(numeric)
             print(frame)
-            print(offset["x"])
-            print(offset["y"])
-            print(offset["z"])
+            print(values[0])
+            print(values[1])
+            print(values[2])
             raise SystemExit(0)
 else:
     raise SystemExit(
@@ -794,6 +818,8 @@ METRICS_ARGS=(
   --started-at "$STARTED_AT"
   --started-at-unix "$STARTED_AT_UNIX"
   --wall-sec "$BENCH_WALL_SEC"
+  --completion-reason "$COMPLETION_REASON"
+  --completion-end-margin-secs "$COMPLETION_END_MARGIN_SECS"
   --parameter-file "$LIDARSLAM_PARAM"
   --parameter-file "$RKO_PARAM"
   --benchmark-harness "${BASH_SOURCE[0]}"

--- a/scripts/write_rko_lio_benchmark_metrics.py
+++ b/scripts/write_rko_lio_benchmark_metrics.py
@@ -8,6 +8,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 from benchmark_provenance import bag_identity, file_identity, software_identity
 
 
@@ -87,6 +89,22 @@ def _bag_duration_seconds(metadata_path: Path) -> float | None:
             return nanoseconds / 1e9
         if in_duration and stripped and not line.startswith(' '):
             break
+    return None
+
+
+def _bag_topic_message_count(metadata_path: Path, topic: str) -> int | None:
+    """Return the recorded message count for a topic from rosbag2 metadata."""
+    if not metadata_path.is_file():
+        return None
+    try:
+        data = yaml.safe_load(metadata_path.read_text(encoding='utf-8')) or {}
+        topics = data['rosbag2_bagfile_information']['topics_with_message_count']
+        for entry in topics:
+            metadata = entry.get('topic_metadata', {})
+            if metadata.get('name') == topic:
+                return int(entry['message_count'])
+    except (KeyError, TypeError, ValueError, yaml.YAMLError):
+        return None
     return None
 
 
@@ -216,6 +234,17 @@ def main() -> int:
         help='Measured wall time for the full benchmark run',
     )
     parser.add_argument(
+        '--completion-reason',
+        default='',
+        help='Authoritative reason the replay was considered complete.',
+    )
+    parser.add_argument(
+        '--completion-end-margin-secs',
+        type=float,
+        default=None,
+        help='Allowed trajectory-to-bag-end gap for completion fallback.',
+    )
+    parser.add_argument(
         '--started-at',
         default='',
         help='Optional ISO-8601 start timestamp',
@@ -317,6 +346,8 @@ def main() -> int:
     )
 
     bag_duration_sec = _bag_duration_seconds(bag_path / 'metadata.yaml')
+    input_points_messages = _bag_topic_message_count(
+        bag_path / 'metadata.yaml', args.points_topic)
     reference_meta_data = _read_reference_meta(reference_meta) if reference_meta else {}
     trajectory_offset = _trajectory_offset(
         reference_meta_data, args.trajectory_source_frame)
@@ -331,6 +362,11 @@ def main() -> int:
     rtf = None
     if wall_sec is not None and bag_duration_sec and bag_duration_sec > 0.0:
         rtf = wall_sec / bag_duration_sec
+    raw_output_pose_count = _read_pose_count(raw_tum)
+    raw_output_pose_ratio = (
+        raw_output_pose_count / input_points_messages
+        if input_points_messages and input_points_messages > 0 else None
+    )
 
     if args.pipeline in ('lo', 'small_gicp'):
         frames: dict[str, str] = {
@@ -361,6 +397,13 @@ def main() -> int:
         'bag_duration_sec': bag_duration_sec,
         'points_topic': args.points_topic,
         'imu_topic': args.imu_topic,
+        'completion': {
+            'reason': args.completion_reason or None,
+            'end_margin_sec': args.completion_end_margin_secs,
+            'input_points_messages': input_points_messages,
+            'raw_output_pose_count': raw_output_pose_count,
+            'raw_output_pose_ratio': raw_output_pose_ratio,
+        },
         'frames': frames,
         'reference': {
             'source': reference_source,
@@ -375,7 +418,8 @@ def main() -> int:
             'wall_sec': wall_sec,
             'rtf': rtf,
             'tum_path': str(corrected_tum if corrected_tum.is_file() else raw_tum),
-            'tum_lines': _read_pose_count(corrected_tum if corrected_tum.is_file() else raw_tum),
+            'tum_lines': _read_pose_count(
+                corrected_tum if corrected_tum.is_file() else raw_tum),
             'log_path': str(launch_log) if launch_log.is_file() else '',
             'param_path': str(lidarslam_param),
             'out_dir': str(out_dir),


### PR DESCRIPTION
## What changed

- require an authoritative offline completion signal or a trajectory within 0.25 s of the bag end
- fail launches that exit or stall before completion instead of scoring partial runs
- make SIGINT/SIGTERM clean up and exit with 130/143, preventing map-save and scoring after cancellation
- validate reference-frame xyz offsets as finite numbers before replay
- record completion reason, expected LiDAR message count, raw output pose count, and their ratio in benchmark metrics/schema
- adopt `double_downsample: false` for the shared RTK-SLAM MID-360 preset after clean full-sequence cross-validation

## Why

The former 120 s completion margin allowed a mid-sequence writer pause to look complete. That produced partial but apparently valid release evidence and allowed an interrupted run to continue into map-save. Release evidence must prove the complete input was processed.

The MID-360 setting is backed by clean full-sequence results: Construction Hall 1 improved from 0.569 m to 0.321 m RMSE and the seq2 holdout improved from 0.125 m to 0.086 m.

## Validation

- `bash -n scripts/run_rko_lio_graph_benchmark.sh`
- focused benchmark/config/docs tests: 33 passed
- full `graph_based_slam/test` under ROS 2 Jazzy: 1342 passed, 13 skipped
- `git diff --check`
