### PR TITLE
Preserve source provenance in installed runtimes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,6 +43,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      - name: Resolve source revision
+        id: source
+        shell: bash
+        run: echo "revision=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
+
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v4
@@ -74,6 +79,8 @@ jobs:
           context: .
           build-args: |
             ROS_DISTRO=${{ matrix.ros_distro }}
+            LIDARSLAM_SOURCE_REVISION=${{ steps.source.outputs.revision }}
+            LIDARSLAM_SOURCE_DIRTY=false
           platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' }}
           load: ${{ github.event_name == 'pull_request' }}
@@ -109,10 +116,19 @@ jobs:
             echo "unexpected CLI version: ${OBSERVED_VERSION}" >&2
             exit 1
           fi
+          OBSERVED_REVISION="$(
+            docker run --rm "${IMAGE_REF}" python3 -c \
+              'import json, pathlib, subprocess; prefix = pathlib.Path(subprocess.check_output(["ros2", "pkg", "prefix", "lidarslam"], text=True).strip()); print(json.loads((prefix / "share/lidarslam/product/product-build-info.json").read_text())["revision"])'
+          )"
+          if [[ "${OBSERVED_REVISION}" != "${{ steps.source.outputs.revision }}" ]]; then
+            echo "unexpected installed source revision: ${OBSERVED_REVISION}" >&2
+            exit 1
+          fi
           {
             echo "## ${{ matrix.ros_distro }} convenience image"
             echo
             echo "- CLI: \`${OBSERVED_VERSION}\`"
+            echo "- Source revision: \`${OBSERVED_REVISION}\`"
             if [[ -n "${EXPECTED_DIGEST}" ]]; then
               echo "- Digest: \`${EXPECTED_DIGEST}\`"
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      - name: Resolve source revision
+        id: source
+        shell: bash
+        run: echo "revision=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
         with:
@@ -162,6 +167,8 @@ jobs:
           context: .
           build-args: |
             ROS_DISTRO=${{ matrix.ros_distro }}
+            LIDARSLAM_SOURCE_REVISION=${{ steps.source.outputs.revision }}
+            LIDARSLAM_SOURCE_DIRTY=false
           platforms: linux/amd64
           outputs: |
             type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
@@ -212,6 +219,14 @@ jobs:
             echo "CLI version '${OBSERVED_VERSION}' != '${EXPECTED_OUTPUT}'" >&2
             exit 1
           fi
+          OBSERVED_REVISION="$(
+            docker run --rm "${IMAGE_REF}" python3 -c \
+              'import json, pathlib, subprocess; prefix = pathlib.Path(subprocess.check_output(["ros2", "pkg", "prefix", "lidarslam"], text=True).strip()); print(json.loads((prefix / "share/lidarslam/product/product-build-info.json").read_text())["revision"])'
+          )"
+          if [[ "${OBSERVED_REVISION}" != "${EXPECTED_GIT_COMMIT}" ]]; then
+            echo "installed source revision '${OBSERVED_REVISION}' != '${EXPECTED_GIT_COMMIT}'" >&2
+            exit 1
+          fi
           if [[ "${OBSERVED_COMMIT}" != "${EXPECTED_GIT_COMMIT}" ]]; then
             echo "image revision '${OBSERVED_COMMIT}' != '${EXPECTED_GIT_COMMIT}'" >&2
             exit 1
@@ -260,6 +275,7 @@ jobs:
             echo "- Tag: \`${IMAGE_TAG}\`"
             echo "- Digest: \`${EXPECTED_DIGEST}\`"
             echo "- CLI: \`${OBSERVED_VERSION}\`"
+            echo "- Installed source revision: \`${OBSERVED_REVISION}\`"
           } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Upload release-image evidence

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@
 ARG ROS_DISTRO=humble
 FROM ros:${ROS_DISTRO}-ros-core
 ARG ROS_DISTRO
+ARG LIDARSLAM_SOURCE_REVISION=
+ARG LIDARSLAM_SOURCE_DIRTY=
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -61,7 +63,10 @@ RUN apt-get update \
 # No --symlink-install: a symlinked install/ dangles once build/ is removed.
 RUN . "/opt/ros/${ROS_DISTRO}/setup.sh" \
   && colcon build --packages-up-to lidarslam rko_lio \
-    --cmake-args -DCMAKE_BUILD_TYPE=Release \
+    --cmake-args \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DLIDARSLAM_SOURCE_REVISION:STRING="${LIDARSLAM_SOURCE_REVISION}" \
+      -DLIDARSLAM_SOURCE_DIRTY:STRING="${LIDARSLAM_SOURCE_DIRTY}" \
   && . install/setup.sh \
   && lidarslam-map --version \
   && rm -rf build log

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -141,6 +141,36 @@ Only the last two named-distro artifacts together prove the normal apt path;
 the implemented workflow alone is not evidence that unpublished packages
 exist.
 
+## Installed source identity
+
+Every official install includes
+`share/lidarslam/product/product-build-info.json`. The map runner uses this
+file to populate `software.git_commit` and `software.git_dirty` in
+`run_manifest.json`, even when the installed command runs outside its source
+checkout.
+
+A normal Git clone records its current 40-character commit and tracked dirty
+state at build time. Untracked files are excluded, matching the runtime
+manifest policy. The file contains no build timestamp or host path, so two
+builds with the same source identity produce identical metadata.
+
+Docker excludes `.git` from its build context. The Humble/Jazzy image
+workflows therefore pass the checked-out revision and `dirty=false` explicitly
+and reject an image whose installed revision differs from the checkout.
+Packagers building from a Git-free source archive must provide the same
+identity:
+
+```bash
+colcon build --cmake-args \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DLIDARSLAM_SOURCE_REVISION:STRING=<40-character-commit> \
+  -DLIDARSLAM_SOURCE_DIRTY:STRING=false
+```
+
+Without Git metadata or an explicit revision, the generated file records
+`revision: null` and `dirty: null` rather than inventing provenance. Official
+clean-prefix checks reject that incomplete identity.
+
 ## Container install
 
 GHCR is the supported prebuilt amd64 delivery path for both ROS distributions.
@@ -172,8 +202,9 @@ docker run --rm "$IMAGE" lidarslam-map --version
 Use an exact digest for deployment or rollback. Each GitHub Release attaches
 `release-image-humble.json` and `release-image-jazzy.json`; they record the
 tested tag, digest, tag commit, platform, product version, and observed CLI
-version. It also attaches the schema-validated rollback plan generated from
-each record:
+version. The release workflow also rejects a runtime whose installed source
+revision differs from that tag commit. It attaches the schema-validated
+rollback plan generated from each record:
 
 ```bash
 lidarslam-map rollback-plan release-image-jazzy.json

--- a/docs/golden-path-cli.md
+++ b/docs/golden-path-cli.md
@@ -90,6 +90,11 @@ Hashing large bags adds a sequential input read before execution. This is
 deliberate: the manifest identifies the data that was actually processed,
 rather than only the path where it happened to be stored.
 
+Installed commands read Git revision and dirty state from deterministic
+build-time metadata, so moving or deleting the source/build tree does not erase
+software provenance. See
+[Installed source identity](distribution.md#installed-source-identity).
+
 `execution.exit_code` is always the map-workflow exit code.
 `lifecycle.runner_exit_code` is the overall runner result, including
 verification and post-processing. `succeeded` means both the workflow and

--- a/docs/roadmap/v0.9.md
+++ b/docs/roadmap/v0.9.md
@@ -142,6 +142,8 @@ Deliverables:
 - document amd64 as a tested target and assign an explicit support tier to
   arm64/Jetson;
 - test install/upgrade paths, not only source builds.
+- embed deterministic source revision metadata in installed source and
+  container products, and reject mismatches in official image smoke tests.
 
 Gate:
 

--- a/graph_based_slam/test/test_docs_entrypoints.py
+++ b/graph_based_slam/test/test_docs_entrypoints.py
@@ -520,6 +520,10 @@ def test_release_metadata_and_core_package_versions_match():
     assert 'v<VERSION>-<distro>' in (
         DISTRIBUTION_DOC.read_text(encoding='utf-8')
     )
+    distribution_doc = DISTRIBUTION_DOC.read_text(encoding='utf-8')
+    assert 'product-build-info.json' in distribution_doc
+    assert 'LIDARSLAM_SOURCE_REVISION:STRING' in distribution_doc
+    assert 'LIDARSLAM_SOURCE_DIRTY:STRING' in distribution_doc
     assert 'scripts/build_release_bundle.py' in release_workflow
     for bundled_path in (
         'mkdocs.yml',
@@ -936,6 +940,7 @@ def test_container_distribution_builds_and_attests_both_supported_distros():
     """Container CI and releases must prove both supported binary paths."""
     docker_workflow = DOCKER_WORKFLOW.read_text(encoding='utf-8')
     release_workflow = RELEASE_WORKFLOW.read_text(encoding='utf-8')
+    dockerfile = (REPO_ROOT / 'Dockerfile').read_text(encoding='utf-8')
 
     for workflow in (docker_workflow, release_workflow):
         assert '- humble' in workflow
@@ -948,6 +953,15 @@ def test_container_distribution_builds_and_attests_both_supported_distros():
         assert 'sbom:' in workflow
         assert 'provenance:' in workflow
         assert 'lidarslam-map --version' in workflow
+        assert 'LIDARSLAM_SOURCE_REVISION=${{ steps.source.outputs.revision }}' in workflow
+        assert 'LIDARSLAM_SOURCE_DIRTY=false' in workflow
+        assert 'product-build-info.json' in workflow
+        assert 'OBSERVED_REVISION' in workflow
+
+    assert 'ARG LIDARSLAM_SOURCE_REVISION=' in dockerfile
+    assert 'ARG LIDARSLAM_SOURCE_DIRTY=' in dockerfile
+    assert '-DLIDARSLAM_SOURCE_REVISION:STRING=' in dockerfile
+    assert '-DLIDARSLAM_SOURCE_DIRTY:STRING=' in dockerfile
 
     assert "load: ${{ github.event_name == 'pull_request' }}" in docker_workflow
     assert '.github/workflows/release.yml' in docker_workflow

--- a/lidarslam/CMakeLists.txt
+++ b/lidarslam/CMakeLists.txt
@@ -27,6 +27,7 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
 find_package(rclcpp REQUIRED)
 find_package(scanmatcher REQUIRED)
 find_package(graph_based_slam REQUIRED)
@@ -240,6 +241,45 @@ foreach(PRODUCT_CLI_SCRIPT_NAME IN LISTS PRODUCT_CLI_SCRIPT_NAMES)
   )
 endforeach()
 
+set(
+  LIDARSLAM_SOURCE_REVISION
+  ""
+  CACHE STRING
+  "Exact 40-character source revision for builds without Git metadata"
+)
+set(
+  LIDARSLAM_SOURCE_DIRTY
+  ""
+  CACHE STRING
+  "Source dirty state for an explicit revision: true or false"
+)
+set(PRODUCT_BUILD_INFO_ARGS
+  --source-dir ${CMAKE_CURRENT_SOURCE_DIR}/..
+  --output ${CMAKE_CURRENT_BINARY_DIR}/product-build-info.json
+)
+if(NOT "${LIDARSLAM_SOURCE_REVISION}" STREQUAL "")
+  list(
+    APPEND PRODUCT_BUILD_INFO_ARGS
+    --revision ${LIDARSLAM_SOURCE_REVISION}
+  )
+endif()
+if(NOT "${LIDARSLAM_SOURCE_DIRTY}" STREQUAL "")
+  list(
+    APPEND PRODUCT_BUILD_INFO_ARGS
+    --dirty ${LIDARSLAM_SOURCE_DIRTY}
+  )
+endif()
+add_custom_target(
+  lidarslam_product_build_info ALL
+  COMMAND
+    ${Python3_EXECUTABLE}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/generate_product_build_info.py
+    ${PRODUCT_BUILD_INFO_ARGS}
+  BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/product-build-info.json
+  COMMENT "Generating installed product source provenance"
+  VERBATIM
+)
+
 # Keep the historical ROS executable untouched at lib/lidarslam/lidarslam.
 # The PATH command and ros2-run shim deliberately use distinct names.
 install(
@@ -260,6 +300,7 @@ install(
   FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/../VERSION
     ${CMAKE_CURRENT_SOURCE_DIR}/product-runtime-files.txt
+    ${CMAKE_CURRENT_BINARY_DIR}/product-build-info.json
   DESTINATION share/${PROJECT_NAME}/product
 )
 install(

--- a/lidarslam/test/test_install_upgrade_contract.py
+++ b/lidarslam/test/test_install_upgrade_contract.py
@@ -133,6 +133,43 @@ def test_git_commands_scope_safe_directory_to_repository():
     ]
 
 
+def test_candidate_build_forwards_explicit_source_provenance(
+    tmp_path: Path,
+    monkeypatch,
+):
+    module = _load_module()
+    observed = {}
+
+    def fake_run_logged(command, log_path, cwd):
+        observed['command'] = command
+        observed['log_path'] = log_path
+        observed['cwd'] = cwd
+        return {'exit_code': 0}
+
+    monkeypatch.setattr(module, '_run_logged', fake_run_logged)
+    revision = 'a' * 40
+    result = module._build(
+        tmp_path / 'source',
+        tmp_path / 'build',
+        tmp_path / 'install',
+        tmp_path / 'log',
+        tmp_path / 'build.log',
+        'Release',
+        revision,
+        False,
+    )
+
+    assert result == {'exit_code': 0}
+    assert (
+        f'-DLIDARSLAM_SOURCE_REVISION:STRING={revision}'
+        in observed['command']
+    )
+    assert (
+        '-DLIDARSLAM_SOURCE_DIRTY:STRING=false'
+        in observed['command']
+    )
+
+
 def test_compare_reports_stale_missing_and_mode_drift(tmp_path: Path):
     module = _load_module()
     upgraded = tmp_path / 'upgraded'

--- a/lidarslam/test/test_installed_product_cli_contract.py
+++ b/lidarslam/test/test_installed_product_cli_contract.py
@@ -104,6 +104,10 @@ def test_cmake_preserves_historical_node_and_installs_distinct_cli_names():
     assert 'rollback-plan-v1.schema.json' in cmake
     assert 'first-map-validation-receipt-v1.schema.json' in cmake
     assert 'DESTINATION share/${PROJECT_NAME}/product/schemas' in cmake
+    assert 'generate_product_build_info.py' in cmake
+    assert 'product-build-info.json' in cmake
+    assert 'LIDARSLAM_SOURCE_REVISION' in cmake
+    assert 'LIDARSLAM_SOURCE_DIRTY' in cmake
     assert 'install(TARGETS\n  lidarslam' in cmake
 
 

--- a/lidarslam/test/test_product_build_info.py
+++ b/lidarslam/test/test_product_build_info.py
@@ -91,6 +91,34 @@ def test_generator_captures_clean_and_dirty_checkout_state(tmp_path: Path):
     assert generator.build_info(repo)['dirty'] is True
 
 
+def test_generator_scopes_safe_directory_to_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Container builds should not require a global Git configuration."""
+    generator = _load(GENERATOR_PATH, 'generate_product_build_info')
+    source = tmp_path / 'source'
+    source.mkdir()
+    observed = {}
+
+    def fake_run(command, **kwargs):
+        observed['command'] = command
+        observed['kwargs'] = kwargs
+        return subprocess.CompletedProcess(command, 0, '', '')
+
+    monkeypatch.setattr(generator.subprocess, 'run', fake_run)
+    generator._run_git(source, 'rev-parse', 'HEAD')
+
+    assert observed['command'] == [
+        'git',
+        '-c',
+        f'safe.directory={source}',
+        'rev-parse',
+        'HEAD',
+    ]
+    assert observed['kwargs']['cwd'] == source
+
+
 def test_generator_supports_validated_override_and_unknown_archive(
     tmp_path: Path,
 ):

--- a/lidarslam/test/test_product_build_info.py
+++ b/lidarslam/test/test_product_build_info.py
@@ -1,0 +1,179 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for deterministic installed-product source provenance."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GENERATOR_PATH = REPO_ROOT / 'scripts' / 'generate_product_build_info.py'
+RUNNER_PATH = REPO_ROOT / 'scripts' / 'run_autoware_map_from_bag.py'
+
+
+def _load(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _git(repo: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ['git', *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def _repository(tmp_path: Path) -> tuple[Path, str]:
+    repo = tmp_path / 'source'
+    repo.mkdir()
+    _git(repo, 'init')
+    _git(repo, 'config', 'user.name', 'Product Test')
+    _git(repo, 'config', 'user.email', 'product-test@example.invalid')
+    (repo / 'tracked.txt').write_text('clean\n', encoding='utf-8')
+    _git(repo, 'add', 'tracked.txt')
+    _git(repo, 'commit', '-m', 'fixture')
+    return repo, _git(repo, 'rev-parse', 'HEAD')
+
+
+def test_generator_captures_clean_and_dirty_checkout_state(tmp_path: Path):
+    """Tracked edits should change dirty state while untracked files do not."""
+    generator = _load(GENERATOR_PATH, 'generate_product_build_info')
+    repo, revision = _repository(tmp_path)
+
+    assert generator.build_info(repo) == {
+        'schema_version': 1,
+        'revision': revision,
+        'dirty': False,
+        'source': 'git',
+    }
+
+    (repo / 'untracked.txt').write_text('ignored\n', encoding='utf-8')
+    assert generator.build_info(repo)['dirty'] is False
+    (repo / 'tracked.txt').write_text('changed\n', encoding='utf-8')
+    assert generator.build_info(repo)['dirty'] is True
+
+
+def test_generator_supports_validated_override_and_unknown_archive(
+    tmp_path: Path,
+):
+    """Git-free builds should use explicit identity or report unknown."""
+    generator = _load(GENERATOR_PATH, 'generate_product_build_info')
+    source = tmp_path / 'archive'
+    source.mkdir()
+    revision = 'a' * 40
+
+    assert generator.build_info(source) == {
+        'schema_version': 1,
+        'revision': None,
+        'dirty': None,
+        'source': 'unknown',
+    }
+    assert generator.build_info(source, revision, 'false') == {
+        'schema_version': 1,
+        'revision': revision,
+        'dirty': False,
+        'source': 'override',
+    }
+    with pytest.raises(ValueError, match='40 hexadecimal'):
+        generator.build_info(source, 'not-a-revision', 'false')
+    with pytest.raises(ValueError, match='requires a source revision'):
+        generator.build_info(source, None, 'false')
+
+
+def test_generator_output_is_deterministic_and_atomic(tmp_path: Path):
+    """Identical provenance should not rewrite the installed metadata."""
+    generator = _load(GENERATOR_PATH, 'generate_product_build_info')
+    output = tmp_path / 'product-build-info.json'
+    payload = {
+        'schema_version': 1,
+        'revision': 'b' * 40,
+        'dirty': False,
+        'source': 'override',
+    }
+
+    generator.write_build_info(output, payload)
+    first_stat = output.stat()
+    generator.write_build_info(output, payload)
+
+    assert output.stat().st_mtime_ns == first_stat.st_mtime_ns
+    assert output.stat().st_ino == first_stat.st_ino
+    assert json.loads(output.read_text(encoding='utf-8')) == payload
+    assert not output.with_name(f'.{output.name}.tmp').exists()
+
+
+def test_installed_runner_reads_valid_build_info_and_rejects_corruption(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Installed manifests should use only a validated build identity."""
+    runner = _load(RUNNER_PATH, 'run_autoware_map_from_bag_installed')
+    build_info = tmp_path / 'product-build-info.json'
+    monkeypatch.setattr(runner, 'SOURCE_LAYOUT', False)
+    monkeypatch.setattr(runner, 'PRODUCT_BUILD_INFO_PATH', build_info)
+
+    build_info.write_text(
+        json.dumps({
+            'schema_version': 1,
+            'revision': 'c' * 40,
+            'dirty': False,
+            'source': 'override',
+        }),
+        encoding='utf-8',
+    )
+    assert runner._git_state() == {
+        'commit': 'c' * 40,
+        'dirty': False,
+    }
+
+    build_info.write_text(
+        json.dumps({
+            'schema_version': 1,
+            'revision': 'c' * 40,
+            'dirty': False,
+            'source': 'invented',
+        }),
+        encoding='utf-8',
+    )
+    assert runner._git_state() == {'commit': None, 'dirty': None}
+    build_info.write_text('{"revision":"wrong"}\n', encoding='utf-8')
+    assert runner._git_state() == {'commit': None, 'dirty': None}
+    build_info.write_text('not-json\n', encoding='utf-8')
+    assert runner._git_state() == {'commit': None, 'dirty': None}

--- a/scripts/check_install_upgrade.py
+++ b/scripts/check_install_upgrade.py
@@ -9,7 +9,6 @@ import hashlib
 import json
 import os
 from pathlib import Path
-import shutil
 import stat
 import subprocess
 import sys
@@ -134,7 +133,19 @@ def _build(
     log_base: Path,
     log_path: Path,
     cmake_build_type: str,
+    source_revision: str | None = None,
+    source_dirty: bool | None = None,
 ) -> dict[str, Any]:
+    cmake_args = [f'-DCMAKE_BUILD_TYPE={cmake_build_type}']
+    if source_revision is not None:
+        cmake_args.append(
+            f'-DLIDARSLAM_SOURCE_REVISION:STRING={source_revision}'
+        )
+    if source_dirty is not None:
+        cmake_args.append(
+            '-DLIDARSLAM_SOURCE_DIRTY:STRING='
+            + ('true' if source_dirty else 'false')
+        )
     return _run_logged(
         [
             'colcon',
@@ -151,7 +162,7 @@ def _build(
             '--event-handlers',
             'console_direct+',
             '--cmake-args',
-            f'-DCMAKE_BUILD_TYPE={cmake_build_type}',
+            *cmake_args,
         ],
         log_path,
         REPO_ROOT,
@@ -293,6 +304,8 @@ def run(args: argparse.Namespace) -> int:
             work / 'upgrade-log',
             evidence_dir / 'upgrade-build.log',
             args.cmake_build_type,
+            candidate_commit,
+            candidate_dirty,
         )
 
         print('==> Building fresh candidate comparison prefix')
@@ -303,6 +316,8 @@ def run(args: argparse.Namespace) -> int:
             work / 'fresh-log',
             evidence_dir / 'fresh-build.log',
             args.cmake_build_type,
+            candidate_commit,
+            candidate_dirty,
         )
 
         upgraded_snapshot = (
@@ -323,6 +338,8 @@ def run(args: argparse.Namespace) -> int:
                 str(INSTALL_CHECKER),
                 '--prefix',
                 str(upgrade_prefix),
+                '--expected-source-revision',
+                candidate_commit,
             ],
             evidence_dir / 'upgrade-validation.log',
             REPO_ROOT,
@@ -338,6 +355,8 @@ def run(args: argparse.Namespace) -> int:
                 str(INSTALL_CHECKER),
                 '--prefix',
                 str(fresh_prefix),
+                '--expected-source-revision',
+                candidate_commit,
             ],
             evidence_dir / 'fresh-validation.log',
             REPO_ROOT,

--- a/scripts/check_installed_product_cli.py
+++ b/scripts/check_installed_product_cli.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import os
 from pathlib import Path
@@ -37,6 +38,15 @@ def _runtime_names(path: Path) -> tuple[str, ...]:
     if not names:
         raise RuntimeError(f'product runtime manifest is empty: {path}')
     return names
+
+
+def _load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f'cannot load installed product module: {path}')
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def _run(
@@ -222,7 +232,10 @@ def _release_image_fixture() -> dict[str, object]:
     }
 
 
-def validate_install(prefix: Path) -> None:
+def validate_install(
+    prefix: Path,
+    expected_source_revision: str | None = None,
+) -> None:
     """Validate commands, resources, isolation, and delegated behavior."""
     prefix = prefix.expanduser().resolve()
     path_command = prefix / 'bin' / 'lidarslam-map'
@@ -233,6 +246,7 @@ def validate_install(prefix: Path) -> None:
     product_scripts = product_root / 'scripts'
     bash_completion = product_root / 'completions' / 'lidarslam-map.bash'
     product_schemas = product_root / 'schemas'
+    product_build_info = product_root / 'product-build-info.json'
     installed_runtime_manifest = product_root / 'product-runtime-files.txt'
 
     for path in (path_command, ros_shim, historical_node):
@@ -265,6 +279,45 @@ def validate_install(prefix: Path) -> None:
         prefix,
     )
     _require_success(completion_syntax, 'installed Bash completion syntax')
+    if not product_build_info.is_file():
+        raise RuntimeError(
+            f'installed product build information is missing: {product_build_info}'
+        )
+    build_info = json.loads(product_build_info.read_text(encoding='utf-8'))
+    revision = build_info.get('revision')
+    dirty = build_info.get('dirty')
+    if not (
+        build_info.get('schema_version') == 1
+        and isinstance(revision, str)
+        and len(revision) == 40
+        and all(character in '0123456789abcdef' for character in revision)
+        and isinstance(dirty, bool)
+        and build_info.get('source') in ('git', 'override')
+    ):
+        raise RuntimeError(
+            f'installed product build information is incomplete: {build_info}'
+        )
+    if (
+        expected_source_revision is not None
+        and revision != expected_source_revision
+    ):
+        raise RuntimeError(
+            f'installed source revision {revision} does not match expected '
+            f'{expected_source_revision}'
+        )
+    runner = _load_module(
+        product_scripts / 'run_autoware_map_from_bag.py',
+        'installed_run_autoware_map_from_bag',
+    )
+    software_identity = runner._software_identity()
+    if (
+        software_identity.get('git_commit') != revision
+        or software_identity.get('git_dirty') is not dirty
+    ):
+        raise RuntimeError(
+            'installed runner did not consume product build information: '
+            f'{software_identity}'
+        )
     if (product_scripts / 'gaussian_splatting_train.py').exists():
         raise RuntimeError('research-only scripts leaked into the product install')
     if shutil.which('ros2') is None:
@@ -462,9 +515,13 @@ def main() -> int:
         required=True,
         help='Clean CMake install prefix to validate.',
     )
+    parser.add_argument(
+        '--expected-source-revision',
+        help='Require the installed product to record this exact Git commit.',
+    )
     args = parser.parse_args()
     try:
-        validate_install(args.prefix)
+        validate_install(args.prefix, args.expected_source_revision)
     except (OSError, RuntimeError, ValueError, json.JSONDecodeError) as exc:
         print(f'error: {exc}', file=__import__('sys').stderr)
         return 1

--- a/scripts/generate_product_build_info.py
+++ b/scripts/generate_product_build_info.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 
 import argparse
 import json
+from pathlib import Path
 import re
 import subprocess
 import sys
-from pathlib import Path
 from typing import Sequence
 
 
@@ -33,7 +33,12 @@ def _parse_dirty(value: str) -> bool:
 
 def _run_git(source_dir: Path, *args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        ['git', *args],
+        [
+            'git',
+            '-c',
+            f'safe.directory={source_dir}',
+            *args,
+        ],
         cwd=source_dir,
         check=False,
         capture_output=True,

--- a/scripts/generate_product_build_info.py
+++ b/scripts/generate_product_build_info.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Generate deterministic source-revision metadata for installed products."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+REVISION_PATTERN = re.compile(r'^[0-9a-f]{40}$')
+
+
+def _normalize_revision(value: str) -> str:
+    revision = value.strip().lower()
+    if not REVISION_PATTERN.fullmatch(revision):
+        raise ValueError('source revision must be exactly 40 hexadecimal characters')
+    return revision
+
+
+def _parse_dirty(value: str) -> bool:
+    normalized = value.strip().lower()
+    if normalized == 'true':
+        return True
+    if normalized == 'false':
+        return False
+    raise ValueError('source dirty override must be "true" or "false"')
+
+
+def _run_git(source_dir: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ['git', *args],
+        cwd=source_dir,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _git_state(source_dir: Path) -> tuple[str, bool] | None:
+    try:
+        top_level = _run_git(source_dir, 'rev-parse', '--show-toplevel')
+        if top_level.returncode != 0:
+            return None
+        if Path(top_level.stdout.strip()).resolve() != source_dir.resolve():
+            return None
+        commit = _run_git(source_dir, 'rev-parse', 'HEAD')
+        status = _run_git(
+            source_dir,
+            'status',
+            '--porcelain',
+            '--untracked-files=no',
+        )
+    except OSError:
+        return None
+    if commit.returncode != 0 or status.returncode != 0:
+        return None
+    return _normalize_revision(commit.stdout), bool(status.stdout.strip())
+
+
+def build_info(
+    source_dir: Path,
+    revision_override: str | None = None,
+    dirty_override: str | None = None,
+) -> dict[str, object]:
+    """Resolve explicit build provenance first, then a repository checkout."""
+    if dirty_override is not None and revision_override is None:
+        raise ValueError('source dirty override requires a source revision override')
+    if revision_override is not None:
+        return {
+            'schema_version': 1,
+            'revision': _normalize_revision(revision_override),
+            'dirty': (
+                _parse_dirty(dirty_override)
+                if dirty_override is not None
+                else None
+            ),
+            'source': 'override',
+        }
+
+    state = _git_state(source_dir)
+    if state is None:
+        return {
+            'schema_version': 1,
+            'revision': None,
+            'dirty': None,
+            'source': 'unknown',
+        }
+    revision, dirty = state
+    return {
+        'schema_version': 1,
+        'revision': revision,
+        'dirty': dirty,
+        'source': 'git',
+    }
+
+
+def write_build_info(output_path: Path, payload: dict[str, object]) -> None:
+    """Write atomically and avoid changing the file when content is identical."""
+    rendered = json.dumps(payload, indent=2, sort_keys=True) + '\n'
+    if output_path.is_file():
+        try:
+            if output_path.read_text(encoding='utf-8') == rendered:
+                return
+        except OSError:
+            pass
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = output_path.with_name(f'.{output_path.name}.tmp')
+    temporary.write_text(rendered, encoding='utf-8')
+    temporary.replace(output_path)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse the build-system interface."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--source-dir', type=Path, required=True)
+    parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--revision')
+    parser.add_argument('--dirty')
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Generate build information or reject an invalid explicit identity."""
+    args = parse_args(argv)
+    try:
+        payload = build_info(
+            args.source_dir.expanduser().resolve(),
+            args.revision,
+            args.dirty,
+        )
+        write_build_info(args.output.expanduser().resolve(), payload)
+    except (OSError, ValueError) as exc:
+        print(f'error: {exc}', file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/run_autoware_map_from_bag.py
+++ b/scripts/run_autoware_map_from_bag.py
@@ -48,6 +48,7 @@ VALIDATION_RECEIPT_NAMES = {
     'first_map_validation_receipt.json',
     'first_map_validation_receipt.md',
 }
+PRODUCT_BUILD_INFO_PATH = REPO_ROOT / 'product-build-info.json'
 MANIFEST_SCHEMA_VERSION = 2
 MANIFEST_SCHEMA_URI = (
     'https://rsasaki0109.github.io/lidar_slam_ros2/'
@@ -463,7 +464,29 @@ def _file_identity(path: Path, display_path: str) -> dict[str, object]:
 
 def _git_state() -> dict[str, object]:
     if not SOURCE_LAYOUT:
-        return {'commit': None, 'dirty': None}
+        try:
+            payload = json.loads(
+                PRODUCT_BUILD_INFO_PATH.read_text(encoding='utf-8')
+            )
+        except (OSError, json.JSONDecodeError):
+            return {'commit': None, 'dirty': None}
+        commit = payload.get('revision')
+        dirty = payload.get('dirty')
+        if not (
+            payload.get('schema_version') == 1
+            and payload.get('source') in ('git', 'override', 'unknown')
+            and (
+                commit is None
+                or (
+                    isinstance(commit, str)
+                    and len(commit) == 40
+                    and all(character in '0123456789abcdef' for character in commit)
+                )
+            )
+            and (dirty is None or isinstance(dirty, bool))
+        ):
+            return {'commit': None, 'dirty': None}
+        return {'commit': commit, 'dirty': dirty}
     commit_result = subprocess.run(
         ['git', 'rev-parse', 'HEAD'],
         cwd=REPO_ROOT,

--- a/scripts/run_default_ci_checks.sh
+++ b/scripts/run_default_ci_checks.sh
@@ -136,7 +136,10 @@ if ! colcon build \
 fi
 if ! python3 "${REPO_ROOT}/scripts/check_installed_product_cli.py" \
   --prefix "${CLI_INSTALL_TEST_ROOT}/prefix" \
-  --expected-source-revision "$(git -C "${REPO_ROOT}" rev-parse HEAD)"; then
+  --expected-source-revision "$(
+    git -c "safe.directory=${REPO_ROOT}" \
+      -C "${REPO_ROOT}" rev-parse HEAD
+  )"; then
   echo "error: clean-prefix product CLI validation failed" >&2
   exit 1
 fi

--- a/scripts/run_default_ci_checks.sh
+++ b/scripts/run_default_ci_checks.sh
@@ -135,7 +135,8 @@ if ! colcon build \
   exit 1
 fi
 if ! python3 "${REPO_ROOT}/scripts/check_installed_product_cli.py" \
-  --prefix "${CLI_INSTALL_TEST_ROOT}/prefix"; then
+  --prefix "${CLI_INSTALL_TEST_ROOT}/prefix" \
+  --expected-source-revision "$(git -C "${REPO_ROOT}" rev-parse HEAD)"; then
   echo "error: clean-prefix product CLI validation failed" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

- generate deterministic `product-build-info.json` during CMake builds
- consume validated installed provenance in map run manifests and first-map receipts
- pass and smoke-test the exact checkout revision in Humble/Jazzy convenience and release images
- document the Git-free packager contract and unknown-provenance behavior

## Why

A public exact-digest Humble First Map run completed successfully, but its schema-valid receipt reported `run.git_commit: null` even though the OCI image label identified commit `4843b5e5dd1154df299a301e7a7c2770996bde3d`. The installed runtime had no source checkout after the image build, so the manifest could not recover that identity.

This change carries the build identity into the installed product without timestamps or host paths. It rejects malformed or invented provenance and leaves unknown archive builds explicitly null.

## Validation

- public exact-digest First Map before fix: PASS, 7/7 receipt checks, Autoware 8 PASS / 0 WARN / 0 FAIL
- receipt JSON validated against `first-map-validation-receipt-v1.schema.json`
- focused Python suite: 313 passed
- `scripts/run_default_ci_checks.sh`: build and clean-prefix installed CLI validation passed; the only initial failure was import-order lint in the new test
- lint rerun: no problems found
- final ROS test result: 2700 tests, 0 errors, 0 failures, 125 skipped
