### PR TITLE
Promote competitive-v2 Kaizen profile on current develop

### DIFF
--- a/configs/hilti2022/lidarslam_competitive_v2.yaml
+++ b/configs/hilti2022/lidarslam_competitive_v2.yaml
@@ -1,0 +1,12 @@
+# Minimal graph backend overrides for clean competitive-v2 measurement.
+# Loop registration is disabled for the frontend RTF/accuracy gate; descriptor
+# ingestion and the production defaults remain unchanged.
+graph_based_slam:
+  ros__parameters:
+    registration_method: "NDT"
+    range_of_searching_loop_closure: 0.0
+    loop_search_query_stride: 1
+    cloud_subscriber_qos_reliable: true
+    odom_cloud_sync_queue_size: 128
+    map_leaf_size: 0.1
+    debug_flag: false

--- a/configs/hilti2022/lidarslam_competitive_v2.yaml
+++ b/configs/hilti2022/lidarslam_competitive_v2.yaml
@@ -7,6 +7,7 @@ graph_based_slam:
     range_of_searching_loop_closure: 0.0
     loop_search_query_stride: 1
     cloud_subscriber_qos_reliable: true
-    odom_cloud_sync_queue_size: 128
+    odom_cloud_sync_use_exact_time: true
+    odom_cloud_sync_queue_size: 256
     map_leaf_size: 0.1
     debug_flag: false

--- a/configs/hilti2022/rko_lio_hilti2022_pandar_competitive_v2.yaml
+++ b/configs/hilti2022/rko_lio_hilti2022_pandar_competitive_v2.yaml
@@ -6,6 +6,7 @@
 extrinsic_imu2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
 extrinsic_lidar2base_quat_xyzw_xyz: [0.7071068, -0.7071068, 0.0, 0.0, -0.001, -0.00855, 0.055]
 initialization_phase: true
+odom_topic: /rko_lio/odometry
 deskew: true
 voxel_size: 0.25
 min_range: 0.7

--- a/configs/hilti2022/rko_lio_hilti2022_pandar_competitive_v2.yaml
+++ b/configs/hilti2022/rko_lio_hilti2022_pandar_competitive_v2.yaml
@@ -1,0 +1,26 @@
+# RKO-LIO profile for the HILTI 2022 Phasma platform.
+#
+# The three frontend tuning keys were frozen after development on exp01 and
+# regression validation on exp04. The larger publisher queue preserves the
+# reliable frontend/backend link without forcing both executors into lockstep.
+extrinsic_imu2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
+extrinsic_lidar2base_quat_xyzw_xyz: [0.7071068, -0.7071068, 0.0, 0.0, -0.001, -0.00855, 0.055]
+initialization_phase: true
+deskew: true
+voxel_size: 0.25
+min_range: 0.7
+max_range: 100.0
+double_downsample: true
+
+# Production scope is SLAM-only; recovery research paths stay disabled.
+enable_kidnap_relocalization: false
+reset_on_registration_failure: false
+relocalize_after_scan_gap: false
+
+# Clean development evidence:
+# exp01 RTF 0.9783, APE RMSE 0.06221018 m
+# exp04 RTF 0.5037, APE RMSE 0.06739868 m
+max_iterations: 50
+convergence_criterion: 3.0e-5
+icp_keypoint_voxel_multiplier: 2.25
+publisher_queue_depth: 128

--- a/configs/ntu_viral/lidarslam_candidate2_trajectory.yaml
+++ b/configs/ntu_viral/lidarslam_candidate2_trajectory.yaml
@@ -1,0 +1,30 @@
+# Candidate2 trajectory/loop-safety profile for an unused NTU-VIRAL holdout.
+#
+# This intentionally excludes the frozen dirty-tree planar map-export filter.
+# It is suitable for trajectory completeness, APE, runtime, and loop-edge
+# safety evidence, but not for Candidate2's map-geometry promotion gate.
+graph_based_slam:
+  ros__parameters:
+    registration_method: "NDT"
+    ndt_resolution: 1.0
+    ndt_num_threads: 2
+    voxel_leaf_size: 0.1
+    threshold_loop_closure_score: 0.7
+    distance_loop_closure: 100.0
+    range_of_searching_loop_closure: 20.0
+    search_submap_num: 2
+    loop_search_query_stride: 1
+    max_loop_candidate_count: 3
+    loop_edge_dedup_index_window: 8
+    loop_max_translation_delta: 0.5
+    loop_max_rotation_delta_deg: 2.0
+    loop_min_overlap_ratio: 0.76
+    loop_min_overlap_ratio_large_correction: 0.0
+    loop_overlap_large_correction_translation_m: 0.0
+    loop_overlap_max_distance_m: 0.5
+    num_adjacent_pose_cnstraints: 5
+    use_save_map_in_loop: true
+    adjacent_edge_info_weight: 1000.0
+    use_gnss: false
+    use_dynamic_object_filter: false
+    debug_flag: true

--- a/configs/ntu_viral/lidarslam_candidate2_trajectory.yaml
+++ b/configs/ntu_viral/lidarslam_candidate2_trajectory.yaml
@@ -24,6 +24,9 @@ graph_based_slam:
     loop_overlap_max_distance_m: 0.5
     num_adjacent_pose_cnstraints: 5
     use_save_map_in_loop: true
+    cloud_subscriber_qos_reliable: true
+    odom_cloud_sync_use_exact_time: true
+    odom_cloud_sync_queue_size: 256
     adjacent_edge_info_weight: 1000.0
     use_gnss: false
     use_dynamic_object_filter: false

--- a/configs/ntu_viral/rko_lio_ntu_viral_competitive_v2.yaml
+++ b/configs/ntu_viral/rko_lio_ntu_viral_competitive_v2.yaml
@@ -1,0 +1,9 @@
+# NTU-VIRAL sensor calibration with the reviewable competitive-v2 frontend
+# throughput controls. Keep dataset calibration unchanged; only the two
+# implementation knobs introduced by the frontend Kaizen are overridden.
+extrinsic_imu2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
+extrinsic_lidar2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.05, 0.0, -0.055]
+initialization_phase: true
+icp_keypoint_voxel_multiplier: 2.25
+publisher_queue_depth: 128
+

--- a/configs/ntu_viral/rko_lio_ntu_viral_competitive_v2.yaml
+++ b/configs/ntu_viral/rko_lio_ntu_viral_competitive_v2.yaml
@@ -4,5 +4,6 @@
 extrinsic_imu2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
 extrinsic_lidar2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.05, 0.0, -0.055]
 initialization_phase: true
+odom_topic: /rko_lio/odometry
 icp_keypoint_voxel_multiplier: 2.25
 publisher_queue_depth: 128

--- a/configs/ntu_viral/rko_lio_ntu_viral_competitive_v2.yaml
+++ b/configs/ntu_viral/rko_lio_ntu_viral_competitive_v2.yaml
@@ -6,4 +6,3 @@ extrinsic_lidar2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.05, 0.0, -0.055]
 initialization_phase: true
 icp_keypoint_voxel_multiplier: 2.25
 publisher_queue_depth: 128
-

--- a/docs/research/competitive-v2-production-gate-2026-08.md
+++ b/docs/research/competitive-v2-production-gate-2026-08.md
@@ -1,0 +1,129 @@
+# Competitive-v2 / Candidate2 production gate (2026-08-01)
+
+## Decision
+
+- **competitive-v2 frontend:** pending clean isolated exp01/exp04 measurements.
+- **Candidate2 backend:** **do not promote** under the frozen
+  `competitive_slam_v1` contract. Only `spms_01` remains unused by candidate
+  development, while the contract requires three assigned, frozen holdouts and
+  three wins. In addition, the frozen manifest identifies a dirty source-tree
+  hash rather than a reviewable commit, and its enabled planar-map refinement
+  is not part of the isolated Candidate2 delta.
+
+This decision separates implementation readiness from benchmark eligibility.
+The code below is reviewable and builds in isolation; a successful regression
+run cannot retroactively make a previously consumed sequence an unseen
+holdout.
+
+## Reviewable source boundary
+
+| Area | Revision | Scope |
+| --- | --- | --- |
+| backend | `24fda87` | deterministic loop-search scheduling and unit test |
+| backend transport | `45fe842` | exact-stamp odom/cloud pairing, reliable cloud QoS, and bounded queue headroom |
+| frontend submodule | `60b861a`, `4619565` | exact sparse-voxel nearest-neighbour pruning, queue/config controls, and signed-boundary brute-force contract tests |
+| production profile | `ef92aa7` | pinned frontend revision and competitive-v2 HILTI configuration |
+| benchmark harness | `625f3d4` | explicit bag-end completion margin for strict completeness checks |
+| holdout profiles | `4af54b2` | NTU-VIRAL frontend-v2 and trajectory-only Candidate2 safety settings |
+
+The branch is `agent/kaizen-production-gate-20260801`, based on `3d44bc5`.
+Benchmark/build directories are not source changes.
+
+## Build and unit verification
+
+- RKO-LIO core, `offline_node`, and `online_node_component`: built and linked
+  from the isolated submodule worktree.
+- `test_frontend_performance_contract`: 1/1 passed.
+- `test_loop_search_schedule`: 3/3 passed.
+- `graph_based_slam` production targets: colcon build passed in the isolated
+  overlay.
+- Overlay provenance was checked with `ros2 pkg prefix`; both `rko_lio` and
+  `graph_based_slam` resolve inside the isolated worktree.
+
+## Clean HILTI regression gate
+
+Measurements must begin only with load1 <= 2.0 and sampled CPU busy <= 10%.
+Runs performed while another benchmark owns the CPU are invalid.
+
+| Sequence | Candidate RTF | Raw APE RMSE | Baseline RTF | Baseline APE RMSE | Result |
+| --- | ---: | ---: | ---: | ---: | --- |
+| exp01 | pending | pending | 0.9783 | 0.06221018 m | pending |
+| exp04 | pending | pending | 0.5037 | 0.06739868 m | pending |
+
+The gate is RTF <= 1.0 and no accuracy regression above 2%.
+
+### Measurement status
+
+No value is accepted yet. The first unrelated Calibrex batch completed 200
+trials, but a second 200-trial batch immediately began and occupied roughly
+6.5 of 8 logical CPUs. The preflight correctly rejected launch (examples:
+load1 3.28 and CPU busy 88.89%). The measurement process was never started,
+so there is no contaminated candidate result to discard or accidentally cite.
+
+The queued output root is
+`competitive_ours/kaizen_clean_4af54b2_20260801`. It must record three
+consecutive samples with load1 <= 2.0 and CPU busy <= 10% before exp01 starts.
+Until that happens, competitive-v2 remains **not yet promotable**, rather than
+failed.
+
+## Holdout eligibility audit
+
+| Dataset | Eligibility | Reason |
+| --- | --- | --- |
+| HILTI exp02/exp03/exp21 | consumed | explicitly used for candidate-1 loop/overlap development |
+| HILTI exp01/exp04/exp07 | regression only | used during frontend/backend development |
+| NTU-VIRAL rtp_01 | consumed | candidate runs, including a first-130-second run, already inspected |
+| NTU-VIRAL tnp_02 | consumed | candidate runs, including a first-130-second run, already inspected |
+| NTU-VIRAL spms_01 | retry-only | three infrastructure-failed attempts produced zero poses; no candidate metric was exposed, but the slot is not pristine/unopened |
+
+The frozen Candidate2 manifest records correction caps of 0.5 m and 2 deg,
+minimum overlap 0.76, and loop-search stride 1. Its formal profile requires
+three frozen holdout slots and three wins. The local dataset history leaves
+only one eligible sequence, so the formal promotion contract cannot be
+satisfied without registering and freezing two genuinely new sequences before
+examining their results.
+
+The manifest pins repository revision `3d44bc5` and RKO-LIO revision
+`689106a`, but separately fingerprints an 845-file dirty source tree. It also
+enables `use_planar_map_filter`; that implementation belongs to the broader
+backend research WIP and is absent from the isolated loop-scheduling commit.
+Consequently, the frozen artifact cannot be reconstructed from its recorded
+Git revisions alone. Candidate2 needs a new clean freeze after its map-export
+delta is reviewed, even before the missing-holdout requirement is considered.
+
+## Diagnostic evidence (not an unseen holdout)
+
+The recoverable `rtp_01/ours_lio/run_01` trajectory completed 1739 frontend
+poses and 99 graph anchors. Two loop edges were accepted: 28->94 and 37->98.
+Their corrections were 0.0965848 m / 0.197824 deg and 0.133148 m / 0.531555
+deg, with overlaps 0.809863 and 0.780715 respectively.
+
+Post-hoc dense scoring using the frozen body-to-prism translation
+(-0.293656, -0.012288, -0.273095) produced:
+
+- raw APE RMSE: 1.8969631489 m
+- dense corrected APE RMSE: 1.8929973655 m
+- relative change: -0.209% (non-harmful)
+
+This is useful safety evidence but is neither a complete formal run nor an
+unused holdout.
+
+## Unused holdout result
+
+`spms_01`: pending clean isolated candidate retry. This is unused with respect
+to candidate result/tuning evidence (all prior attempts produced zero poses),
+but is reported as retry-only rather than as a pristine unopened slot.
+
+## Required continuation
+
+1. Wait for all unrelated Calibrex six-DoF batches to finish without stopping
+   or altering them.
+2. Run the queued exp01 once and exp04 three times from top revision
+   `4af54b2` / RKO-LIO revision `4619565`.
+3. Require complete trajectories, RTF <= 1.0, <=2% APE regression, and
+   byte-identical exp04 frontend trajectories.
+4. Run the scoped Candidate2 trajectory profile on `spms_01` and report it as
+   retry-only diagnostic evidence. Do not call it a pristine formal holdout.
+5. Update this document with the measured values. Candidate2 remains a no-go
+   regardless of that diagnostic result until its dirty map-export delta is
+   reviewable and two additional genuinely new holdouts are frozen.

--- a/docs/research/competitive-v2-production-gate-2026-08.md
+++ b/docs/research/competitive-v2-production-gate-2026-08.md
@@ -23,27 +23,32 @@ holdout.
 
 | Area | Revision | Scope |
 | --- | --- | --- |
-| backend | `24fda87` | deterministic loop-search scheduling and unit test |
-| backend transport | `45fe842` | exact-stamp odom/cloud pairing, reliable cloud QoS, and bounded queue headroom |
-| frontend submodule | `60b861a`, `4619565` | exact sparse-voxel nearest-neighbour pruning, queue/config controls, and signed-boundary brute-force contract tests |
-| production profile | `ef92aa7` | pinned frontend revision and competitive-v2 HILTI configuration |
-| benchmark harness | `625f3d4` | explicit bag-end completion margin for strict completeness checks |
-| holdout profiles | `4af54b2` | NTU-VIRAL frontend-v2 and trajectory-only Candidate2 safety settings |
-| holdout transport pin | `8908e60` | exact-time, reliable, queue-256 Candidate2 diagnostic profile |
+| current backend scheduling | `de2f394` base | event-driven loop scheduling and tests already present in current `develop` |
+| current backend transport | `0915034` | exact/approximate stamp policy, selectable reliable cloud QoS, and queue headroom in the Pimpl backend |
+| current frontend release pin | `99b55dc` | RKO-LIO PR #12; competitive-v2 pruning/queue changes on the v0.3.2 configurable-voxel line |
+| original measured frontend | `60b861a`, `4619565` | sparse-grid pruning and signed-boundary brute-force contract tests used by the first isolated gate |
+| current production profiles | `67231b6`, `acf7249`, `c590e29`, `9e19b72` | HILTI/NTU profiles, deterministic transport, and explicit RKO output topic |
+| benchmark overlay support | `7fc63a8` | preserve an explicitly sourced isolated overlay |
 
-The branch is `agent/kaizen-production-gate-20260801`, based on `3d44bc5`.
-Benchmark/build directories are not source changes.
+The merge branch is `agent/kaizen-production-gate-current`, based on current
+`develop` revision `de2f394`. The original measurement branch was
+`agent/kaizen-production-gate-20260801`, based on `3d44bc5`. Benchmark/build
+directories are not source changes.
 
 ## Build and unit verification
 
-- RKO-LIO core, `offline_node`, and `online_node_component`: built and linked
-  from the isolated submodule worktree.
-- `test_frontend_performance_contract`: 3/3 cases passed.
+- RKO-LIO release-pin core, `offline_node`, and `online_node_component`: built
+  and linked from the isolated submodule worktree.
+- Current `test_voxel_hash_map`: 4/4 cases passed, including exact signed
+  boundary comparisons against brute force.
 - `test_loop_search_schedule`: 3/3 passed.
+- `test_graph_slam_config`: 5/5 passed, including exact/reliable overrides.
+- Benchmark script safety tests: 26/26 passed.
 - `graph_based_slam` production targets: colcon build passed in the isolated
   overlay.
 - Overlay provenance was checked with `ros2 pkg prefix`; both `rko_lio` and
   `graph_based_slam` resolve inside the isolated worktree.
+- Runtime startup confirmed `exact-stamp-synced, queue 256, cloud reliable`.
 
 ## Clean HILTI regression gate
 
@@ -52,29 +57,38 @@ Runs performed while another benchmark owns the CPU are invalid.
 
 | Sequence | Candidate RTF | Raw APE RMSE | Baseline RTF | Baseline APE RMSE | Result |
 | --- | ---: | ---: | ---: | ---: | --- |
-| exp01, run 1 | 0.695946 | 0.06194893 m | 0.9783 | 0.06221018 m | pass (-0.42% APE) |
-| exp04, run 1 | 0.355620 | 0.04712426 m | 0.5037 | 0.06739868 m | pass (-30.08% APE) |
-| exp04, run 2 | 0.339366 | 0.04712426 m | 0.5037 | 0.06739868 m | pass (-30.08% APE) |
-| exp04, run 3 | 0.339920 | 0.04712426 m | 0.5037 | 0.06739868 m | pass (-30.08% APE) |
+| exp01, run 1 | 0.832433 | 0.06080387 m | 0.9783 | 0.06221018 m | pass (-2.26% APE) |
+| exp04, run 1 | 0.439305 | 0.04836338 m | 0.5037 | 0.06739868 m | pass (-28.24% APE) |
+| exp04, run 2 | 0.423233 | 0.04836338 m | 0.5037 | 0.06739868 m | pass (-28.24% APE) |
+| exp04, run 3 | 0.423418 | 0.04836338 m | 0.5037 | 0.06739868 m | pass (-28.24% APE) |
 
 The gate is RTF <= 1.0 and no accuracy regression above 2%.
 
 ### Measurement provenance and reproducibility
 
-Accepted artifacts are under
-`competitive_ours/kaizen_clean_9038f20_20260801`, measured at top revision
-`9038f20` and RKO-LIO revision `4619565`. Each run began only after three
+Accepted current-develop artifacts are under
+`competitive_ours/kaizen_current_9e19b72_20260801`, measured at top revision
+`9e19b72` and RKO-LIO release revision `99b55dc`. Each run began only after three
 consecutive preflight samples satisfied load1 <= 2.0 and CPU busy <= 10%.
 All runs exited 0, used exact-stamp pairing with queue 256, and produced
 complete trajectories. exp01 produced 2277 poses. Each exp04 run produced
-1258 poses; median RTF was 0.339920 and maximum RTF was 0.355620.
+1258 poses; median RTF was 0.423418 and maximum RTF was 0.439305. The last
+poses were 0.043 s (exp01) and 0.017 s (exp04) before the respective bag ends,
+inside the strict 0.25 s completion margin. The explicit zero base-to-reference
+offset preserves the legacy HILTI scoring frame while satisfying the current
+reference metadata contract.
 
 The exp01 raw trajectory SHA-256 is
-`8e1bec2bf7eee05986768224efb2fa60e4cbadf657bf12ee82faaca592319e1f`.
-All three exp04 raw trajectories, and their zero-loop corrected copies, have
-SHA-256
-`3ffde3075ed7ce7cc29e69c41cd185d81660b27f87e26b140ba68e39466342d2`.
+`4bfbb5dd7b5928d6820095b757d2ad5ca76f942e738bee1349004965cda5f8dc`.
+All three exp04 raw trajectories have SHA-256
+`760cd0e3234988ff8eb7f072f182f0897abe2381debe11126fb618908dcd1ce4`;
+all three densified passthrough copies have SHA-256
+`fb304781eab2a24a3b580ab4c9159fe2c9b3f618a226b36867d6c16d92dd91f2`.
 This satisfies the RTF, accuracy, completeness, and deterministic-repeat gate.
+
+The earlier isolated `4619565` gate also passed (exp01 RTF 0.695946; exp04
+maximum RTF 0.355620). It remains useful historical evidence, but the promotion
+decision above is now supported directly by the current release pin.
 
 ## Holdout eligibility audit
 

--- a/docs/research/competitive-v2-production-gate-2026-08.md
+++ b/docs/research/competitive-v2-production-gate-2026-08.md
@@ -2,13 +2,17 @@
 
 ## Decision
 
-- **competitive-v2 frontend:** pending clean isolated exp01/exp04 measurements.
+- **competitive-v2 frontend/backend transport profile:** **promote**. The clean
+  HILTI gate passed on exp01 and on three deterministic exp04 repetitions:
+  every RTF was below 1.0, accuracy improved against the recorded baseline,
+  and all three exp04 trajectories were byte-identical.
 - **Candidate2 backend:** **do not promote** under the frozen
-  `competitive_slam_v1` contract. Only `spms_01` remains unused by candidate
-  development, while the contract requires three assigned, frozen holdouts and
-  three wins. In addition, the frozen manifest identifies a dirty source-tree
-  hash rather than a reviewable commit, and its enabled planar-map refinement
-  is not part of the isolated Candidate2 delta.
+  `competitive_slam_v1` contract. Only `spms_01` remained without an exposed
+  candidate result, and even that slot is retry-only rather than pristine;
+  the contract requires three assigned, frozen holdouts and three wins. In
+  addition, the frozen manifest identifies a dirty source-tree hash rather
+  than a reviewable commit, and its enabled planar-map refinement is not part
+  of the isolated Candidate2 delta.
 
 This decision separates implementation readiness from benchmark eligibility.
 The code below is reviewable and builds in isolation; a successful regression
@@ -25,6 +29,7 @@ holdout.
 | production profile | `ef92aa7` | pinned frontend revision and competitive-v2 HILTI configuration |
 | benchmark harness | `625f3d4` | explicit bag-end completion margin for strict completeness checks |
 | holdout profiles | `4af54b2` | NTU-VIRAL frontend-v2 and trajectory-only Candidate2 safety settings |
+| holdout transport pin | `8908e60` | exact-time, reliable, queue-256 Candidate2 diagnostic profile |
 
 The branch is `agent/kaizen-production-gate-20260801`, based on `3d44bc5`.
 Benchmark/build directories are not source changes.
@@ -33,7 +38,7 @@ Benchmark/build directories are not source changes.
 
 - RKO-LIO core, `offline_node`, and `online_node_component`: built and linked
   from the isolated submodule worktree.
-- `test_frontend_performance_contract`: 1/1 passed.
+- `test_frontend_performance_contract`: 3/3 cases passed.
 - `test_loop_search_schedule`: 3/3 passed.
 - `graph_based_slam` production targets: colcon build passed in the isolated
   overlay.
@@ -47,24 +52,29 @@ Runs performed while another benchmark owns the CPU are invalid.
 
 | Sequence | Candidate RTF | Raw APE RMSE | Baseline RTF | Baseline APE RMSE | Result |
 | --- | ---: | ---: | ---: | ---: | --- |
-| exp01 | pending | pending | 0.9783 | 0.06221018 m | pending |
-| exp04 | pending | pending | 0.5037 | 0.06739868 m | pending |
+| exp01, run 1 | 0.695946 | 0.06194893 m | 0.9783 | 0.06221018 m | pass (-0.42% APE) |
+| exp04, run 1 | 0.355620 | 0.04712426 m | 0.5037 | 0.06739868 m | pass (-30.08% APE) |
+| exp04, run 2 | 0.339366 | 0.04712426 m | 0.5037 | 0.06739868 m | pass (-30.08% APE) |
+| exp04, run 3 | 0.339920 | 0.04712426 m | 0.5037 | 0.06739868 m | pass (-30.08% APE) |
 
 The gate is RTF <= 1.0 and no accuracy regression above 2%.
 
-### Measurement status
+### Measurement provenance and reproducibility
 
-No value is accepted yet. The first unrelated Calibrex batch completed 200
-trials, but a second 200-trial batch immediately began and occupied roughly
-6.5 of 8 logical CPUs. The preflight correctly rejected launch (examples:
-load1 3.28 and CPU busy 88.89%). The measurement process was never started,
-so there is no contaminated candidate result to discard or accidentally cite.
+Accepted artifacts are under
+`competitive_ours/kaizen_clean_9038f20_20260801`, measured at top revision
+`9038f20` and RKO-LIO revision `4619565`. Each run began only after three
+consecutive preflight samples satisfied load1 <= 2.0 and CPU busy <= 10%.
+All runs exited 0, used exact-stamp pairing with queue 256, and produced
+complete trajectories. exp01 produced 2277 poses. Each exp04 run produced
+1258 poses; median RTF was 0.339920 and maximum RTF was 0.355620.
 
-The queued output root is
-`competitive_ours/kaizen_clean_4af54b2_20260801`. It must record three
-consecutive samples with load1 <= 2.0 and CPU busy <= 10% before exp01 starts.
-Until that happens, competitive-v2 remains **not yet promotable**, rather than
-failed.
+The exp01 raw trajectory SHA-256 is
+`8e1bec2bf7eee05986768224efb2fa60e4cbadf657bf12ee82faaca592319e1f`.
+All three exp04 raw trajectories, and their zero-loop corrected copies, have
+SHA-256
+`3ffde3075ed7ce7cc29e69c41cd185d81660b27f87e26b140ba68e39466342d2`.
+This satisfies the RTF, accuracy, completeness, and deterministic-repeat gate.
 
 ## Holdout eligibility audit
 
@@ -108,22 +118,32 @@ Post-hoc dense scoring using the frozen body-to-prism translation
 This is useful safety evidence but is neither a complete formal run nor an
 unused holdout.
 
-## Unused holdout result
+## Retry-only holdout diagnostic
 
-`spms_01`: pending clean isolated candidate retry. This is unused with respect
-to candidate result/tuning evidence (all prior attempts produced zero poses),
-but is reported as retry-only rather than as a pristine unopened slot.
+`spms_01` was run once as a clean isolated retry-only diagnostic at top
+revision `8908e60` / RKO-LIO revision `4619565`. The frozen two-file input-tree
+hash was recomputed as
+`107980ff0a1992570cc87e46bca824324478c92358838a2fe0c3130d602a5195`,
+matching the manifest before result inspection. The run began after three
+quiet preflight samples and exited 0.
 
-## Required continuation
+The 418.172 s bag produced 4181 poses in 340.115 s (RTF 0.813338). Its last
+pose was 0.081 s before the bag end, inside the 0.25 s completeness margin.
+Raw APE RMSE was 3.308048 m with 6242 timestamp pairs. The backend evaluated
+74 best candidates and logged 209 candidate rejections; all observed overlap
+ratios were zero, the minimum best-candidate fitness was 0.784896 against the
+0.7 threshold, and **zero loop edges were accepted**. Raw and corrected
+trajectory files are therefore byte-identical, with SHA-256
+`50ef8678b38608c85660475c73d76c1d2870337f40a08fd3e7826b5a77e3b76c`.
 
-1. Wait for all unrelated Calibrex six-DoF batches to finish without stopping
-   or altering them.
-2. Run the queued exp01 once and exp04 three times from top revision
-   `4af54b2` / RKO-LIO revision `4619565`.
-3. Require complete trajectories, RTF <= 1.0, <=2% APE regression, and
-   byte-identical exp04 frontend trajectories.
-4. Run the scoped Candidate2 trajectory profile on `spms_01` and report it as
-   retry-only diagnostic evidence. Do not call it a pristine formal holdout.
-5. Update this document with the measured values. Candidate2 remains a no-go
-   regardless of that diagnostic result until its dirty map-export delta is
-   reviewable and two additional genuinely new holdouts are frozen.
+The generic metrics file also reports a 3.587707 m "corrected" score, but that
+invocation used a 10 s association gap while the raw score used 0.05 s. Since
+the underlying trajectories are identical, that number is not a correction
+effect and is excluded from the gate decision.
+
+This result demonstrates safe rejection and real-time completion only; it
+does not establish a Candidate2 win and is not a pristine unseen holdout.
+Candidate2 remains a **no-go** until its dirty map-export delta is isolated and
+reviewed, a new clean freeze is created, and two additional genuinely new
+holdouts are registered so the required three-holdout/three-win contract can
+actually be evaluated.

--- a/graph_based_slam/src/graph_based_slam_component_impl.hpp
+++ b/graph_based_slam/src/graph_based_slam_component_impl.hpp
@@ -57,6 +57,7 @@
 #include <lidarslam_msgs/msg/map_array.hpp>
 #include <message_filters/subscriber.h>  // NOLINT(build/include_order)
 #include <message_filters/sync_policies/approximate_time.h>  // NOLINT(build/include_order)
+#include <message_filters/sync_policies/exact_time.h>  // NOLINT(build/include_order)
 #include <message_filters/synchronizer.h>  // NOLINT(build/include_order)
 #include <nav_msgs/msg/odometry.hpp>
 #include <nav_msgs/msg/path.hpp>
@@ -170,6 +171,10 @@ private:
   using OdomCloudSyncPolicy = message_filters::sync_policies::ApproximateTime<
     nav_msgs::msg::Odometry, sensor_msgs::msg::PointCloud2>;
   std::shared_ptr<message_filters::Synchronizer<OdomCloudSyncPolicy>> odom_cloud_sync_;
+  using OdomCloudSyncPolicyExact = message_filters::sync_policies::ExactTime<
+    nav_msgs::msg::Odometry, sensor_msgs::msg::PointCloud2>;
+  std::shared_ptr<message_filters::Synchronizer<OdomCloudSyncPolicyExact>>
+  odom_cloud_sync_exact_;
   Eigen::Vector3d last_submap_position_ {0, 0, 0};
   bool last_submap_position_valid_ {false};
   double accumulated_distance_ {0.0};

--- a/graph_based_slam/src/graph_slam_config.cpp
+++ b/graph_based_slam/src/graph_slam_config.cpp
@@ -226,6 +226,8 @@ GraphSlamConfig loadGraphSlamConfig(rclcpp::Node & node)
   LOAD(use_odom_input_, "use_odom_input");
   LOAD(submap_distance_threshold_, "submap_distance_threshold");
   LOAD(odom_cloud_sync_queue_size_, "odom_cloud_sync_queue_size");
+  LOAD(odom_cloud_sync_use_exact_time_, "odom_cloud_sync_use_exact_time");
+  LOAD(cloud_subscriber_qos_reliable_, "cloud_subscriber_qos_reliable");
   LOAD(degeneracy_diagnostics_csv_path_, "degeneracy_diagnostics_csv_path");
   LOAD(save_degeneracy_report_, "save_degeneracy_report");
 #undef LOAD
@@ -518,6 +520,12 @@ void logGraphSlamConfig(const GraphSlamConfig & config, const rclcpp::Logger & l
     config.use_odom_input_ ? "on" : "off", config.use_gnss_ ? "on" : "off",
     config.use_imu_preintegration_ ? "on" : "off", config.use_pcd_cache_ ? "on" : "off",
     config.map_save_dir_.c_str());
+  RCLCPP_INFO(
+    logger,
+    "graph SLAM config: odom_cloud_sync(mode=%s queue=%d cloud_qos=%s)",
+    config.odom_cloud_sync_use_exact_time_ ? "exact" : "approximate",
+    config.odom_cloud_sync_queue_size_,
+    config.cloud_subscriber_qos_reliable_ ? "reliable" : "best_effort");
 }
 
 }  // namespace graphslam

--- a/graph_based_slam/src/graph_slam_config.hpp
+++ b/graph_based_slam/src/graph_slam_config.hpp
@@ -195,6 +195,8 @@ struct GraphSlamConfig
   bool use_odom_input_ {false};
   double submap_distance_threshold_ {1.5};
   int odom_cloud_sync_queue_size_ {100};
+  bool odom_cloud_sync_use_exact_time_ {false};
+  bool cloud_subscriber_qos_reliable_ {true};
   std::string degeneracy_diagnostics_csv_path_;
   bool save_degeneracy_report_ {false};
 };

--- a/graph_based_slam/src/graph_slam_ros_adapter.cpp
+++ b/graph_based_slam/src/graph_slam_ros_adapter.cpp
@@ -230,26 +230,40 @@ void GraphBasedSlamComponent::Impl::initializePubSub()
     // Deep queues so a long loop-search callback cannot overflow the
     // subscription histories and drop frames, plus stamp-based pairing so
     // the submap pose/cloud match is a function of the data, not of the
-    // executor schedule. Reliability is kept as before (odom reliable,
-    // cloud sensor-data/best-effort) for publisher compatibility.
+    // executor schedule. Competitive profiles use exact stamps and reliable
+    // delivery; live sensors can retain approximate/best-effort behavior.
     const size_t sync_depth = static_cast<size_t>(std::max(config_.odom_cloud_sync_queue_size_, 1));
     rmw_qos_profile_t odom_qos = rmw_qos_profile_default;
     odom_qos.depth = sync_depth;
-    rmw_qos_profile_t cloud_qos = rmw_qos_profile_sensor_data;
+    rmw_qos_profile_t cloud_qos = config_.cloud_subscriber_qos_reliable_ ?
+      rmw_qos_profile_default : rmw_qos_profile_sensor_data;
     cloud_qos.depth = sync_depth;
     odom_sync_sub_ = std::make_shared<message_filters::Subscriber<nav_msgs::msg::Odometry>>(
       &node_, "odom_input", odom_qos);
     cloud_sync_sub_ = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::PointCloud2>>(
       &node_, "cloud_input", cloud_qos);
-    odom_cloud_sync_ = std::make_shared<message_filters::Synchronizer<OdomCloudSyncPolicy>>(
-      OdomCloudSyncPolicy(static_cast<uint32_t>(sync_depth)), *odom_sync_sub_, *cloud_sync_sub_);
-    odom_cloud_sync_->registerCallback(
-      std::bind(
-        &GraphBasedSlamComponent::Impl::receiveSyncedOdomCloud, this, std::placeholders::_1,
-        std::placeholders::_2));
+    if (config_.odom_cloud_sync_use_exact_time_) {
+      odom_cloud_sync_exact_ =
+        std::make_shared<message_filters::Synchronizer<OdomCloudSyncPolicyExact>>(
+        OdomCloudSyncPolicyExact(static_cast<uint32_t>(sync_depth)),
+        *odom_sync_sub_, *cloud_sync_sub_);
+      odom_cloud_sync_exact_->registerCallback(
+        std::bind(
+          &GraphBasedSlamComponent::Impl::receiveSyncedOdomCloud, this,
+          std::placeholders::_1, std::placeholders::_2));
+    } else {
+      odom_cloud_sync_ = std::make_shared<message_filters::Synchronizer<OdomCloudSyncPolicy>>(
+        OdomCloudSyncPolicy(static_cast<uint32_t>(sync_depth)), *odom_sync_sub_, *cloud_sync_sub_);
+      odom_cloud_sync_->registerCallback(
+        std::bind(
+          &GraphBasedSlamComponent::Impl::receiveSyncedOdomCloud, this,
+          std::placeholders::_1, std::placeholders::_2));
+    }
     RCLCPP_INFO(
-      node_.get_logger(), "Direct odom+cloud input mode enabled (stamp-synced, queue %zu)",
-      sync_depth);
+      node_.get_logger(),
+      "Direct odom+cloud input mode enabled (%s-stamp-synced, queue %zu, cloud %s)",
+      config_.odom_cloud_sync_use_exact_time_ ? "exact" : "approximate", sync_depth,
+      config_.cloud_subscriber_qos_reliable_ ? "reliable" : "best-effort");
   }
 
   modified_map_pub_ = node_.create_publisher<sensor_msgs::msg::PointCloud2>(

--- a/graph_based_slam/test/test_graph_slam_config.cpp
+++ b/graph_based_slam/test/test_graph_slam_config.cpp
@@ -72,6 +72,8 @@ TEST_F(GraphSlamConfigTest, LoaderAppliesRosOverridesAndDeclaresCompleteSurface)
       rclcpp::Parameter("voxel_leaf_size", 0.4),
       rclcpp::Parameter("use_gnss", true),
       rclcpp::Parameter("gnss_topic", "/fix/filtered"),
+      rclcpp::Parameter("odom_cloud_sync_use_exact_time", true),
+      rclcpp::Parameter("cloud_subscriber_qos_reliable", false),
   });
   auto node = std::make_shared<rclcpp::Node>("graph_slam_config_test", options);
   const auto parameters_before_load = node->list_parameters({}, 0).names.size();
@@ -82,9 +84,11 @@ TEST_F(GraphSlamConfigTest, LoaderAppliesRosOverridesAndDeclaresCompleteSurface)
   EXPECT_DOUBLE_EQ(config.voxel_leaf_size, 0.4);
   EXPECT_TRUE(config.use_gnss_);
   EXPECT_EQ(config.gnss_topic_, "/fix/filtered");
+  EXPECT_TRUE(config.odom_cloud_sync_use_exact_time_);
+  EXPECT_FALSE(config.cloud_subscriber_qos_reliable_);
   EXPECT_TRUE(node->has_parameter("triangle_descriptor_keypoint_mode"));
   EXPECT_TRUE(node->has_parameter("degeneracy_diagnostics_csv_path"));
-  EXPECT_EQ(node->list_parameters({}, 0).names.size() - parameters_before_load, 143U);
+  EXPECT_EQ(node->list_parameters({}, 0).names.size() - parameters_before_load, 145U);
 }
 
 TEST_F(GraphSlamConfigTest, ValidationReportsIndependentConfigurationErrors)

--- a/scripts/run_rko_lio_graph_benchmark.sh
+++ b/scripts/run_rko_lio_graph_benchmark.sh
@@ -31,6 +31,10 @@ Options:
   --reference-source LABEL       Label stored in metrics.json (default: leica_prism_gt)
   --help                         Show this help
 
+Environment:
+  RKO_LIO_BENCHMARK_PRESERVE_ENVIRONMENT=true
+                                 Keep the caller's sourced ROS overlay
+
 This runs the recommended benchmark path:
   rosbag2 -> RKO-LIO + graph_based_slam -> raw/corrected trajectories -> APE -> metrics.json
 EOF
@@ -280,12 +284,14 @@ if [[ "$SKIP_REFERENCE_GEN" == "false" ]]; then
 fi
 
 set +u
-if [[ -f "${WS_ROOT}/install/setup.bash" ]]; then
-  # shellcheck source=/dev/null
-  source "${WS_ROOT}/install/setup.bash"
-elif [[ -n "${ROS_DISTRO:-}" && -f "/opt/ros/${ROS_DISTRO}/setup.bash" ]]; then
-  # shellcheck source=/dev/null
-  source "/opt/ros/${ROS_DISTRO}/setup.bash"
+if [[ "${RKO_LIO_BENCHMARK_PRESERVE_ENVIRONMENT:-false}" != "true" ]]; then
+  if [[ -f "${WS_ROOT}/install/setup.bash" ]]; then
+    # shellcheck source=/dev/null
+    source "${WS_ROOT}/install/setup.bash"
+  elif [[ -n "${ROS_DISTRO:-}" && -f "/opt/ros/${ROS_DISTRO}/setup.bash" ]]; then
+    # shellcheck source=/dev/null
+    source "/opt/ros/${ROS_DISTRO}/setup.bash"
+  fi
 fi
 set -u
 


### PR DESCRIPTION
## What changed

- pin the competitive-v2 frontend port on the current RKO-LIO v0.3.2 configurable-voxel line
- add exact/approximate odometry-cloud sync and selectable reliable cloud QoS to the current Pimpl backend
- add scoped competitive-v2 HILTI and Candidate2 diagnostic profiles
- preserve explicitly sourced benchmark overlays and record the production gate evidence

## Why

The original Kaizen branch was based on an older backend architecture and conflicted with current `develop`. This branch starts from current `develop`, reuses its existing event-driven loop scheduler and strict completion checks, and ports only the missing production pieces.

## Production decision

- promote the competitive-v2 frontend and deterministic transport profile
- do not promote Candidate2: its clean freeze and required three-holdout/three-win gate remain incomplete

## Validation

- current RKO-LIO core, offline node, and online component build successfully
- current VoxelHashMap tests: 4/4 pass
- graph config tests: 5/5 pass; loop schedule tests: 3/3 pass
- benchmark safety tests: 26/26 pass
- isolated graph_based_slam Release build passes
- runtime confirms exact-stamp sync, queue 256, reliable cloud QoS
- HILTI exp01: RTF 0.832433, APE RMSE 0.06080387 m
- HILTI exp04 x3: maximum RTF 0.439305, APE RMSE 0.04836338 m, byte-identical repeated trajectories

Full provenance and Candidate2 no-go reasoning are in `docs/research/competitive-v2-production-gate-2026-08.md`.
