### PR TITLE
test(bench): keep provenance import lint-clean

### DIFF
--- a/graph_based_slam/test/test_rko_lio_benchmark_tools.py
+++ b/graph_based_slam/test/test_rko_lio_benchmark_tools.py
@@ -47,9 +47,8 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[2]
 REFERENCE_SCRIPT = REPO_ROOT / 'scripts' / 'generate_ntu_viral_tnp01_reference.py'
 WRITE_METRICS_SCRIPT = REPO_ROOT / 'scripts' / 'write_rko_lio_benchmark_metrics.py'
+BENCHMARK_PROVENANCE_SCRIPT = REPO_ROOT / 'scripts' / 'benchmark_provenance.py'
 sys.path.insert(0, str(REPO_ROOT / 'scripts'))
-
-import benchmark_provenance
 
 
 def _load_module(path: Path, name: str):
@@ -64,6 +63,8 @@ def _load_module(path: Path, name: str):
 REFERENCE_MODULE = _load_module(REFERENCE_SCRIPT, 'generate_ntu_viral_tnp01_reference')
 WRITE_METRICS_MODULE = _load_module(
     WRITE_METRICS_SCRIPT, 'write_rko_lio_benchmark_metrics')
+BENCHMARK_PROVENANCE_MODULE = _load_module(
+    BENCHMARK_PROVENANCE_SCRIPT, 'benchmark_provenance_for_test')
 
 
 def test_git_provenance_explicitly_trusts_only_selected_repo(
@@ -75,9 +76,9 @@ def test_git_provenance_explicitly_trusts_only_selected_repo(
         stdout = 'a' * 40 + '\n' if 'rev-parse' in command else ''
         return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr='')
 
-    monkeypatch.setattr(benchmark_provenance.subprocess, 'run', fake_run)
+    monkeypatch.setattr(BENCHMARK_PROVENANCE_MODULE.subprocess, 'run', fake_run)
 
-    state = benchmark_provenance._git_state(tmp_path)
+    state = BENCHMARK_PROVENANCE_MODULE._git_state(tmp_path)
 
     expected_prefix = ['git', '-c', f'safe.directory={tmp_path}']
     assert [call[0][:3] for call in calls] == [
@@ -92,10 +93,10 @@ def test_git_provenance_rejects_unidentifiable_commit(
         return subprocess.CompletedProcess(
             command, 128, stdout='', stderr='dubious ownership')
 
-    monkeypatch.setattr(benchmark_provenance.subprocess, 'run', fake_run)
+    monkeypatch.setattr(BENCHMARK_PROVENANCE_MODULE.subprocess, 'run', fake_run)
 
     with pytest.raises(RuntimeError, match='dubious ownership'):
-        benchmark_provenance._git_state(tmp_path)
+        BENCHMARK_PROVENANCE_MODULE._git_state(tmp_path)
 
 
 def _write_binary_xyz_pcd(path, points):


### PR DESCRIPTION
## What changed

- load the benchmark provenance helper through the existing test-module loader
- remove the late module import that violated the ROS ament flake8 policy

## Why

PR #414's provenance behavior passed in both Humble and Jazzy containers, but its new regression test triggered `E402 module level import not at top of file`. This is a test-only lint correction; the strict provenance implementation and schema remain unchanged.

## Validation

- benchmark provenance/metrics tests: 6 passed
- `ament_flake8 graph_based_slam/test/test_rko_lio_benchmark_tools.py`: no problems
- `git diff --check`
