### PR TITLE
Bind release evidence to candidate commit

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -105,6 +105,18 @@ different commit, refuses to overwrite its output, and embeds a
 schema-validated SHA-256 inventory. Repeating it from the same commit produces
 the same bundle bytes.
 
+Before building the bundle, run the hard benchmark gate from the same clean
+commit:
+
+```bash
+bash scripts/run_release_readiness_checks.sh --fail-on-profiles
+```
+
+The wrapper binds every blocking release profile to the exact current `HEAD`.
+Evidence produced by an older clean revision is rejected as `NO_DATA`, so a
+release candidate must be benchmarked again after its final code commit.
+Report-only profiles remain cross-revision historical comparisons.
+
 ## Automated Publication
 
 Two GitHub Actions workflows matter for release:

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -757,6 +757,15 @@ The release command uses the per-dataset profile thresholds. With
 threshold or has no matching run. A passing synthetic fixture therefore
 checks reporting mechanics but cannot count as release evidence.
 
+The wrapper resolves the current repository `HEAD` and binds every blocking
+profile to that exact 40-character commit. Clean benchmark evidence from an
+older revision is reported as a candidate-commit mismatch and evaluates as
+`NO_DATA`; it cannot authorize the current release candidate. Profiles marked
+`report_only_until` remain useful as historical comparisons and are not
+commit-bound. When invoking `benchmark_summary.py` directly as a hard gate,
+pass both `--fail-on-profiles` and
+`--required-git-commit "$(git rev-parse HEAD)"`.
+
 For a one-off uniform threshold check, `--ape-threshold <metres>` is also
 hard:
 
@@ -767,7 +776,8 @@ hard:
   `ground_truth` runs; `cross_validation` runs stay visible in reports without
   blocking release
 
-`--fail-on-profiles` requires an active, existing release-profile YAML.
+`--fail-on-profiles` requires an active, existing release-profile YAML and an
+exact candidate commit (automatically supplied by the wrapper).
 Profiles marked `report_only_until` remain non-blocking even when their data
 is absent. Neither hard benchmark gate can be combined with
 `--skip-benchmark-summary`. Without `--ape-threshold` or

--- a/graph_based_slam/test/test_benchmark_reporting_tools.py
+++ b/graph_based_slam/test/test_benchmark_reporting_tools.py
@@ -622,6 +622,14 @@ def test_report_only_profile_may_remain_without_data(tmp_path):
     )
 
     assert result.returncode == 0, result.stderr
+    expected_commit = subprocess.run(
+        ['git', 'rev-parse', 'HEAD'],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=REPO_ROOT,
+    ).stdout.strip()
+    assert f'Release candidate commit: {expected_commit}' in result.stdout
     assert '| optional_dataset | NO_DATA |' in result.stdout
     assert (out_dir / 'benchmark_report.html').is_file()
 

--- a/lidarslam/test/test_benchmark_summary_profiles.py
+++ b/lidarslam/test/test_benchmark_summary_profiles.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+import subprocess
 import textwrap
 
 import pytest
@@ -63,6 +64,8 @@ def _rec(**overrides):
         'ape_pairs': overrides.get('ape_pairs', 500),
         'provenance_complete': overrides.get('provenance_complete', True),
         'provenance_git_dirty': overrides.get('provenance_git_dirty', False),
+        'provenance_git_commit': overrides.get(
+            'provenance_git_commit', 'a' * 40),
     }
     return base
 
@@ -162,6 +165,49 @@ def test_load_release_profiles_rejects_non_boolean_provenance_gate(tmp_path: Pat
     )
     with pytest.raises(ValueError, match='require_clean_provenance must be boolean'):
         module.load_release_profiles(bad)
+
+
+def test_cli_rejects_malformed_required_git_commit(tmp_path: Path):
+    result = subprocess.run(
+        [
+            'python3',
+            str(SCRIPT_PATH),
+            '--root',
+            str(tmp_path),
+            '--release-profile',
+            str(DEFAULT_PROFILE_YAML),
+            '--required-git-commit',
+            'abc123',
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=REPO_ROOT,
+    )
+
+    assert result.returncode == 1
+    assert 'exactly 40 lowercase hexadecimal characters' in result.stdout
+
+
+def test_cli_hard_profile_gate_requires_commit_binding(tmp_path: Path):
+    result = subprocess.run(
+        [
+            'python3',
+            str(SCRIPT_PATH),
+            '--root',
+            str(tmp_path),
+            '--release-profile',
+            str(DEFAULT_PROFILE_YAML),
+            '--fail-on-profiles',
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=REPO_ROOT,
+    )
+
+    assert result.returncode == 1
+    assert 'requires --required-git-commit' in result.stdout
 
 
 def test_evaluate_pass_picks_best_matching_run():
@@ -288,6 +334,98 @@ def test_provenance_rejection_diagnostics_preserve_multiple_causes():
         'incomplete provenance: legacy; dirty revision: local'
     )
     assert result['no_data_reason'] in rendered
+
+
+def test_blocking_profile_requires_exact_release_candidate_commit():
+    """Clean evidence from an older revision must fail the release gate."""
+    module = _load_module()
+    candidate_commit = 'b' * 40
+    profile = {
+        'name': 'p',
+        'metric': 'ape_rmse_gt_m',
+        'pass': 1.0,
+        'match': {'require_clean_provenance': True},
+    }
+    records = [
+        _rec(
+            run='old_clean_run',
+            ape_rmse_m='0.01',
+            provenance_git_commit='a' * 40,
+        ),
+    ]
+
+    [result] = module.evaluate_release_profiles(
+        [profile],
+        records,
+        required_git_commit=candidate_commit,
+    )
+    rendered = '\n'.join(module.render_release_profile_section([result]))
+
+    assert result['status'] == 'NO_DATA'
+    assert result['matched_runs'] == 0
+    assert result['no_data_reason'] == (
+        'candidate commit mismatch (required bbbbbbbbbbbb): '
+        'old_clean_run@aaaaaaaaaaaa'
+    )
+    assert result['no_data_reason'] in rendered
+
+
+def test_blocking_profile_accepts_exact_release_candidate_commit():
+    """Clean evidence from the requested revision remains eligible."""
+    module = _load_module()
+    candidate_commit = 'b' * 40
+    profile = {
+        'name': 'p',
+        'metric': 'ape_rmse_gt_m',
+        'pass': 1.0,
+        'match': {'require_clean_provenance': True},
+    }
+    records = [
+        _rec(
+            run='candidate_run',
+            ape_rmse_m='0.20',
+            provenance_git_commit=candidate_commit,
+        ),
+    ]
+
+    [result] = module.evaluate_release_profiles(
+        [profile],
+        records,
+        required_git_commit=candidate_commit,
+    )
+    rendered = '\n'.join(module.render_release_profile_section([result]))
+
+    assert result['status'] == 'PASS'
+    assert result['best_run'] == 'candidate_run'
+    assert 'clean provenance @ bbbbbbbbbbbb' in rendered
+
+
+def test_report_only_profile_remains_a_cross_revision_comparison():
+    """Commit binding applies only to profiles that can block release."""
+    module = _load_module()
+    profile = {
+        'name': 'historical',
+        'metric': 'ape_rmse_gt_m',
+        'pass': 1.0,
+        'report_only_until': 'future-cycle',
+        'match': {'require_clean_provenance': True},
+    }
+    records = [
+        _rec(
+            run='older_baseline',
+            provenance_git_commit='a' * 40,
+        ),
+    ]
+
+    [result] = module.evaluate_release_profiles(
+        [profile],
+        records,
+        required_git_commit='b' * 40,
+    )
+
+    assert result['status'] == 'PASS'
+    assert result['best_run'] == 'older_baseline'
+    assert result['required_git_commit'] is None
 
 
 def test_metric_ape_rmse_gt_m_skips_cross_validation():

--- a/scripts/benchmark_summary.py
+++ b/scripts/benchmark_summary.py
@@ -73,14 +73,16 @@ def _valid_file_identity(value: Any) -> bool:
     )
 
 
-def _provenance_state(run: dict[str, Any]) -> tuple[bool, bool | None]:
+def _provenance_state(
+    run: dict[str, Any],
+) -> tuple[bool, bool | None, str | None]:
     provenance = run.get("provenance")
     if not isinstance(provenance, dict):
-        return False, None
+        return False, None, None
     input_identity = provenance.get("input")
     software = provenance.get("software")
     if not isinstance(input_identity, dict) or not isinstance(software, dict):
-        return False, None
+        return False, None, None
     bag = input_identity.get("bag")
     storage_files = bag.get("storage_files") if isinstance(bag, dict) else None
     parameter_files = software.get("parameter_files")
@@ -112,7 +114,13 @@ def _provenance_state(run: dict[str, Any]) -> tuple[bool, bool | None]:
         and _valid_file_identity(software.get("benchmark_harness"))
         and _valid_file_identity(software.get("metrics_writer"))
     )
-    return complete, dirty if isinstance(dirty, bool) else None
+    valid_commit = (
+        commit
+        if isinstance(commit, str)
+        and re.fullmatch(r"[0-9a-f]{40}", commit) is not None
+        else None
+    )
+    return complete, dirty if isinstance(dirty, bool) else None, valid_commit
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -212,8 +220,12 @@ def _profile_match(
     rec: dict[str, Any],
     *,
     check_provenance: bool = True,
+    required_git_commit: str | None = None,
 ) -> bool:
     match = profile.get("match") or {}
+    commit_bound = bool(
+        required_git_commit and not profile.get("report_only_until")
+    )
     bag_substr = match.get("bag_name_contains")
     if bag_substr and bag_substr not in (rec.get("bag") or ""):
         return False
@@ -231,12 +243,20 @@ def _profile_match(
         pairs = _as_float(rec.get("ape_pairs"))
         if pairs is None or pairs < float(min_pairs):
             return False
-    if check_provenance and match.get("require_clean_provenance"):
+    if check_provenance and (
+        match.get("require_clean_provenance") or commit_bound
+    ):
         if (
             rec.get("provenance_complete") is not True
             or rec.get("provenance_git_dirty") is not False
         ):
             return False
+    if (
+        check_provenance
+        and commit_bound
+        and rec.get("provenance_git_commit") != required_git_commit
+    ):
+        return False
     return True
 
 
@@ -254,6 +274,8 @@ def _profile_metric_value(profile: dict[str, Any], rec: dict[str, Any]) -> float
 def evaluate_release_profiles(
     profiles: list[dict[str, Any]],
     records: list[dict[str, Any]],
+    *,
+    required_git_commit: str | None = None,
 ) -> list[dict[str, Any]]:
     """For each profile, find the best matching run and assign a status.
 
@@ -273,22 +295,43 @@ def evaluate_release_profiles(
         ]
         matched = [
             rec for rec in candidates
-            if _profile_match(prof, rec)
+            if _profile_match(
+                prof,
+                rec,
+                required_git_commit=required_git_commit,
+            )
         ]
         provenance_rejections: dict[str, list[str]] = {
             "incomplete": [],
             "dirty": [],
+            "commit_mismatch": [],
         }
-        if (prof.get("match") or {}).get("require_clean_provenance"):
+        commit_bound = bool(
+            required_git_commit and not prof.get("report_only_until")
+        )
+        if (
+            (prof.get("match") or {}).get("require_clean_provenance")
+            or commit_bound
+        ):
             for rec in candidates:
                 if rec.get("provenance_complete") is not True:
-                    provenance_rejections["incomplete"].append(
-                        str(rec.get("run") or "<unnamed>")
-                    )
+                    label = str(rec.get("run") or "<unnamed>")
+                    if label not in provenance_rejections["incomplete"]:
+                        provenance_rejections["incomplete"].append(label)
                 elif rec.get("provenance_git_dirty") is not False:
-                    provenance_rejections["dirty"].append(
-                        str(rec.get("run") or "<unnamed>")
+                    label = str(rec.get("run") or "<unnamed>")
+                    if label not in provenance_rejections["dirty"]:
+                        provenance_rejections["dirty"].append(label)
+                elif (
+                    commit_bound
+                    and rec.get("provenance_git_commit") != required_git_commit
+                ):
+                    label = (
+                        f"{rec.get('run') or '<unnamed>'}"
+                        f"@{str(rec.get('provenance_git_commit') or 'unknown')[:12]}"
                     )
+                    if label not in provenance_rejections["commit_mismatch"]:
+                        provenance_rejections["commit_mismatch"].append(label)
         result: dict[str, Any] = {
             "name": prof["name"],
             "description": prof.get("description", ""),
@@ -299,12 +342,17 @@ def evaluate_release_profiles(
             "matched_runs": len(matched),
             "candidate_runs": len(candidates),
             "provenance_rejections": provenance_rejections,
+            "required_git_commit": (
+                required_git_commit
+                if required_git_commit and not prof.get("report_only_until")
+                else None
+            ),
         }
         if not matched:
             result["status"] = "NO_DATA"
             result["best_run"] = None
             result["best_value"] = None
-            if provenance_rejections["incomplete"] or provenance_rejections["dirty"]:
+            if any(provenance_rejections.values()):
                 reasons = []
                 if provenance_rejections["incomplete"]:
                     reasons.append(
@@ -315,6 +363,12 @@ def evaluate_release_profiles(
                     reasons.append(
                         "dirty revision: "
                         + ", ".join(provenance_rejections["dirty"])
+                    )
+                if provenance_rejections["commit_mismatch"]:
+                    reasons.append(
+                        f"candidate commit mismatch (required "
+                        f"{required_git_commit[:12]}): "
+                        + ", ".join(provenance_rejections["commit_mismatch"])
                     )
                 result["no_data_reason"] = "; ".join(reasons)
             else:
@@ -359,6 +413,11 @@ def render_release_profile_section(results: list[dict[str, Any]]) -> list[str]:
     lines.append("| " + " | ".join(header) + " |")
     lines.append("| " + " | ".join(["---"] * len(header)) + " |")
     for r in results:
+        evidence = str(r.get("no_data_reason") or "")
+        if not evidence and r.get("best_run"):
+            evidence = "clean provenance"
+            if r.get("required_git_commit"):
+                evidence += " @ " + str(r["required_git_commit"])[:12]
         lines.append(
             "| "
             + " | ".join(
@@ -370,13 +429,7 @@ def render_release_profile_section(results: list[dict[str, Any]]) -> list[str]:
                     _fmt_float(r.get("best_value")),
                     _fmt_float(r.get("pass")),
                     _fmt_float(r.get("target")),
-                    str(
-                        r.get("no_data_reason")
-                        or (
-                            "clean provenance"
-                            if r.get("best_run") else ""
-                        )
-                    ),
+                    evidence,
                     str(r.get("report_only_until") or ""),
                 ]
             )
@@ -443,7 +496,31 @@ def main() -> int:
             "FAIL or has NO_DATA (report_only_until profiles never block)."
         ),
     )
+    ap.add_argument(
+        "--required-git-commit",
+        default="",
+        help=(
+            "Require blocking release-profile evidence from this exact 40-character "
+            "lowercase Git commit. Required with --fail-on-profiles; report-only "
+            "profiles remain historical comparisons."
+        ),
+    )
     args = ap.parse_args()
+
+    if args.required_git_commit and re.fullmatch(
+        r"[0-9a-f]{40}", args.required_git_commit
+    ) is None:
+        print(
+            "error: --required-git-commit must be exactly 40 lowercase "
+            "hexadecimal characters"
+        )
+        return 1
+    if args.required_git_commit and not args.release_profile:
+        print("error: --required-git-commit requires --release-profile")
+        return 1
+    if args.fail_on_profiles and not args.required_git_commit:
+        print("error: --fail-on-profiles requires --required-git-commit")
+        return 1
 
     root = Path(args.root).expanduser().resolve()
     metrics_paths = sorted(root.rglob("metrics.json"))
@@ -508,7 +585,11 @@ def main() -> int:
         ape = evo.get("ape") if isinstance(evo, dict) else None
         ape_rmse = (ape.get("rmse") if isinstance(ape, dict) else None) if ape is not None else None
         ape_pairs = (ape.get("pairs") if isinstance(ape, dict) else None) if ape is not None else None
-        provenance_complete, provenance_git_dirty = _provenance_state(r)
+        (
+            provenance_complete,
+            provenance_git_dirty,
+            provenance_git_commit,
+        ) = _provenance_state(r)
         provenance_status = (
             "clean"
             if provenance_complete and provenance_git_dirty is False
@@ -586,6 +667,7 @@ def main() -> int:
                 "ape_pairs": ape_pairs,
                 "provenance_complete": provenance_complete,
                 "provenance_git_dirty": provenance_git_dirty,
+                "provenance_git_commit": provenance_git_commit,
                 "provenance_status": provenance_status,
                 "primary_raw": primary_raw,
                 "primary_missing": primary_missing,
@@ -703,7 +785,11 @@ def main() -> int:
     if args.release_profile:
         profile_path = Path(args.release_profile).expanduser().resolve()
         profiles = load_release_profiles(profile_path)
-        profile_results = evaluate_release_profiles(profiles, records_sorted)
+        profile_results = evaluate_release_profiles(
+            profiles,
+            records_sorted,
+            required_git_commit=args.required_git_commit or None,
+        )
         md_lines.extend(render_release_profile_section(profile_results))
 
     md = "\n".join(md_lines) + "\n"

--- a/scripts/run_release_readiness_checks.sh
+++ b/scripts/run_release_readiness_checks.sh
@@ -15,7 +15,8 @@ Options:
   --release-profile <path>      Release-profile YAML (per-dataset pass/target)
                                 Default: scripts/release_profiles.yaml when omitted
   --no-release-profile          Disable the release-profile gate
-  --fail-on-profiles            Fail if a blocking profile FAILs or has NO_DATA
+  --fail-on-profiles            Fail if a blocking profile FAILs or has NO_DATA;
+                                evidence is bound to the current Git commit
   --skip-default-ci             Skip scripts/run_default_ci_checks.sh
   --skip-benchmark-summary      Skip benchmark summary generation
   --public-mid360-completion    Run the public MID-360 segment-reset completion gate
@@ -131,7 +132,9 @@ The release-profile gate runs in addition to (or instead of) --ape-threshold:
 each profile in the YAML scores its own pass/target threshold against the best
 matching run, with optional report_only_until semantics so hard datasets
 can soak without blocking release. A blocking profile with no matching run
-fails closed.
+fails closed. With --fail-on-profiles, blocking evidence must also have clean,
+complete provenance for the exact current repository commit. Report-only
+profiles remain historical comparisons and are not commit-bound.
 EOF
 }
 
@@ -418,9 +421,25 @@ if [[ "${FAIL_ON_PROFILES}" == "true" && ! -f "${RELEASE_PROFILE}" ]]; then
   fail "release profile not found: ${RELEASE_PROFILE}"
 fi
 
+RELEASE_CANDIDATE_COMMIT=""
+if [[ "${FAIL_ON_PROFILES}" == "true" ]]; then
+  if ! RELEASE_CANDIDATE_COMMIT="$(
+    git -c "safe.directory=${REPO_ROOT}" \
+      -C "${REPO_ROOT}" rev-parse --verify HEAD^{commit}
+  )"; then
+    fail "cannot resolve the release-candidate Git commit from ${REPO_ROOT}"
+  fi
+  if [[ ! "${RELEASE_CANDIDATE_COMMIT}" =~ ^[0-9a-f]{40}$ ]]; then
+    fail "release-candidate Git commit is not an exact 40-character object ID"
+  fi
+fi
+
 mkdir -p "${OUT_DIR}"
 
 echo "Release readiness output: ${OUT_DIR}"
+if [[ -n "${RELEASE_CANDIDATE_COMMIT}" ]]; then
+  echo "Release candidate commit: ${RELEASE_CANDIDATE_COMMIT}"
+fi
 
 if [[ "${RUN_DEFAULT_CI}" == "true" ]]; then
   echo "==> Running default workflow checks"
@@ -449,7 +468,10 @@ if [[ "${RUN_BENCHMARK_SUMMARY}" == "true" ]]; then
     if [[ -n "${RELEASE_PROFILE}" && -f "${RELEASE_PROFILE}" ]]; then
       SUMMARY_CMD+=(--release-profile "${RELEASE_PROFILE}")
       if [[ "${FAIL_ON_PROFILES}" == "true" ]]; then
-        SUMMARY_CMD+=(--fail-on-profiles)
+        SUMMARY_CMD+=(
+          --fail-on-profiles
+          --required-git-commit "${RELEASE_CANDIDATE_COMMIT}"
+        )
       fi
     elif [[ -n "${RELEASE_PROFILE}" ]]; then
       echo "warning: release profile not found at ${RELEASE_PROFILE}; continuing without profile gate" >&2


### PR DESCRIPTION
## What changed

- Bind every blocking release profile to the exact release-candidate Git commit.
- Require complete, clean provenance for commit-bound evidence even when a profile omits that YAML matcher.
- Keep report-only profiles available as cross-revision historical comparisons.
- Resolve and display the current candidate commit automatically in the release wrapper.
- Add regression coverage and release/benchmark documentation.

## Why

The hard release gate could previously accept clean benchmark evidence generated by an older commit. That allowed a newly changed release candidate to inherit stale qualification results.

The gate now fails closed: evidence from another revision is reported as NO_DATA with an explicit candidate-commit mismatch. Final candidates must be benchmarked again after their final code commit.

## Impact

Release operators get an auditable, exact link between the candidate source revision and every blocking benchmark result. Existing report-only comparisons remain usable across revisions.

## Validation

- bash scripts/run_default_ci_checks.sh — 2726 tests, 0 errors, 0 failures, 125 skipped
- targeted pytest suite — 54 passed
- git diff --check
- real mounted benchmark corpus hard gate — expected exit 2; current commit 4805ef5600559d43af95c121e6b7cbd874c97eda rejected stale clean evidence with candidate-commit mismatch diagnostics