### PR TITLE
Promote competitive-v2 Kaizen profile

### DIFF
--- a/configs/hilti2022/lidarslam_competitive_v2.yaml
+++ b/configs/hilti2022/lidarslam_competitive_v2.yaml
@@ -1,0 +1,12 @@
+# Minimal graph backend overrides for clean competitive-v2 measurement.
+# Loop registration is disabled for the frontend RTF/accuracy gate; descriptor
+# ingestion and the production defaults remain unchanged.
+graph_based_slam:
+  ros__parameters:
+    registration_method: "NDT"
+    range_of_searching_loop_closure: 0.0
+    loop_search_query_stride: 1
+    cloud_subscriber_qos_reliable: true
+    odom_cloud_sync_queue_size: 128
+    map_leaf_size: 0.1
+    debug_flag: false

--- a/configs/hilti2022/lidarslam_competitive_v2.yaml
+++ b/configs/hilti2022/lidarslam_competitive_v2.yaml
@@ -7,6 +7,7 @@ graph_based_slam:
     range_of_searching_loop_closure: 0.0
     loop_search_query_stride: 1
     cloud_subscriber_qos_reliable: true
-    odom_cloud_sync_queue_size: 128
+    odom_cloud_sync_use_exact_time: true
+    odom_cloud_sync_queue_size: 256
     map_leaf_size: 0.1
     debug_flag: false

--- a/configs/hilti2022/rko_lio_hilti2022_pandar_competitive_v2.yaml
+++ b/configs/hilti2022/rko_lio_hilti2022_pandar_competitive_v2.yaml
@@ -1,0 +1,26 @@
+# RKO-LIO profile for the HILTI 2022 Phasma platform.
+#
+# The three frontend tuning keys were frozen after development on exp01 and
+# regression validation on exp04. The larger publisher queue preserves the
+# reliable frontend/backend link without forcing both executors into lockstep.
+extrinsic_imu2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
+extrinsic_lidar2base_quat_xyzw_xyz: [0.7071068, -0.7071068, 0.0, 0.0, -0.001, -0.00855, 0.055]
+initialization_phase: true
+deskew: true
+voxel_size: 0.25
+min_range: 0.7
+max_range: 100.0
+double_downsample: true
+
+# Production scope is SLAM-only; recovery research paths stay disabled.
+enable_kidnap_relocalization: false
+reset_on_registration_failure: false
+relocalize_after_scan_gap: false
+
+# Clean development evidence:
+# exp01 RTF 0.9783, APE RMSE 0.06221018 m
+# exp04 RTF 0.5037, APE RMSE 0.06739868 m
+max_iterations: 50
+convergence_criterion: 3.0e-5
+icp_keypoint_voxel_multiplier: 2.25
+publisher_queue_depth: 128

--- a/configs/ntu_viral/lidarslam_candidate2_trajectory.yaml
+++ b/configs/ntu_viral/lidarslam_candidate2_trajectory.yaml
@@ -1,0 +1,30 @@
+# Candidate2 trajectory/loop-safety profile for an unused NTU-VIRAL holdout.
+#
+# This intentionally excludes the frozen dirty-tree planar map-export filter.
+# It is suitable for trajectory completeness, APE, runtime, and loop-edge
+# safety evidence, but not for Candidate2's map-geometry promotion gate.
+graph_based_slam:
+  ros__parameters:
+    registration_method: "NDT"
+    ndt_resolution: 1.0
+    ndt_num_threads: 2
+    voxel_leaf_size: 0.1
+    threshold_loop_closure_score: 0.7
+    distance_loop_closure: 100.0
+    range_of_searching_loop_closure: 20.0
+    search_submap_num: 2
+    loop_search_query_stride: 1
+    max_loop_candidate_count: 3
+    loop_edge_dedup_index_window: 8
+    loop_max_translation_delta: 0.5
+    loop_max_rotation_delta_deg: 2.0
+    loop_min_overlap_ratio: 0.76
+    loop_min_overlap_ratio_large_correction: 0.0
+    loop_overlap_large_correction_translation_m: 0.0
+    loop_overlap_max_distance_m: 0.5
+    num_adjacent_pose_cnstraints: 5
+    use_save_map_in_loop: true
+    adjacent_edge_info_weight: 1000.0
+    use_gnss: false
+    use_dynamic_object_filter: false
+    debug_flag: true

--- a/configs/ntu_viral/lidarslam_candidate2_trajectory.yaml
+++ b/configs/ntu_viral/lidarslam_candidate2_trajectory.yaml
@@ -24,6 +24,9 @@ graph_based_slam:
     loop_overlap_max_distance_m: 0.5
     num_adjacent_pose_cnstraints: 5
     use_save_map_in_loop: true
+    cloud_subscriber_qos_reliable: true
+    odom_cloud_sync_use_exact_time: true
+    odom_cloud_sync_queue_size: 256
     adjacent_edge_info_weight: 1000.0
     use_gnss: false
     use_dynamic_object_filter: false

--- a/configs/ntu_viral/rko_lio_ntu_viral_competitive_v2.yaml
+++ b/configs/ntu_viral/rko_lio_ntu_viral_competitive_v2.yaml
@@ -1,0 +1,9 @@
+# NTU-VIRAL sensor calibration with the reviewable competitive-v2 frontend
+# throughput controls. Keep dataset calibration unchanged; only the two
+# implementation knobs introduced by the frontend Kaizen are overridden.
+extrinsic_imu2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
+extrinsic_lidar2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.05, 0.0, -0.055]
+initialization_phase: true
+icp_keypoint_voxel_multiplier: 2.25
+publisher_queue_depth: 128
+

--- a/configs/ntu_viral/rko_lio_ntu_viral_competitive_v2.yaml
+++ b/configs/ntu_viral/rko_lio_ntu_viral_competitive_v2.yaml
@@ -6,4 +6,3 @@ extrinsic_lidar2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.05, 0.0, -0.055]
 initialization_phase: true
 icp_keypoint_voxel_multiplier: 2.25
 publisher_queue_depth: 128
-

--- a/docs/research/competitive-v2-production-gate-2026-08.md
+++ b/docs/research/competitive-v2-production-gate-2026-08.md
@@ -1,0 +1,129 @@
+# Competitive-v2 / Candidate2 production gate (2026-08-01)
+
+## Decision
+
+- **competitive-v2 frontend:** pending clean isolated exp01/exp04 measurements.
+- **Candidate2 backend:** **do not promote** under the frozen
+  `competitive_slam_v1` contract. Only `spms_01` remains unused by candidate
+  development, while the contract requires three assigned, frozen holdouts and
+  three wins. In addition, the frozen manifest identifies a dirty source-tree
+  hash rather than a reviewable commit, and its enabled planar-map refinement
+  is not part of the isolated Candidate2 delta.
+
+This decision separates implementation readiness from benchmark eligibility.
+The code below is reviewable and builds in isolation; a successful regression
+run cannot retroactively make a previously consumed sequence an unseen
+holdout.
+
+## Reviewable source boundary
+
+| Area | Revision | Scope |
+| --- | --- | --- |
+| backend | `24fda87` | deterministic loop-search scheduling and unit test |
+| backend transport | `45fe842` | exact-stamp odom/cloud pairing, reliable cloud QoS, and bounded queue headroom |
+| frontend submodule | `60b861a`, `4619565` | exact sparse-voxel nearest-neighbour pruning, queue/config controls, and signed-boundary brute-force contract tests |
+| production profile | `ef92aa7` | pinned frontend revision and competitive-v2 HILTI configuration |
+| benchmark harness | `625f3d4` | explicit bag-end completion margin for strict completeness checks |
+| holdout profiles | `4af54b2` | NTU-VIRAL frontend-v2 and trajectory-only Candidate2 safety settings |
+
+The branch is `agent/kaizen-production-gate-20260801`, based on `3d44bc5`.
+Benchmark/build directories are not source changes.
+
+## Build and unit verification
+
+- RKO-LIO core, `offline_node`, and `online_node_component`: built and linked
+  from the isolated submodule worktree.
+- `test_frontend_performance_contract`: 1/1 passed.
+- `test_loop_search_schedule`: 3/3 passed.
+- `graph_based_slam` production targets: colcon build passed in the isolated
+  overlay.
+- Overlay provenance was checked with `ros2 pkg prefix`; both `rko_lio` and
+  `graph_based_slam` resolve inside the isolated worktree.
+
+## Clean HILTI regression gate
+
+Measurements must begin only with load1 <= 2.0 and sampled CPU busy <= 10%.
+Runs performed while another benchmark owns the CPU are invalid.
+
+| Sequence | Candidate RTF | Raw APE RMSE | Baseline RTF | Baseline APE RMSE | Result |
+| --- | ---: | ---: | ---: | ---: | --- |
+| exp01 | pending | pending | 0.9783 | 0.06221018 m | pending |
+| exp04 | pending | pending | 0.5037 | 0.06739868 m | pending |
+
+The gate is RTF <= 1.0 and no accuracy regression above 2%.
+
+### Measurement status
+
+No value is accepted yet. The first unrelated Calibrex batch completed 200
+trials, but a second 200-trial batch immediately began and occupied roughly
+6.5 of 8 logical CPUs. The preflight correctly rejected launch (examples:
+load1 3.28 and CPU busy 88.89%). The measurement process was never started,
+so there is no contaminated candidate result to discard or accidentally cite.
+
+The queued output root is
+`competitive_ours/kaizen_clean_4af54b2_20260801`. It must record three
+consecutive samples with load1 <= 2.0 and CPU busy <= 10% before exp01 starts.
+Until that happens, competitive-v2 remains **not yet promotable**, rather than
+failed.
+
+## Holdout eligibility audit
+
+| Dataset | Eligibility | Reason |
+| --- | --- | --- |
+| HILTI exp02/exp03/exp21 | consumed | explicitly used for candidate-1 loop/overlap development |
+| HILTI exp01/exp04/exp07 | regression only | used during frontend/backend development |
+| NTU-VIRAL rtp_01 | consumed | candidate runs, including a first-130-second run, already inspected |
+| NTU-VIRAL tnp_02 | consumed | candidate runs, including a first-130-second run, already inspected |
+| NTU-VIRAL spms_01 | retry-only | three infrastructure-failed attempts produced zero poses; no candidate metric was exposed, but the slot is not pristine/unopened |
+
+The frozen Candidate2 manifest records correction caps of 0.5 m and 2 deg,
+minimum overlap 0.76, and loop-search stride 1. Its formal profile requires
+three frozen holdout slots and three wins. The local dataset history leaves
+only one eligible sequence, so the formal promotion contract cannot be
+satisfied without registering and freezing two genuinely new sequences before
+examining their results.
+
+The manifest pins repository revision `3d44bc5` and RKO-LIO revision
+`689106a`, but separately fingerprints an 845-file dirty source tree. It also
+enables `use_planar_map_filter`; that implementation belongs to the broader
+backend research WIP and is absent from the isolated loop-scheduling commit.
+Consequently, the frozen artifact cannot be reconstructed from its recorded
+Git revisions alone. Candidate2 needs a new clean freeze after its map-export
+delta is reviewed, even before the missing-holdout requirement is considered.
+
+## Diagnostic evidence (not an unseen holdout)
+
+The recoverable `rtp_01/ours_lio/run_01` trajectory completed 1739 frontend
+poses and 99 graph anchors. Two loop edges were accepted: 28->94 and 37->98.
+Their corrections were 0.0965848 m / 0.197824 deg and 0.133148 m / 0.531555
+deg, with overlaps 0.809863 and 0.780715 respectively.
+
+Post-hoc dense scoring using the frozen body-to-prism translation
+(-0.293656, -0.012288, -0.273095) produced:
+
+- raw APE RMSE: 1.8969631489 m
+- dense corrected APE RMSE: 1.8929973655 m
+- relative change: -0.209% (non-harmful)
+
+This is useful safety evidence but is neither a complete formal run nor an
+unused holdout.
+
+## Unused holdout result
+
+`spms_01`: pending clean isolated candidate retry. This is unused with respect
+to candidate result/tuning evidence (all prior attempts produced zero poses),
+but is reported as retry-only rather than as a pristine unopened slot.
+
+## Required continuation
+
+1. Wait for all unrelated Calibrex six-DoF batches to finish without stopping
+   or altering them.
+2. Run the queued exp01 once and exp04 three times from top revision
+   `4af54b2` / RKO-LIO revision `4619565`.
+3. Require complete trajectories, RTF <= 1.0, <=2% APE regression, and
+   byte-identical exp04 frontend trajectories.
+4. Run the scoped Candidate2 trajectory profile on `spms_01` and report it as
+   retry-only diagnostic evidence. Do not call it a pristine formal holdout.
+5. Update this document with the measured values. Candidate2 remains a no-go
+   regardless of that diagnostic result until its dirty map-export delta is
+   reviewable and two additional genuinely new holdouts are frozen.

--- a/docs/research/competitive-v2-production-gate-2026-08.md
+++ b/docs/research/competitive-v2-production-gate-2026-08.md
@@ -2,13 +2,17 @@
 
 ## Decision
 
-- **competitive-v2 frontend:** pending clean isolated exp01/exp04 measurements.
+- **competitive-v2 frontend/backend transport profile:** **promote**. The clean
+  HILTI gate passed on exp01 and on three deterministic exp04 repetitions:
+  every RTF was below 1.0, accuracy improved against the recorded baseline,
+  and all three exp04 trajectories were byte-identical.
 - **Candidate2 backend:** **do not promote** under the frozen
-  `competitive_slam_v1` contract. Only `spms_01` remains unused by candidate
-  development, while the contract requires three assigned, frozen holdouts and
-  three wins. In addition, the frozen manifest identifies a dirty source-tree
-  hash rather than a reviewable commit, and its enabled planar-map refinement
-  is not part of the isolated Candidate2 delta.
+  `competitive_slam_v1` contract. Only `spms_01` remained without an exposed
+  candidate result, and even that slot is retry-only rather than pristine;
+  the contract requires three assigned, frozen holdouts and three wins. In
+  addition, the frozen manifest identifies a dirty source-tree hash rather
+  than a reviewable commit, and its enabled planar-map refinement is not part
+  of the isolated Candidate2 delta.
 
 This decision separates implementation readiness from benchmark eligibility.
 The code below is reviewable and builds in isolation; a successful regression
@@ -25,6 +29,7 @@ holdout.
 | production profile | `ef92aa7` | pinned frontend revision and competitive-v2 HILTI configuration |
 | benchmark harness | `625f3d4` | explicit bag-end completion margin for strict completeness checks |
 | holdout profiles | `4af54b2` | NTU-VIRAL frontend-v2 and trajectory-only Candidate2 safety settings |
+| holdout transport pin | `8908e60` | exact-time, reliable, queue-256 Candidate2 diagnostic profile |
 
 The branch is `agent/kaizen-production-gate-20260801`, based on `3d44bc5`.
 Benchmark/build directories are not source changes.
@@ -33,7 +38,7 @@ Benchmark/build directories are not source changes.
 
 - RKO-LIO core, `offline_node`, and `online_node_component`: built and linked
   from the isolated submodule worktree.
-- `test_frontend_performance_contract`: 1/1 passed.
+- `test_frontend_performance_contract`: 3/3 cases passed.
 - `test_loop_search_schedule`: 3/3 passed.
 - `graph_based_slam` production targets: colcon build passed in the isolated
   overlay.
@@ -47,24 +52,29 @@ Runs performed while another benchmark owns the CPU are invalid.
 
 | Sequence | Candidate RTF | Raw APE RMSE | Baseline RTF | Baseline APE RMSE | Result |
 | --- | ---: | ---: | ---: | ---: | --- |
-| exp01 | pending | pending | 0.9783 | 0.06221018 m | pending |
-| exp04 | pending | pending | 0.5037 | 0.06739868 m | pending |
+| exp01, run 1 | 0.695946 | 0.06194893 m | 0.9783 | 0.06221018 m | pass (-0.42% APE) |
+| exp04, run 1 | 0.355620 | 0.04712426 m | 0.5037 | 0.06739868 m | pass (-30.08% APE) |
+| exp04, run 2 | 0.339366 | 0.04712426 m | 0.5037 | 0.06739868 m | pass (-30.08% APE) |
+| exp04, run 3 | 0.339920 | 0.04712426 m | 0.5037 | 0.06739868 m | pass (-30.08% APE) |
 
 The gate is RTF <= 1.0 and no accuracy regression above 2%.
 
-### Measurement status
+### Measurement provenance and reproducibility
 
-No value is accepted yet. The first unrelated Calibrex batch completed 200
-trials, but a second 200-trial batch immediately began and occupied roughly
-6.5 of 8 logical CPUs. The preflight correctly rejected launch (examples:
-load1 3.28 and CPU busy 88.89%). The measurement process was never started,
-so there is no contaminated candidate result to discard or accidentally cite.
+Accepted artifacts are under
+`competitive_ours/kaizen_clean_9038f20_20260801`, measured at top revision
+`9038f20` and RKO-LIO revision `4619565`. Each run began only after three
+consecutive preflight samples satisfied load1 <= 2.0 and CPU busy <= 10%.
+All runs exited 0, used exact-stamp pairing with queue 256, and produced
+complete trajectories. exp01 produced 2277 poses. Each exp04 run produced
+1258 poses; median RTF was 0.339920 and maximum RTF was 0.355620.
 
-The queued output root is
-`competitive_ours/kaizen_clean_4af54b2_20260801`. It must record three
-consecutive samples with load1 <= 2.0 and CPU busy <= 10% before exp01 starts.
-Until that happens, competitive-v2 remains **not yet promotable**, rather than
-failed.
+The exp01 raw trajectory SHA-256 is
+`8e1bec2bf7eee05986768224efb2fa60e4cbadf657bf12ee82faaca592319e1f`.
+All three exp04 raw trajectories, and their zero-loop corrected copies, have
+SHA-256
+`3ffde3075ed7ce7cc29e69c41cd185d81660b27f87e26b140ba68e39466342d2`.
+This satisfies the RTF, accuracy, completeness, and deterministic-repeat gate.
 
 ## Holdout eligibility audit
 
@@ -108,22 +118,32 @@ Post-hoc dense scoring using the frozen body-to-prism translation
 This is useful safety evidence but is neither a complete formal run nor an
 unused holdout.
 
-## Unused holdout result
+## Retry-only holdout diagnostic
 
-`spms_01`: pending clean isolated candidate retry. This is unused with respect
-to candidate result/tuning evidence (all prior attempts produced zero poses),
-but is reported as retry-only rather than as a pristine unopened slot.
+`spms_01` was run once as a clean isolated retry-only diagnostic at top
+revision `8908e60` / RKO-LIO revision `4619565`. The frozen two-file input-tree
+hash was recomputed as
+`107980ff0a1992570cc87e46bca824324478c92358838a2fe0c3130d602a5195`,
+matching the manifest before result inspection. The run began after three
+quiet preflight samples and exited 0.
 
-## Required continuation
+The 418.172 s bag produced 4181 poses in 340.115 s (RTF 0.813338). Its last
+pose was 0.081 s before the bag end, inside the 0.25 s completeness margin.
+Raw APE RMSE was 3.308048 m with 6242 timestamp pairs. The backend evaluated
+74 best candidates and logged 209 candidate rejections; all observed overlap
+ratios were zero, the minimum best-candidate fitness was 0.784896 against the
+0.7 threshold, and **zero loop edges were accepted**. Raw and corrected
+trajectory files are therefore byte-identical, with SHA-256
+`50ef8678b38608c85660475c73d76c1d2870337f40a08fd3e7826b5a77e3b76c`.
 
-1. Wait for all unrelated Calibrex six-DoF batches to finish without stopping
-   or altering them.
-2. Run the queued exp01 once and exp04 three times from top revision
-   `4af54b2` / RKO-LIO revision `4619565`.
-3. Require complete trajectories, RTF <= 1.0, <=2% APE regression, and
-   byte-identical exp04 frontend trajectories.
-4. Run the scoped Candidate2 trajectory profile on `spms_01` and report it as
-   retry-only diagnostic evidence. Do not call it a pristine formal holdout.
-5. Update this document with the measured values. Candidate2 remains a no-go
-   regardless of that diagnostic result until its dirty map-export delta is
-   reviewable and two additional genuinely new holdouts are frozen.
+The generic metrics file also reports a 3.587707 m "corrected" score, but that
+invocation used a 10 s association gap while the raw score used 0.05 s. Since
+the underlying trajectories are identical, that number is not a correction
+effect and is excluded from the gate decision.
+
+This result demonstrates safe rejection and real-time completion only; it
+does not establish a Candidate2 win and is not a pristine unseen holdout.
+Candidate2 remains a **no-go** until its dirty map-export delta is isolated and
+reviewed, a new clean freeze is created, and two additional genuinely new
+holdouts are registered so the required three-holdout/three-win contract can
+actually be evaluated.

--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -183,6 +183,13 @@ if(BUILD_TESTING)
     target_include_directories(test_loop_edge_robustifier PRIVATE include)
   endif()
   ament_add_gtest(
+    test_loop_search_schedule
+    test/test_loop_search_schedule.cpp
+  )
+  if(TARGET test_loop_search_schedule)
+    target_include_directories(test_loop_search_schedule PRIVATE include)
+  endif()
+  ament_add_gtest(
     test_triangle_descriptor
     test/test_triangle_descriptor.cpp
   )

--- a/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
+++ b/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
@@ -205,6 +205,7 @@ private:
     double distance_loop_closure_;
     double range_of_searching_loop_closure_;
     int search_submap_num_;
+    int loop_search_query_stride_ {1};
     int max_loop_candidate_count_ {3};
     int loop_edge_dedup_index_window_ {8};
     double loop_max_translation_delta_ {15.0};

--- a/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
+++ b/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
@@ -96,6 +96,7 @@ extern "C" {
 #include <lidarslam_msgs/msg/map_array.hpp>
 #include <message_filters/subscriber.h>  // NOLINT(build/include_order)
 #include <message_filters/sync_policies/approximate_time.h>  // NOLINT(build/include_order)
+#include <message_filters/sync_policies/exact_time.h>  // NOLINT(build/include_order)
 #include <message_filters/synchronizer.h>  // NOLINT(build/include_order)
 #include <nav_msgs/msg/odometry.hpp>
 #include <nav_msgs/msg/path.hpp>
@@ -421,6 +422,17 @@ private:
     using OdomCloudSyncPolicy = message_filters::sync_policies::ApproximateTime <
       nav_msgs::msg::Odometry, sensor_msgs::msg::PointCloud2 >;
     std::shared_ptr < message_filters::Synchronizer < OdomCloudSyncPolicy >> odom_cloud_sync_;
+    // RKO-LIO stamps its paired odometry and deskewed cloud identically.
+    // ExactTime makes pairing a function of those data stamps rather than
+    // ApproximateTime arrival order, while remaining opt-in for other inputs.
+    bool odom_cloud_sync_use_exact_time_ {false};
+    using OdomCloudSyncPolicyExact = message_filters::sync_policies::ExactTime <
+      nav_msgs::msg::Odometry, sensor_msgs::msg::PointCloud2 >;
+    std::shared_ptr < message_filters::Synchronizer <
+    OdomCloudSyncPolicyExact >> odom_cloud_sync_exact_;
+    // Mapping defaults to lossless/reliable cloud delivery. Live users can
+    // explicitly restore the legacy best-effort sensor-data profile.
+    bool cloud_subscriber_qos_reliable_ {true};
     Eigen::Vector3d last_submap_position_ {0, 0, 0};
     bool last_submap_position_valid_ {false};
     double accumulated_distance_ {0.0};

--- a/graph_based_slam/include/graph_based_slam/loop_search_schedule.hpp
+++ b/graph_based_slam/include/graph_based_slam/loop_search_schedule.hpp
@@ -1,0 +1,47 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef GRAPH_BASED_SLAM__LOOP_SEARCH_SCHEDULE_HPP_
+#define GRAPH_BASED_SLAM__LOOP_SEARCH_SCHEDULE_HPP_
+
+namespace graphslam::loop_search_schedule
+{
+
+inline bool shouldSearch(int zero_based_query_index, int query_stride)
+{
+  if (zero_based_query_index < 0) {
+    return false;
+  }
+  const int safe_stride = query_stride < 1 ? 1 : query_stride;
+  return safe_stride == 1 || ((zero_based_query_index + 1) % safe_stride) == 0;
+}
+
+}  // namespace graphslam::loop_search_schedule
+
+#endif  // GRAPH_BASED_SLAM__LOOP_SEARCH_SCHEDULE_HPP_

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -43,6 +43,7 @@
 #include "graph_based_slam/dynamic_object_filter.hpp"
 #include "graph_based_slam/gnss_alignment.hpp"
 #include "graph_based_slam/gnss_geometry.hpp"
+#include "graph_based_slam/loop_search_schedule.hpp"
 #include "graph_based_slam/loop_verifier.hpp"
 #include "graph_based_slam/map_saver.hpp"
 #include "graph_based_slam/pose_graph_optimization.hpp"
@@ -88,6 +89,8 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   get_parameter("range_of_searching_loop_closure", range_of_searching_loop_closure_);
   declare_parameter("search_submap_num", 3);
   get_parameter("search_submap_num", search_submap_num_);
+  declare_parameter("loop_search_query_stride", 1);
+  get_parameter("loop_search_query_stride", loop_search_query_stride_);
   declare_parameter("max_loop_candidate_count", 3);
   get_parameter("max_loop_candidate_count", max_loop_candidate_count_);
   declare_parameter("loop_edge_dedup_index_window", 8);
@@ -481,6 +484,13 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
       "search_submap_num must be >= 1, clamping %d to 1",
       search_submap_num_);
     search_submap_num_ = 1;
+  }
+  if (loop_search_query_stride_ < 1) {
+    RCLCPP_WARN(
+      get_logger(),
+      "loop_search_query_stride must be >= 1, clamping %d to 1",
+      loop_search_query_stride_);
+    loop_search_query_stride_ = 1;
   }
   if (max_loop_candidate_count_ < 1) {
     RCLCPP_WARN(
@@ -904,6 +914,7 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   std::cout << "range_of_searching_loop_closure[m]:" << range_of_searching_loop_closure_ <<
     std::endl;
   std::cout << "search_submap_num:" << search_submap_num_ << std::endl;
+  std::cout << "loop_search_query_stride:" << loop_search_query_stride_ << std::endl;
   std::cout << "max_loop_candidate_count:" << max_loop_candidate_count_ << std::endl;
   std::cout << "loop_edge_dedup_index_window:" << loop_edge_dedup_index_window_ << std::endl;
   std::cout << "loop_max_translation_delta[m]:" << loop_max_translation_delta_ << std::endl;
@@ -1397,7 +1408,13 @@ void GraphBasedSlamComponent::runEventDrivenLoopSearch()
     map_array_msg.submaps.resize(query_idx + 1);
     const auto build_filtered_local_submap = makeFilteredLocalSubmapProvider(map_array_msg);
     backend_core_.ingestDescriptors(query_idx + 1, build_filtered_local_submap);
-    searchLoopForLatest(map_array_msg, loop_edges, query_idx + 1, query_idx);
+    if (loop_search_schedule::shouldSearch(query_idx, loop_search_query_stride_)) {
+      searchLoopForLatest(map_array_msg, loop_edges, query_idx + 1, query_idx);
+    } else if (debug_flag_) {
+      RCLCPP_INFO(
+        get_logger(), "loop search registration skipped for query submap %d by stride %d",
+        query_idx, loop_search_query_stride_);
+    }
     last_searched_submap_idx_ = query_idx;
   }
 }

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -1100,6 +1100,10 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   get_parameter("submap_distance_threshold", submap_distance_threshold_);
   declare_parameter("odom_cloud_sync_queue_size", 100);
   get_parameter("odom_cloud_sync_queue_size", odom_cloud_sync_queue_size_);
+  declare_parameter("odom_cloud_sync_use_exact_time", false);
+  get_parameter("odom_cloud_sync_use_exact_time", odom_cloud_sync_use_exact_time_);
+  declare_parameter("cloud_subscriber_qos_reliable", true);
+  get_parameter("cloud_subscriber_qos_reliable", cloud_subscriber_qos_reliable_);
   // v0.8 Phase 1 report-only degeneracy diagnostics (opt-in, default off:
   // empty path / false flag leaves default behavior untouched).
   declare_parameter("degeneracy_diagnostics_csv_path", std::string(""));
@@ -1240,25 +1244,40 @@ void GraphBasedSlamComponent::initializePubSub()
     // Deep queues so a long loop-search callback cannot overflow the
     // subscription histories and drop frames, plus stamp-based pairing so
     // the submap pose/cloud match is a function of the data, not of the
-    // executor schedule. Reliability is kept as before (odom reliable,
-    // cloud sensor-data/best-effort) for publisher compatibility.
+    // executor schedule. The cloud subscriber defaults to reliable delivery
+    // for mapping completeness, matching RKO-LIO's reliable publisher.
     const size_t sync_depth = static_cast<size_t>(std::max(odom_cloud_sync_queue_size_, 1));
     rmw_qos_profile_t odom_qos = rmw_qos_profile_default;
     odom_qos.depth = sync_depth;
-    rmw_qos_profile_t cloud_qos = rmw_qos_profile_sensor_data;
+    rmw_qos_profile_t cloud_qos =
+      cloud_subscriber_qos_reliable_ ? rmw_qos_profile_default : rmw_qos_profile_sensor_data;
     cloud_qos.depth = sync_depth;
     odom_sync_sub_ = std::make_shared<message_filters::Subscriber<nav_msgs::msg::Odometry>>(
       this, "odom_input", odom_qos);
     cloud_sync_sub_ = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::PointCloud2>>(
       this, "cloud_input", cloud_qos);
-    odom_cloud_sync_ = std::make_shared<message_filters::Synchronizer<OdomCloudSyncPolicy>>(
-      OdomCloudSyncPolicy(static_cast<uint32_t>(sync_depth)), *odom_sync_sub_, *cloud_sync_sub_);
-    odom_cloud_sync_->registerCallback(
-      std::bind(
-        &GraphBasedSlamComponent::receiveSyncedOdomCloud, this, std::placeholders::_1,
-        std::placeholders::_2));
-    RCLCPP_INFO(
-      get_logger(), "Direct odom+cloud input mode enabled (stamp-synced, queue %zu)", sync_depth);
+    if (odom_cloud_sync_use_exact_time_) {
+      odom_cloud_sync_exact_ =
+        std::make_shared<message_filters::Synchronizer<OdomCloudSyncPolicyExact>>(
+        OdomCloudSyncPolicyExact(static_cast<uint32_t>(sync_depth)), *odom_sync_sub_,
+        *cloud_sync_sub_);
+      odom_cloud_sync_exact_->registerCallback(
+        std::bind(
+          &GraphBasedSlamComponent::receiveSyncedOdomCloud, this, std::placeholders::_1,
+          std::placeholders::_2));
+      RCLCPP_INFO(
+        get_logger(),
+        "Direct odom+cloud input mode enabled (exact-stamp-synced, queue %zu)", sync_depth);
+    } else {
+      odom_cloud_sync_ = std::make_shared<message_filters::Synchronizer<OdomCloudSyncPolicy>>(
+        OdomCloudSyncPolicy(static_cast<uint32_t>(sync_depth)), *odom_sync_sub_, *cloud_sync_sub_);
+      odom_cloud_sync_->registerCallback(
+        std::bind(
+          &GraphBasedSlamComponent::receiveSyncedOdomCloud, this, std::placeholders::_1,
+          std::placeholders::_2));
+      RCLCPP_INFO(
+        get_logger(), "Direct odom+cloud input mode enabled (stamp-synced, queue %zu)", sync_depth);
+    }
   }
 
   modified_map_pub_ = create_publisher<sensor_msgs::msg::PointCloud2>(

--- a/graph_based_slam/src/graph_slam_offline_runner.cpp
+++ b/graph_based_slam/src/graph_slam_offline_runner.cpp
@@ -69,6 +69,7 @@
 #include "graph_based_slam/backend_core.hpp"
 #include "graph_based_slam/degeneracy_diagnostics_csv.hpp"
 #include "graph_based_slam/degeneracy_report_summary.hpp"
+#include "graph_based_slam/loop_search_schedule.hpp"
 #include "graph_based_slam/map_refiner.hpp"
 #include "graph_based_slam/plane_feature_association.hpp"
 #include "graph_based_slam/plane_revisit_constraints.hpp"
@@ -403,6 +404,9 @@ int main(int argc, char ** argv)
 
   graphslam::backend_core::LoopSearchConfig search_config;
   node->get_parameter_or("search_submap_num", search_config.search_submap_num, 3);
+  int loop_search_query_stride = 1;
+  node->get_parameter_or("loop_search_query_stride", loop_search_query_stride, 1);
+  loop_search_query_stride = std::max(1, loop_search_query_stride);
   node->get_parameter_or(
     "prefer_scan_context_candidates", search_config.prefer_scan_context_candidates, false);
   node->get_parameter_or(
@@ -609,6 +613,12 @@ int main(int argc, char ** argv)
       while (next_query_idx < num_submaps) {
         const int query_idx = next_query_idx;
         core.ingestDescriptors(query_idx + 1, filtered_local_provider);
+        if (!graphslam::loop_search_schedule::shouldSearch(
+            query_idx, loop_search_query_stride))
+        {
+          next_query_idx = query_idx + 1;
+          continue;
+        }
         std::vector<graphslam::backend_core::SubmapMeta> visible;
         visible.reserve(query_idx + 1);
         for (int i = 0; i <= query_idx; ++i) {

--- a/graph_based_slam/test/test_loop_search_schedule.cpp
+++ b/graph_based_slam/test/test_loop_search_schedule.cpp
@@ -1,0 +1,54 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include "graph_based_slam/loop_search_schedule.hpp"
+
+TEST(LoopSearchSchedule, StrideOneSearchesEveryNonnegativeQuery)
+{
+  EXPECT_FALSE(graphslam::loop_search_schedule::shouldSearch(-1, 1));
+  EXPECT_TRUE(graphslam::loop_search_schedule::shouldSearch(0, 1));
+  EXPECT_TRUE(graphslam::loop_search_schedule::shouldSearch(17, 1));
+}
+
+TEST(LoopSearchSchedule, StrideFiveUsesOneBasedSubmapMultiples)
+{
+  for (int query = 0; query < 15; ++query) {
+    const bool expected = query == 4 || query == 9 || query == 14;
+    EXPECT_EQ(graphslam::loop_search_schedule::shouldSearch(query, 5), expected)
+      << "query=" << query;
+  }
+}
+
+TEST(LoopSearchSchedule, InvalidStrideFallsBackToEveryQuery)
+{
+  EXPECT_TRUE(graphslam::loop_search_schedule::shouldSearch(0, 0));
+  EXPECT_TRUE(graphslam::loop_search_schedule::shouldSearch(3, -4));
+}

--- a/lidarslam/param/lidarslam.yaml
+++ b/lidarslam/param/lidarslam.yaml
@@ -41,6 +41,9 @@ graph_based_slam:
       distance_loop_closure: 100.0
       range_of_searching_loop_closure: 20.0
       search_submap_num: 2
+      # Registration scheduling only; descriptor state is still ingested for
+      # every submap. Keep 1 for the validated production edge set.
+      loop_search_query_stride: 1
       max_loop_candidate_count: 3
       loop_edge_dedup_index_window: 8
       loop_max_translation_delta: 15.0

--- a/scripts/run_rko_lio_graph_benchmark.sh
+++ b/scripts/run_rko_lio_graph_benchmark.sh
@@ -22,6 +22,8 @@ Options:
   --save-timeout-secs <sec>      Timeout waiting for map outputs (default: 60)
   --offline-timeout-secs <sec>   Max wall-clock for the offline node to finish the bag (default: 1800)
   --quiescence-secs <sec>        Treat the run as done after this many stable seconds (default: 20)
+  --completion-end-margin-secs <sec>
+                                 Required trajectory proximity to bag end (default: 120)
   --skip-map-save                Do not call /map_save or verify the map bundle
   --skip-reference-gen           Reuse an existing reference TUM/meta without regenerating it
   --publish-static-tf BOOL       static_transform_publisher (default: true)
@@ -97,6 +99,7 @@ RUN_NAME=""
 STARTUP_TIMEOUT_SECS=30
 SAVE_TIMEOUT_SECS=60
 QUIESCENCE_SECS=20
+COMPLETION_END_MARGIN_SECS=120
 # Max wall-clock to wait for the offline node to finish replaying the bag.
 # Long / compute-heavy sequences (e.g. dense indoor MID-360) can process well
 # below real time; raise this so the run is not cut off mid-bag.
@@ -182,6 +185,11 @@ while [[ $# -gt 0 ]]; do
     --quiescence-secs)
       require_value "$1" "${2:-}"
       QUIESCENCE_SECS="${OPTION_VALUE}"
+      shift 2
+      ;;
+    --completion-end-margin-secs)
+      require_value "$1" "${2:-}"
+      COMPLETION_END_MARGIN_SECS="${OPTION_VALUE}"
       shift 2
       ;;
     --skip-map-save)
@@ -502,10 +510,11 @@ wait_for_offline_completion() {
         stable_since=$SECONDS
       fi
       if (( SECONDS - stable_since >= QUIESCENCE_SECS )); then
-        # 120 s margin: the lidar stream can end well before the bag's global
-        # end stamp (other topics keep recording; 62 s on stadtgarten_seq2).
+        # Some generic bags retain non-LiDAR topics after the sensor stream,
+        # so the historical default is 120 s. Competitive profiles set a
+        # dataset-specific tight margin and record it in their provenance.
         if [[ -n "$end_stamp" ]] && \
-          raw_tum_reached "$end_stamp" 120.0 && \
+          raw_tum_reached "$end_stamp" "$COMPLETION_END_MARGIN_SECS" && \
           raw_tum_reached_fraction 0.8; then
           echo "Trajectory reached the bag end and stayed quiet for ${QUIESCENCE_SECS}s; treating benchmark run as complete"
           return 0


### PR DESCRIPTION
## What changed

- pin the reviewed RKO-LIO frontend throughput work from rsasaki0109/rko_lio#11
- make loop-search scheduling and odometry/cloud transport deterministic
- add competitive-v2 HILTI and scoped Candidate2 diagnostic profiles
- tighten benchmark completion checks and document the production gate evidence

## Why

The frontend/backend Kaizen work was mixed into a larger research worktree. This PR isolates the production-ready pieces into reviewable commits and records an evidence-based promotion boundary.

## Production decision

- promote the competitive-v2 frontend and deterministic transport profile
- do not promote Candidate2: its clean freeze and required three-holdout/three-win gate remain incomplete

## Validation

- RKO-LIO core, offline node, and online component build successfully
- frontend exactness tests: 3/3 pass on the pinned revision
- graph loop schedule tests: 3/3 pass
- isolated graph_based_slam production build passes
- HILTI exp01: RTF 0.695946, APE RMSE 0.06194893 m
- HILTI exp04 x3: maximum RTF 0.355620, APE RMSE 0.04712426 m, byte-identical trajectories
- retry-only spms_01 diagnostic: complete at RTF 0.813338, zero loop edges accepted

Full provenance and gate reasoning are recorded in `docs/research/competitive-v2-production-gate-2026-08.md`.
